### PR TITLE
refactor: extract DML value coercion chain into coerceColumnValue()

### DIFF
--- a/executor/dml_insert.go
+++ b/executor/dml_insert.go
@@ -286,17 +286,8 @@ func (e *Executor) execInsert(stmt *sqlparser.Insert) (*Result, error) {
 					break
 				}
 				colName := colNames[i]
-				if v != nil {
-					if cm, ok := colMetaMap[colName]; ok {
-						if cm.padLen > 0 {
-							v = padBinaryValue(v, cm.padLen)
-						}
-						v = formatDecimalValue(cm.col.Type, v)
-						v = validateEnumSetValue(cm.col.Type, v)
-						v = coerceDateTimeValue(cm.col.Type, v)
-						v = coerceIntegerValue(cm.col.Type, v)
-						v = coerceBitValue(cm.col.Type, v)
-					}
+				if cm, ok := colMetaMap[colName]; ok {
+					v = coerceColumnValue(cm.col.Type, v)
 				}
 				row[colName] = v
 			}
@@ -650,9 +641,6 @@ func (e *Executor) execInsert(stmt *sqlparser.Insert) (*Result, error) {
 			// Pad BINARY(N), format DECIMAL, validate ENUM/SET.
 			for _, col := range tbl.Def.Columns {
 				if col.Name == colNames[i] {
-					if padLen := binaryPadLength(col.Type); padLen > 0 && v != nil {
-						v = padBinaryValue(v, padLen)
-					}
 					if v != nil {
 						// In strict mode, check DECIMAL range and unsigned constraint before clipping
 						if e.isStrictMode() {
@@ -688,12 +676,8 @@ func (e *Executor) execInsert(stmt *sqlparser.Insert) (*Result, error) {
 								}
 							}
 						}
-						v = formatDecimalValue(col.Type, v)
-						v = validateEnumSetValue(col.Type, v)
-						v = coerceDateTimeValue(col.Type, v)
-						v = coerceIntegerValue(col.Type, v)
-						v = coerceBitValue(col.Type, v)
 					}
+					v = coerceColumnValue(col.Type, v)
 					break
 				}
 			}
@@ -820,16 +804,7 @@ func (e *Executor) execInsert(stmt *sqlparser.Insert) (*Result, error) {
 					// Pad BINARY(N) values, coerce DATE/TIME.
 					for _, col := range tbl.Def.Columns {
 						if col.Name == colName {
-							if padLen := binaryPadLength(col.Type); padLen > 0 && val != nil {
-								val = padBinaryValue(val, padLen)
-							}
-							if val != nil {
-								val = formatDecimalValue(col.Type, val)
-								val = validateEnumSetValue(col.Type, val)
-								val = coerceDateTimeValue(col.Type, val)
-								val = coerceIntegerValue(col.Type, val)
-								val = coerceBitValue(col.Type, val)
-							}
+							val = coerceColumnValue(col.Type, val)
 							break
 						}
 					}

--- a/executor/dml_update.go
+++ b/executor/dml_update.go
@@ -293,10 +293,7 @@ func (e *Executor) execUpdate(stmt *sqlparser.Update) (*Result, error) {
 			}
 			for _, col := range tbl.Def.Columns {
 				if col.Name == colName {
-					if padLen := binaryPadLength(col.Type); padLen > 0 && val != nil {
-						val = padBinaryValue(val, padLen)
-					}
-					if val != nil {
+						if val != nil {
 						colUpper := strings.ToUpper(col.Type)
 						// In non-strict mode, invalid numeric strings are coerced to 0 with warning.
 						isNumericType := strings.Contains(colUpper, "DECIMAL") || strings.Contains(colUpper, "NUMERIC") ||
@@ -332,12 +329,8 @@ func (e *Executor) execUpdate(stmt *sqlparser.Update) (*Result, error) {
 								}
 							}
 						}
-						val = formatDecimalValue(col.Type, val)
-						val = validateEnumSetValue(col.Type, val)
-						val = coerceDateTimeValue(col.Type, val)
-						val = coerceIntegerValue(col.Type, val)
-						val = coerceBitValue(col.Type, val)
 					}
+					val = coerceColumnValue(col.Type, val)
 					break
 				}
 			}
@@ -814,19 +807,11 @@ func (e *Executor) execMultiTableUpdate(stmt *sqlparser.Update) (*Result, error)
 					// Apply the same type coercions used by single-table UPDATE.
 					for _, col := range tbl.Def.Columns {
 						if col.Name == colName {
-							if padLen := binaryPadLength(col.Type); padLen > 0 && val != nil {
-								val = padBinaryValue(val, padLen)
-							}
-							if val != nil {
-								val = formatDecimalValue(col.Type, val)
-								val = validateEnumSetValue(col.Type, val)
-								val = coerceDateTimeValue(col.Type, val)
-								val = coerceIntegerValue(col.Type, val)
-								val = coerceBitValue(col.Type, val)
-							} else if !col.Nullable {
+							if val == nil && !col.Nullable {
 								tbl.Unlock()
 								return nil, mysqlError(1048, "23000", fmt.Sprintf("Column '%s' cannot be null", colName))
 							}
+							val = coerceColumnValue(col.Type, val)
 							break
 						}
 					}

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -6555,6 +6555,23 @@ func decimalMaxString(m, d int) string {
 	return strings.Repeat("9", intDigits) + "." + strings.Repeat("9", d)
 }
 
+// coerceColumnValue applies the standard DML value coercion chain for a column:
+// binary padding, decimal formatting, enum/set validation, datetime coercion,
+// integer coercion, and bit coercion.
+func coerceColumnValue(colType string, val interface{}) interface{} {
+	if padLen := binaryPadLength(colType); padLen > 0 && val != nil {
+		val = padBinaryValue(val, padLen)
+	}
+	if val != nil {
+		val = formatDecimalValue(colType, val)
+		val = validateEnumSetValue(colType, val)
+		val = coerceDateTimeValue(colType, val)
+		val = coerceIntegerValue(colType, val)
+		val = coerceBitValue(colType, val)
+	}
+	return val
+}
+
 // formatDecimalValue formats a value for DECIMAL(M,D), DOUBLE(M,D), or FLOAT(M,D) columns.
 func formatDecimalValue(colType string, v interface{}) interface{} {
 	lower := strings.ToLower(colType)


### PR DESCRIPTION
## Summary
- Extracted the repeated binary-pad + format/validate/coerce chain into a shared `coerceColumnValue(colType, val)` function in `executor/executor.go`
- Replaced 5 duplicated coercion blocks across `dml_insert.go` (3 sites) and `dml_update.go` (2 sites)
- Site-specific logic (strict mode checks in INSERT slow path, non-strict mode warnings in single-table UPDATE, null checks in multi-table UPDATE) is preserved outside the shared function

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./... -count=1 -timeout 60s` passes (88 tests across 8 packages)

Closes #39

🤖 Generated with [Claude Code](https://claude.com/claude-code)