### PR TITLE
feat: information_schema improvements (+2 pass, total 1284)

### DIFF
--- a/cmd/mtrrun/main.go
+++ b/cmd/mtrrun/main.go
@@ -351,7 +351,7 @@ var skipTests = map[string]bool{
 	"funcs_1/is_basics_mixed":                    true,
 	"funcs_1/is_character_sets":                  true,
 	"funcs_1/is_cml_innodb":                      true,
-	"funcs_1/is_cml_memory":                      true,
+	// "funcs_1/is_cml_memory": true, // now passes (eval variable expansion + COLUMNS fixes)
 	"funcs_1/is_coll_char_set_appl":              true,
 	"funcs_1/is_collations":                      true,
 	"funcs_1/is_column_privileges":               true,
@@ -366,7 +366,7 @@ var skipTests = map[string]bool{
 	"funcs_1/is_table_constraints_mysql":         true,
 	"funcs_1/is_table_privileges":                true,
 	"funcs_1/is_tables_innodb":                   true,
-	"funcs_1/is_tables_is":                       true,
+	// "funcs_1/is_tables_is": true, // now passes (IS SYSTEM VIEW entries + utf8_general_ci ordering)
 	"funcs_1/is_tables_memory":                   true,
 	"funcs_1/is_tables_mysql":                    true,
 	"funcs_1/is_user_privileges":                 true,

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -14333,7 +14333,11 @@ func (e *Executor) execUpdate(stmt *sqlparser.Update) (*Result, error) {
 	if stmt.OrderBy != nil && len(stmt.OrderBy) > 0 {
 		sort.SliceStable(matchingIndices, func(a, b int) bool {
 			for _, order := range stmt.OrderBy {
-				colName := sqlparser.String(order.Expr)
+				orderExpr := order.Expr
+				if collateExpr, ok := orderExpr.(*sqlparser.CollateExpr); ok {
+					orderExpr = collateExpr.Expr
+				}
+				colName := sqlparser.String(orderExpr)
 				colName = strings.Trim(colName, "`")
 				va := rowValueByColumnName(tbl.Rows[matchingIndices[a]], colName)
 				vb := rowValueByColumnName(tbl.Rows[matchingIndices[b]], colName)
@@ -16367,7 +16371,11 @@ func (e *Executor) execShow(stmt *sqlparser.Show, query string) (*Result, error)
 			}
 			return &Result{Columns: []string{"Collation", "Charset", "Id", "Default", "Compiled", "Sortlen", "Pad_attribute"}, Rows: rows, IsResultSet: true}, nil
 		case sqlparser.Table: // SHOW TABLES
-			db, err := e.Catalog.GetDatabase(e.CurrentDB)
+			targetDB := e.CurrentDB
+			if !basic.DbName.IsEmpty() {
+				targetDB = basic.DbName.String()
+			}
+			db, err := e.Catalog.GetDatabase(targetDB)
 			if err != nil {
 				return nil, err
 			}
@@ -16385,7 +16393,7 @@ func (e *Executor) execShow(stmt *sqlparser.Show, query string) (*Result, error)
 				rows = append(rows, []interface{}{t})
 			}
 			return &Result{
-				Columns:     []string{fmt.Sprintf("Tables_in_%s", e.CurrentDB)},
+				Columns:     []string{fmt.Sprintf("Tables_in_%s", targetDB)},
 				Rows:        rows,
 				IsResultSet: true,
 			}, nil
@@ -16395,7 +16403,20 @@ func (e *Executor) execShow(stmt *sqlparser.Show, query string) (*Result, error)
 	upper := strings.ToUpper(strings.TrimSpace(query))
 
 	if strings.HasPrefix(upper, "SHOW TABLES") {
-		db, err := e.Catalog.GetDatabase(e.CurrentDB)
+		targetDB := e.CurrentDB
+		// Parse SHOW TABLES FROM/IN <database>
+		if idx := strings.Index(upper, " FROM "); idx >= 0 {
+			rest := strings.TrimSpace(query[idx+6:])
+			dbName := strings.Fields(rest)[0]
+			dbName = strings.Trim(dbName, "`")
+			targetDB = dbName
+		} else if idx := strings.Index(upper, " IN "); idx >= 0 {
+			rest := strings.TrimSpace(query[idx+4:])
+			dbName := strings.Fields(rest)[0]
+			dbName = strings.Trim(dbName, "`")
+			targetDB = dbName
+		}
+		db, err := e.Catalog.GetDatabase(targetDB)
 		if err != nil {
 			return nil, err
 		}
@@ -16409,7 +16430,7 @@ func (e *Executor) execShow(stmt *sqlparser.Show, query string) (*Result, error)
 			rows = append(rows, []interface{}{t})
 		}
 		return &Result{
-			Columns:     []string{fmt.Sprintf("Tables_in_%s", e.CurrentDB)},
+			Columns:     []string{fmt.Sprintf("Tables_in_%s", targetDB)},
 			Rows:        rows,
 			IsResultSet: true,
 		}, nil
@@ -28108,7 +28129,13 @@ func normalizeUTF8GeneralCIKey(s string) string {
 		if unicode.Is(unicode.Mn, r) {
 			continue
 		}
-		b.WriteRune(r)
+		// In MySQL's utf8_general_ci, non-letter ASCII symbols like '_' (0x5F)
+		// sort after letters. Remap them to high codepoints to match MySQL ordering.
+		if r == '_' {
+			b.WriteRune('\u007F') // DEL sorts after all ASCII letters
+		} else {
+			b.WriteRune(r)
+		}
 	}
 	return b.String()
 }
@@ -28369,12 +28396,21 @@ func applyOrderBy(orderBy sqlparser.OrderBy, colNames []string, rows [][]interfa
 	}
 
 	type orderSpec struct {
-		colIdx int
-		asc    bool
+		colIdx    int
+		asc       bool
+		collation string
 	}
 	var specs []orderSpec
 	for _, order := range orderBy {
-		colName := sqlparser.String(order.Expr)
+		// Handle COLLATE expressions by extracting the inner column name
+		// and using the specified collation for comparison
+		expr := order.Expr
+		orderCollation := collation
+		if collateExpr, ok := expr.(*sqlparser.CollateExpr); ok {
+			expr = collateExpr.Expr
+			orderCollation = collateExpr.Collation
+		}
+		colName := sqlparser.String(expr)
 		colName = strings.Trim(colName, "`")
 		colIdx := -1
 		for i, c := range colNames {
@@ -28387,7 +28423,7 @@ func applyOrderBy(orderBy sqlparser.OrderBy, colNames []string, rows [][]interfa
 			continue
 		}
 		asc := order.Direction == sqlparser.AscOrder || order.Direction == 0
-		specs = append(specs, orderSpec{colIdx: colIdx, asc: asc})
+		specs = append(specs, orderSpec{colIdx: colIdx, asc: asc, collation: orderCollation})
 	}
 	if len(specs) == 0 {
 		return rows, nil
@@ -28395,7 +28431,11 @@ func applyOrderBy(orderBy sqlparser.OrderBy, colNames []string, rows [][]interfa
 
 	sort.SliceStable(rows, func(i, j int) bool {
 		for _, spec := range specs {
-			cmp := compareByCollation(rows[i][spec.colIdx], rows[j][spec.colIdx], collation)
+			coll := spec.collation
+			if coll == "" {
+				coll = collation
+			}
+			cmp := compareByCollation(rows[i][spec.colIdx], rows[j][spec.colIdx], coll)
 			if cmp == 0 {
 				continue
 			}
@@ -28463,7 +28503,11 @@ func applyOrderByWithTypeHints(orderBy sqlparser.OrderBy, colNames []string, row
 	}
 	var specs []orderSpec
 	for _, order := range orderBy {
-		colName := strings.Trim(sqlparser.String(order.Expr), "`")
+		expr := order.Expr
+		if collateExpr, ok := expr.(*sqlparser.CollateExpr); ok {
+			expr = collateExpr.Expr
+		}
+		colName := strings.Trim(sqlparser.String(expr), "`")
 		colIdx := -1
 		for i, c := range colNames {
 			if strings.EqualFold(c, colName) {

--- a/executor/information_schema.go
+++ b/executor/information_schema.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"time"
 
+	catalogPkg "github.com/myuon/mylite/catalog"
 	"github.com/myuon/mylite/storage"
 )
 
@@ -427,7 +428,7 @@ func (e *Executor) buildInformationSchemaRows(tableName, alias string) ([]storag
 			rawRows = []storage.Row{{"ID": int64(1), "USER": "root", "HOST": "localhost", "DB": e.CurrentDB, "COMMAND": "Query", "TIME": int64(0), "STATE": "executing", "INFO": nil}}
 		}
 	case "key_column_usage":
-		rawRows = []storage.Row{{"CONSTRAINT_CATALOG": "def", "CONSTRAINT_SCHEMA": "", "CONSTRAINT_NAME": "", "TABLE_CATALOG": "def", "TABLE_SCHEMA": "", "TABLE_NAME": "", "COLUMN_NAME": "", "ORDINAL_POSITION": int64(1), "POSITION_IN_UNIQUE_CONSTRAINT": nil, "REFERENCED_TABLE_SCHEMA": nil, "REFERENCED_TABLE_NAME": nil, "REFERENCED_COLUMN_NAME": nil}}
+		rawRows = e.infoSchemaKeyColumnUsage()
 	case "referential_constraints":
 		rawRows = []storage.Row{{"CONSTRAINT_CATALOG": "def", "CONSTRAINT_SCHEMA": "", "CONSTRAINT_NAME": "", "UNIQUE_CONSTRAINT_CATALOG": "def", "UNIQUE_CONSTRAINT_SCHEMA": "", "UNIQUE_CONSTRAINT_NAME": "", "MATCH_OPTION": "NONE", "UPDATE_RULE": "RESTRICT", "DELETE_RULE": "RESTRICT", "TABLE_NAME": "", "REFERENCED_TABLE_NAME": ""}}
 	case "innodb_temp_table_info":
@@ -512,7 +513,7 @@ func (e *Executor) buildInformationSchemaRows(tableName, alias string) ([]storag
 	case "table_constraints":
 		rawRows = e.infoSchemaTableConstraints()
 	case "check_constraints":
-		rawRows = []storage.Row{} // empty
+		rawRows = e.infoSchemaCheckConstraints()
 	case "character_sets":
 		rawRows = e.infoSchemaCharacterSets()
 	case "collations":
@@ -1003,6 +1004,11 @@ func (e *Executor) infoSchemaTables() []storage.Row {
 
 	var rows []storage.Row
 	for _, dbName := range dbNames {
+		// Skip information_schema and performance_schema from the regular loop
+		// They have their own virtual table entries added below
+		if strings.EqualFold(dbName, "information_schema") || strings.EqualFold(dbName, "performance_schema") {
+			continue
+		}
 		db, err := e.Catalog.GetDatabase(dbName)
 		if err != nil {
 			continue
@@ -1037,31 +1043,130 @@ func (e *Executor) infoSchemaTables() []storage.Row {
 					avgRowLength = dataLength / tableRows
 				}
 			}
+			// Determine ENGINE from table definition
+			engine := "InnoDB"
+			if tblDef != nil && tblDef.Engine != "" {
+				engine = canonicalEngineName(tblDef.Engine)
+			}
+
+			// Determine ROW_FORMAT from table definition
+			rowFormat := "Dynamic"
+			if tblDef != nil && tblDef.RowFormat != "" {
+				rowFormat = tblDef.RowFormat
+			} else if strings.EqualFold(engine, "MEMORY") {
+				rowFormat = "Fixed"
+			}
+
+			// Determine TABLE_COLLATION from table definition or database charset
+			tableCollation := "utf8mb4_0900_ai_ci"
+			if tblDef != nil && tblDef.Collation != "" {
+				tableCollation = tblDef.Collation
+			} else if tblDef != nil && tblDef.Charset != "" {
+				tableCollation = catalogPkg.DefaultCollationForCharset(tblDef.Charset)
+			} else if db != nil && db.CollationName != "" {
+				tableCollation = db.CollationName
+			}
+
+			// Try to get actual row count from storage engine
+			if tableRows == 0 {
+				if stbl, err := e.Storage.GetTable(dbName, tblName); err == nil {
+					stbl.Mu.RLock()
+					tableRows = int64(len(stbl.Rows))
+					stbl.Mu.RUnlock()
+				}
+			}
+
+			// Compute AUTO_INCREMENT: next value for auto-increment column
+			var autoIncrement interface{} = nil
+			if tblDef != nil {
+				for _, col := range tblDef.Columns {
+					if col.AutoIncrement {
+						if stbl, err := e.Storage.GetTable(dbName, tblName); err == nil {
+							cur := stbl.AutoIncrementValue()
+							autoIncrement = cur + 1
+						}
+						break
+					}
+				}
+			}
+
+			// DATA_FREE: use 0 for InnoDB tables (not nil)
+			var dataFree interface{} = int64(0)
+			if strings.EqualFold(engine, "MEMORY") {
+				dataFree = int64(0)
+			}
+
 			rows = append(rows, storage.Row{
 				"TABLE_CATALOG":   "def",
 				"TABLE_SCHEMA":    dbName,
 				"TABLE_NAME":      tblName,
 				"TABLE_TYPE":      "BASE TABLE",
-				"ENGINE":          "InnoDB",
+				"ENGINE":          engine,
 				"VERSION":         int64(10),
-				"ROW_FORMAT":      "Dynamic",
+				"ROW_FORMAT":      rowFormat,
 				"TABLE_ROWS":      tableRows,
 				"AVG_ROW_LENGTH":  avgRowLength,
 				"DATA_LENGTH":     dataLength,
 				"MAX_DATA_LENGTH": maxDataLength,
 				"INDEX_LENGTH":    indexLength,
-				"DATA_FREE":       nil,
-				"AUTO_INCREMENT":  nil,
+				"DATA_FREE":       dataFree,
+				"AUTO_INCREMENT":  autoIncrement,
 				"CREATE_TIME":     nil,
 				"UPDATE_TIME":     nil,
 				"CHECK_TIME":      nil,
-				"TABLE_COLLATION": "utf8mb4_general_ci",
+				"TABLE_COLLATION": tableCollation,
 				"CHECKSUM":        nil,
 				"CREATE_OPTIONS":  createOptions,
 				"TABLE_COMMENT":   tblComment,
 			})
 		}
 	}
+
+	// Add information_schema virtual tables as SYSTEM VIEW entries
+	// Order matches MySQL 8.0's utf8_general_ci collation ordering
+	isTableNames := []string{
+		"CHARACTER_SETS", "CHECK_CONSTRAINTS",
+		"COLLATIONS", "COLLATION_CHARACTER_SET_APPLICABILITY",
+		"COLUMNS", "COLUMN_PRIVILEGES", "COLUMN_STATISTICS",
+		"ENGINES", "EVENTS", "FILES",
+		"KEYWORDS", "KEY_COLUMN_USAGE",
+		"OPTIMIZER_TRACE",
+		"PARAMETERS", "PARTITIONS", "PLUGINS",
+		"PROCESSLIST",
+		"REFERENTIAL_CONSTRAINTS", "RESOURCE_GROUPS", "ROUTINES",
+		"SCHEMATA", "SCHEMA_PRIVILEGES", "STATISTICS",
+		"ST_GEOMETRY_COLUMNS", "ST_SPATIAL_REFERENCE_SYSTEMS", "ST_UNITS_OF_MEASURE",
+		"TABLES", "TABLESPACES", "TABLE_CONSTRAINTS", "TABLE_PRIVILEGES",
+		"TRIGGERS",
+		"USER_PRIVILEGES",
+		"VIEWS", "VIEW_ROUTINE_USAGE", "VIEW_TABLE_USAGE",
+	}
+	for _, tblName := range isTableNames {
+		rows = append(rows, storage.Row{
+			"TABLE_CATALOG":   "def",
+			"TABLE_SCHEMA":    "information_schema",
+			"TABLE_NAME":      tblName,
+			"TABLE_TYPE":      "SYSTEM VIEW",
+			"ENGINE":          nil,
+			"VERSION":         int64(10),
+			"ROW_FORMAT":      nil,
+			"TABLE_ROWS":      nil,
+			"AVG_ROW_LENGTH":  nil,
+			"DATA_LENGTH":     nil,
+			"MAX_DATA_LENGTH": nil,
+			"INDEX_LENGTH":    nil,
+			"DATA_FREE":       nil,
+			"AUTO_INCREMENT":  nil,
+			"CREATE_TIME":     nil,
+			"UPDATE_TIME":     nil,
+			"CHECK_TIME":      nil,
+			"TABLE_COLLATION": nil,
+			"CHECKSUM":        nil,
+			"CREATE_OPTIONS":  nil,
+			"TABLE_COMMENT":   "",
+		})
+	}
+
 	return rows
 }
 
@@ -1258,8 +1363,45 @@ func (e *Executor) infoSchemaColumns() []storage.Row {
 				} else if col.Unique {
 					columnKey = "UNI"
 				}
+				// Also mark as MUL if part of a non-unique index (first column)
+				if columnKey == "" {
+					for _, idx := range tbl.Indexes {
+						if len(idx.Columns) > 0 {
+							idxCol := normalizeIndexColumnName(idx.Columns[0])
+							if strings.EqualFold(idxCol, col.Name) {
+								columnKey = "MUL"
+								break
+							}
+						}
+					}
+				}
 				if col.AutoIncrement {
 					extra = "auto_increment"
+				} else if col.OnUpdateCurrentTimestamp {
+					if col.Default != nil && strings.ToUpper(*col.Default) == "CURRENT_TIMESTAMP" {
+						extra = "DEFAULT_GENERATED on update CURRENT_TIMESTAMP"
+					} else {
+						extra = "on update CURRENT_TIMESTAMP"
+					}
+				} else if col.Default != nil && strings.ToUpper(*col.Default) == "CURRENT_TIMESTAMP" {
+					// TIMESTAMP/DATETIME with DEFAULT CURRENT_TIMESTAMP (no ON UPDATE)
+					extra = "DEFAULT_GENERATED"
+				}
+
+				// Compute DATETIME_PRECISION for temporal types
+				var datetimePrecision interface{} = nil
+				switch baseType {
+				case "DATETIME", "TIMESTAMP", "TIME":
+					datetimePrecision = int64(0) // default fractional seconds precision
+					// Check for explicit precision like DATETIME(6)
+					if idx := strings.Index(colTypeUpper, "("); idx >= 0 {
+						end := strings.Index(colTypeUpper[idx:], ")")
+						if end > 0 {
+							if n, err := strconv.ParseInt(colTypeUpper[idx+1:idx+end], 10, 64); err == nil {
+								datetimePrecision = n
+							}
+						}
+					}
 				}
 
 				rows = append(rows, storage.Row{
@@ -1275,7 +1417,7 @@ func (e *Executor) infoSchemaColumns() []storage.Row {
 					"CHARACTER_OCTET_LENGTH":   charOctetLen,
 					"NUMERIC_PRECISION":        numPrecision,
 					"NUMERIC_SCALE":            numScale,
-					"DATETIME_PRECISION":       nil,
+					"DATETIME_PRECISION":       datetimePrecision,
 					"CHARACTER_SET_NAME":       charSetName,
 					"COLLATION_NAME":           collationName,
 					"COLUMN_TYPE":              normalizeColumnType(col.Type),
@@ -2337,6 +2479,127 @@ func (e *Executor) psClassDisabled(class string) bool {
 	return false
 }
 
+// infoSchemaKeyColumnUsage returns rows for INFORMATION_SCHEMA.KEY_COLUMN_USAGE.
+func (e *Executor) infoSchemaKeyColumnUsage() []storage.Row {
+	dbNames := e.Catalog.ListDatabases()
+	sort.Strings(dbNames)
+
+	var rows []storage.Row
+	for _, dbName := range dbNames {
+		db, err := e.Catalog.GetDatabase(dbName)
+		if err != nil {
+			continue
+		}
+		tableNames := db.ListTables()
+		sort.Strings(tableNames)
+		for _, tblName := range tableNames {
+			tbl, err := db.GetTable(tblName)
+			if err != nil || tbl == nil {
+				continue
+			}
+			// Primary key constraint
+			if len(tbl.PrimaryKey) > 0 {
+				for i, col := range tbl.PrimaryKey {
+					rows = append(rows, storage.Row{
+						"CONSTRAINT_CATALOG":            "def",
+						"CONSTRAINT_SCHEMA":             dbName,
+						"CONSTRAINT_NAME":               "PRIMARY",
+						"TABLE_CATALOG":                 "def",
+						"TABLE_SCHEMA":                  dbName,
+						"TABLE_NAME":                    tblName,
+						"COLUMN_NAME":                   col,
+						"ORDINAL_POSITION":              int64(i + 1),
+						"POSITION_IN_UNIQUE_CONSTRAINT": nil,
+						"REFERENCED_TABLE_SCHEMA":       nil,
+						"REFERENCED_TABLE_NAME":         nil,
+						"REFERENCED_COLUMN_NAME":        nil,
+					})
+				}
+			}
+			// Unique indexes
+			for _, idx := range tbl.Indexes {
+				if idx.Unique {
+					for i, col := range idx.Columns {
+						colName := normalizeIndexColumnName(col)
+						rows = append(rows, storage.Row{
+							"CONSTRAINT_CATALOG":            "def",
+							"CONSTRAINT_SCHEMA":             dbName,
+							"CONSTRAINT_NAME":               idx.Name,
+							"TABLE_CATALOG":                 "def",
+							"TABLE_SCHEMA":                  dbName,
+							"TABLE_NAME":                    tblName,
+							"COLUMN_NAME":                   colName,
+							"ORDINAL_POSITION":              int64(i + 1),
+							"POSITION_IN_UNIQUE_CONSTRAINT": nil,
+							"REFERENCED_TABLE_SCHEMA":       nil,
+							"REFERENCED_TABLE_NAME":         nil,
+							"REFERENCED_COLUMN_NAME":        nil,
+						})
+					}
+				}
+			}
+		}
+	}
+	return rows
+}
+
+// infoSchemaCheckConstraints returns rows for INFORMATION_SCHEMA.CHECK_CONSTRAINTS.
+func (e *Executor) infoSchemaCheckConstraints() []storage.Row {
+	dbNames := e.Catalog.ListDatabases()
+	sort.Strings(dbNames)
+
+	var rows []storage.Row
+	for _, dbName := range dbNames {
+		db, err := e.Catalog.GetDatabase(dbName)
+		if err != nil {
+			continue
+		}
+		tableNames := db.ListTables()
+		sort.Strings(tableNames)
+		for _, tblName := range tableNames {
+			tbl, err := db.GetTable(tblName)
+			if err != nil || tbl == nil {
+				continue
+			}
+			for _, cc := range tbl.CheckConstraints {
+				rows = append(rows, storage.Row{
+					"CONSTRAINT_CATALOG": "def",
+					"CONSTRAINT_SCHEMA":  dbName,
+					"CONSTRAINT_NAME":    cc.Name,
+					"CHECK_CLAUSE":       cc.Expr,
+				})
+			}
+		}
+	}
+	return rows
+}
+
+// canonicalEngineName returns the MySQL-canonical engine name with proper casing.
+func canonicalEngineName(engine string) string {
+	switch strings.ToUpper(engine) {
+	case "INNODB":
+		return "InnoDB"
+	case "MYISAM":
+		return "MyISAM"
+	case "MEMORY":
+		return "MEMORY"
+	case "CSV":
+		return "CSV"
+	case "ARCHIVE":
+		return "ARCHIVE"
+	case "BLACKHOLE":
+		return "BLACKHOLE"
+	case "MERGE", "MRGSORT":
+		return "MRG_MYISAM"
+	case "FEDERATED":
+		return "FEDERATED"
+	case "NDB", "NDBCLUSTER":
+		return "ndbcluster"
+	default:
+		return engine
+	}
+}
+
 // normalizeColumnType returns the MySQL COLUMN_TYPE string for a given column type.
 // For integer types without explicit display width, it adds the default display width.
 func normalizeColumnType(colType string) string {
@@ -2384,6 +2647,11 @@ func normalizeColumnType(colType string) string {
 		return "int(11)"
 	case "bigint":
 		return "bigint(20)" + suffix
+	case "char":
+		// CHAR without length defaults to CHAR(1)
+		return "char(1)"
+	case "year":
+		return "year(4)"
 	}
 	return t
 }

--- a/mtrrunner/runner.go
+++ b/mtrrunner/runner.go
@@ -327,6 +327,7 @@ type execContext struct {
 	pendingSendByConn map[string]*pendingSend // keyed by connection name ("" for default)
 	pendingSendNext   bool                    // next SQL statement should be sent asynchronously
 	pendingSendEval   bool                    // pending send should use variable substitution
+	pendingEval       bool                    // next SQL statement should have variables expanded in echo
 }
 
 type tableSnapshot struct {
@@ -870,6 +871,9 @@ func (ctx *execContext) executeLines(lines []string) error {
 			stmts = splitStatements(stmt)
 		}
 
+		isEval := ctx.pendingEval
+		ctx.pendingEval = false
+
 		if len(stmts) <= 1 {
 			// Single statement: echo raw lines preserving original formatting
 			// Don't echo if this is a pending send (async dispatch)
@@ -877,6 +881,11 @@ func (ctx *execContext) executeLines(lines []string) error {
 				for _, rl := range rawLines {
 					if rl == "" {
 						continue // Skip blank lines in SQL echo (mysqltest doesn't output them)
+					}
+					// In eval mode, substitute variables in echoed lines
+					if isEval {
+						rl = ctx.substituteVars(rl)
+						rl = stripUndefinedVars(rl)
 					}
 					// Apply --replace_result and --replace_regex to echoed SQL too
 					if len(ctx.replaceResult) > 0 {
@@ -1094,6 +1103,10 @@ func (ctx *execContext) handleDirective(directive string) (handled bool, skip bo
 			}
 			return true, false, err
 		}
+		// eval with no args: mark next SQL statement for variable expansion in echo
+		if name == "eval" {
+			ctx.pendingEval = true
+		}
 		return true, false, nil
 
 	case "shutdown_server":
@@ -1160,7 +1173,12 @@ func (ctx *execContext) handleDirective(directive string) (handled bool, skip bo
 		fields := strings.Fields(args)
 		for i := 0; i+1 < len(fields); i += 2 {
 			if colNum, err := strconv.Atoi(fields[i]); err == nil {
-				ctx.replaceColumns[colNum] = fields[i+1]
+				val := fields[i+1]
+				// Strip surrounding double quotes (mysqltest behavior)
+				if len(val) >= 2 && val[0] == '"' && val[len(val)-1] == '"' {
+					val = val[1 : len(val)-1]
+				}
+				ctx.replaceColumns[colNum] = val
 			}
 		}
 		return true, false, nil


### PR DESCRIPTION
## Summary
- Improve INFORMATION_SCHEMA.TABLES with SYSTEM VIEW entries, per-table ENGINE/ROW_FORMAT/COLLATION, actual row counts, AUTO_INCREMENT
- Improve INFORMATION_SCHEMA.COLUMNS with DATETIME_PRECISION, EXTRA (DEFAULT_GENERATED, on update CURRENT_TIMESTAMP), MUL key, normalizeColumnType fixes
- Add real data for KEY_COLUMN_USAGE and CHECK_CONSTRAINTS tables
- Fix COLLATE expression handling in ORDER BY (utf8_general_ci underscore sorting)
- Fix MTR runner: eval echo variable expansion, --replace_column quote stripping, SHOW TABLES FROM

funcs_1: 11 pass (was 9), 67 skip (was 69)
Total: 1284 pass (was 1282)

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./... -count=1 -timeout 60s` passes (88 tests)
- [x] `go run ./cmd/mtrrun` passes (1284 pass, 1 pre-existing failure in json_no_table)
- [x] funcs_1/is_cml_memory: now PASS
- [x] funcs_1/is_tables_is: now PASS
- [x] No regressions in other suites

Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)