### PR TITLE
refactor: introduce evalArg helpers to reduce func_*.go boilerplate

### DIFF
--- a/executor/eval_helpers.go
+++ b/executor/eval_helpers.go
@@ -1,0 +1,87 @@
+package executor
+
+import (
+	"fmt"
+
+	"vitess.io/vitess/go/vt/sqlparser"
+)
+
+// evalArg1 evaluates a single required argument from a function call.
+// It checks the minimum argument count, evaluates the first expression,
+// and checks for NULL. Returns (value, isNull, error).
+// If isNull is true, the caller should return nil, true, nil.
+func (e *Executor) evalArg1(exprs []sqlparser.Expr, funcName string) (interface{}, bool, error) {
+	if len(exprs) < 1 {
+		return nil, false, fmt.Errorf("%s requires 1 argument", funcName)
+	}
+	val, err := e.evalExpr(exprs[0])
+	if err != nil {
+		return nil, false, err
+	}
+	if val == nil {
+		return nil, true, nil
+	}
+	return val, false, nil
+}
+
+// evalArg1Quiet evaluates a single argument without error on missing args
+// (returns nil, true, nil instead of error). Used by functions that return
+// NULL silently when no arguments are provided.
+func (e *Executor) evalArg1Quiet(exprs []sqlparser.Expr) (interface{}, bool, error) {
+	if len(exprs) < 1 {
+		return nil, true, nil
+	}
+	val, err := e.evalExpr(exprs[0])
+	if err != nil {
+		return nil, false, err
+	}
+	if val == nil {
+		return nil, true, nil
+	}
+	return val, false, nil
+}
+
+// evalArgs2 evaluates exactly 2 required arguments.
+// Returns (val0, val1, hasNull, error). If hasNull is true and error is nil,
+// at least one argument was NULL.
+func (e *Executor) evalArgs2(exprs []sqlparser.Expr, funcName string) (interface{}, interface{}, bool, error) {
+	if len(exprs) < 2 {
+		return nil, nil, false, fmt.Errorf("%s requires 2 arguments", funcName)
+	}
+	v0, err := e.evalExpr(exprs[0])
+	if err != nil {
+		return nil, nil, false, err
+	}
+	v1, err := e.evalExpr(exprs[1])
+	if err != nil {
+		return nil, nil, false, err
+	}
+	if v0 == nil || v1 == nil {
+		return nil, nil, true, nil
+	}
+	return v0, v1, false, nil
+}
+
+// evalArgs3 evaluates exactly 3 required arguments.
+// Returns (val0, val1, val2, hasNull, error).
+func (e *Executor) evalArgs3(exprs []sqlparser.Expr, funcName string) (interface{}, interface{}, interface{}, bool, error) {
+	if len(exprs) < 3 {
+		return nil, nil, nil, false, fmt.Errorf("%s requires 3 arguments", funcName)
+	}
+	v0, err := e.evalExpr(exprs[0])
+	if err != nil {
+		return nil, nil, nil, false, err
+	}
+	v1, err := e.evalExpr(exprs[1])
+	if err != nil {
+		return nil, nil, nil, false, err
+	}
+	v2, err := e.evalExpr(exprs[2])
+	if err != nil {
+		return nil, nil, nil, false, err
+	}
+	if v0 == nil || v1 == nil || v2 == nil {
+		return nil, nil, nil, true, nil
+	}
+	return v0, v1, v2, false, nil
+}

--- a/executor/func_datetime.go
+++ b/executor/func_datetime.go
@@ -136,14 +136,11 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interfac
 		}
 		return int64(t.Second()), true, nil
 	case "date":
-		if len(v.Exprs) < 1 {
-			return nil, true, fmt.Errorf("DATE requires 1 argument")
-		}
-		val, err := e.evalExpr(v.Exprs[0])
+		val, isNull, err := e.evalArg1(v.Exprs, "DATE")
 		if err != nil {
 			return nil, true, err
 		}
-		if val == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		if isZeroDate(val) {
@@ -168,18 +165,11 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interfac
 		}
 		return t.Format("15:04:05"), true, nil
 	case "datediff":
-		if len(v.Exprs) < 2 {
-			return nil, true, fmt.Errorf("DATEDIFF requires 2 arguments")
-		}
-		v0, err := e.evalExpr(v.Exprs[0])
+		v0, v1, hasNull, err := e.evalArgs2(v.Exprs, "DATEDIFF")
 		if err != nil {
 			return nil, true, err
 		}
-		v1, err := e.evalExpr(v.Exprs[1])
-		if err != nil {
-			return nil, true, err
-		}
-		if v0 == nil || v1 == nil {
+		if hasNull {
 			return nil, true, nil
 		}
 		t0, err := parseDateTimeValue(v0)
@@ -371,14 +361,11 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interfac
 		}
 		return t.Add(-dur).Format("2006-01-02 15:04:05"), true, nil
 	case "from_days":
-		if len(v.Exprs) < 1 {
-			return nil, true, nil
-		}
-		val, err := e.evalExpr(v.Exprs[0])
+		val, isNull, err := e.evalArg1Quiet(v.Exprs)
 		if err != nil {
 			return nil, true, err
 		}
-		if val == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		days := int(toInt64(val))
@@ -388,14 +375,11 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interfac
 		t := time.Date(1, 1, 1, 0, 0, 0, 0, time.UTC).AddDate(0, 0, days-1)
 		return t.Format("2006-01-02"), true, nil
 	case "to_days":
-		if len(v.Exprs) < 1 {
-			return nil, true, nil
-		}
-		val, err := e.evalExpr(v.Exprs[0])
+		val, isNull, err := e.evalArg1Quiet(v.Exprs)
 		if err != nil {
 			return nil, true, err
 		}
-		if val == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		if isZeroDate(val) {
@@ -407,14 +391,11 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interfac
 		}
 		return mysqlToDays(t), true, nil
 	case "last_day":
-		if len(v.Exprs) < 1 {
-			return nil, true, nil
-		}
-		val, err := e.evalExpr(v.Exprs[0])
+		val, isNull, err := e.evalArg1Quiet(v.Exprs)
 		if err != nil {
 			return nil, true, err
 		}
-		if val == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		t, parseErr := parseDateTimeValue(val)
@@ -425,14 +406,11 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interfac
 		lastDay := firstOfNextMonth.AddDate(0, 0, -1)
 		return lastDay.Format("2006-01-02"), true, nil
 	case "quarter":
-		if len(v.Exprs) < 1 {
-			return nil, true, nil
-		}
-		val, err := e.evalExpr(v.Exprs[0])
+		val, isNull, err := e.evalArg1Quiet(v.Exprs)
 		if err != nil {
 			return nil, true, err
 		}
-		if val == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		t, parseErr := parseDateTimeValue(val)
@@ -441,14 +419,11 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interfac
 		}
 		return int64((t.Month()-1)/3 + 1), true, nil
 	case "week":
-		if len(v.Exprs) < 1 {
-			return nil, true, nil
-		}
-		val, err := e.evalExpr(v.Exprs[0])
+		val, isNull, err := e.evalArg1Quiet(v.Exprs)
 		if err != nil {
 			return nil, true, err
 		}
-		if val == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		if isZeroDate(val) {
@@ -470,14 +445,11 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interfac
 		_, wk := t.ISOWeek()
 		return int64(wk), true, nil
 	case "weekofyear":
-		if len(v.Exprs) < 1 {
-			return nil, true, nil
-		}
-		val, err := e.evalExpr(v.Exprs[0])
+		val, isNull, err := e.evalArg1Quiet(v.Exprs)
 		if err != nil {
 			return nil, true, err
 		}
-		if val == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		if isZeroDate(val) {
@@ -490,14 +462,11 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interfac
 		_, wk := t.ISOWeek()
 		return int64(wk), true, nil
 	case "yearweek":
-		if len(v.Exprs) < 1 {
-			return nil, true, nil
-		}
-		val, err := e.evalExpr(v.Exprs[0])
+		val, isNull, err := e.evalArg1Quiet(v.Exprs)
 		if err != nil {
 			return nil, true, err
 		}
-		if val == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		t, parseErr := parseDateTimeValue(val)
@@ -507,14 +476,11 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interfac
 		yr, wk := mysqlYearWeek(t, 0)
 		return int64(yr*100 + wk), true, nil
 	case "timestamp":
-		if len(v.Exprs) < 1 {
-			return nil, true, nil
-		}
-		val, err := e.evalExpr(v.Exprs[0])
+		val, isNull, err := e.evalArg1Quiet(v.Exprs)
 		if err != nil {
 			return nil, true, err
 		}
-		if val == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		t, parseErr := parseDateTimeValue(val)
@@ -523,26 +489,20 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interfac
 		}
 		return t.Format("2006-01-02 15:04:05"), true, nil
 	case "sec_to_time":
-		if len(v.Exprs) < 1 {
-			return nil, true, nil
-		}
-		arg, err := e.evalExpr(v.Exprs[0])
+		arg, isNull, err := e.evalArg1Quiet(v.Exprs)
 		if err != nil {
 			return nil, true, err
 		}
-		if arg == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		return secToTimeValue(arg), true, nil
 	case "time_to_sec":
-		if len(v.Exprs) < 1 {
-			return nil, true, fmt.Errorf("TIME_TO_SEC requires 1 argument")
-		}
-		ttsVal, err := e.evalExpr(v.Exprs[0])
+		ttsVal, isNull, err := e.evalArg1(v.Exprs, "TIME_TO_SEC")
 		if err != nil {
 			return nil, true, err
 		}
-		if ttsVal == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		ttsS := toString(ttsVal)
@@ -572,18 +532,11 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interfac
 		}
 		return ttsSecs, true, nil
 	case "period_add":
-		if len(v.Exprs) < 2 {
-			return nil, true, fmt.Errorf("PERIOD_ADD requires 2 arguments")
-		}
-		paP, err := e.evalExpr(v.Exprs[0])
+		paP, paN, hasNull, err := e.evalArgs2(v.Exprs, "PERIOD_ADD")
 		if err != nil {
 			return nil, true, err
 		}
-		paN, err := e.evalExpr(v.Exprs[1])
-		if err != nil {
-			return nil, true, err
-		}
-		if paP == nil || paN == nil {
+		if hasNull {
 			return nil, true, nil
 		}
 		paPeriod := toInt64(paP)
@@ -603,18 +556,11 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interfac
 		paNewM := paTotalM%12 + 1
 		return paNewY*100 + paNewM, true, nil
 	case "period_diff":
-		if len(v.Exprs) < 2 {
-			return nil, true, fmt.Errorf("PERIOD_DIFF requires 2 arguments")
-		}
-		pdP1, err := e.evalExpr(v.Exprs[0])
+		pdP1, pdP2, hasNull, err := e.evalArgs2(v.Exprs, "PERIOD_DIFF")
 		if err != nil {
 			return nil, true, err
 		}
-		pdP2, err := e.evalExpr(v.Exprs[1])
-		if err != nil {
-			return nil, true, err
-		}
-		if pdP1 == nil || pdP2 == nil {
+		if hasNull {
 			return nil, true, nil
 		}
 		pdToMonths := func(period int64) int64 {
@@ -629,22 +575,11 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interfac
 		}
 		return pdToMonths(toInt64(pdP1)) - pdToMonths(toInt64(pdP2)), true, nil
 	case "maketime":
-		if len(v.Exprs) < 3 {
-			return nil, true, fmt.Errorf("MAKETIME requires 3 arguments")
-		}
-		mtH, err := e.evalExpr(v.Exprs[0])
+		mtH, mtM, mtSec, hasNull, err := e.evalArgs3(v.Exprs, "MAKETIME")
 		if err != nil {
 			return nil, true, err
 		}
-		mtM, err := e.evalExpr(v.Exprs[1])
-		if err != nil {
-			return nil, true, err
-		}
-		mtSec, err := e.evalExpr(v.Exprs[2])
-		if err != nil {
-			return nil, true, err
-		}
-		if mtH == nil || mtM == nil || mtSec == nil {
+		if hasNull {
 			return nil, true, nil
 		}
 		mtHi := toInt64(mtH)
@@ -660,14 +595,11 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interfac
 		}
 		return fmt.Sprintf("%s%02d:%02d:%02d", mtNeg, mtHi, mtMi, mtSi), true, nil
 	case "microsecond":
-		if len(v.Exprs) < 1 {
-			return nil, true, fmt.Errorf("MICROSECOND requires 1 argument")
-		}
-		usVal, err := e.evalExpr(v.Exprs[0])
+		usVal, isNull, err := e.evalArg1(v.Exprs, "MICROSECOND")
 		if err != nil {
 			return nil, true, err
 		}
-		if usVal == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		usStr := toString(usVal)
@@ -681,18 +613,11 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interfac
 		}
 		return int64(0), true, nil
 	case "time_format":
-		if len(v.Exprs) < 2 {
-			return nil, true, fmt.Errorf("TIME_FORMAT requires 2 arguments")
-		}
-		tfTime, err := e.evalExpr(v.Exprs[0])
+		tfTime, tfFmt, hasNull, err := e.evalArgs2(v.Exprs, "TIME_FORMAT")
 		if err != nil {
 			return nil, true, err
 		}
-		tfFmt, err := e.evalExpr(v.Exprs[1])
-		if err != nil {
-			return nil, true, err
-		}
-		if tfTime == nil || tfFmt == nil {
+		if hasNull {
 			return nil, true, nil
 		}
 		tfStr := toString(tfTime)
@@ -729,27 +654,20 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interfac
 		if len(v.Exprs) < 3 {
 			return nil, true, fmt.Errorf("CONVERT_TZ requires 3 arguments")
 		}
-		ctzVal, err := e.evalExpr(v.Exprs[0])
+		ctzVal, isNull, err := e.evalArg1Quiet(v.Exprs)
 		if err != nil {
 			return nil, true, err
 		}
-		if ctzVal == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		return toString(ctzVal), true, nil
 	case "timediff":
-		if len(v.Exprs) < 2 {
-			return nil, true, fmt.Errorf("TIMEDIFF requires 2 arguments")
-		}
-		tdA, err := e.evalExpr(v.Exprs[0])
+		tdA, tdB, hasNull, err := e.evalArgs2(v.Exprs, "TIMEDIFF")
 		if err != nil {
 			return nil, true, err
 		}
-		tdB, err := e.evalExpr(v.Exprs[1])
-		if err != nil {
-			return nil, true, err
-		}
-		if tdA == nil || tdB == nil {
+		if hasNull {
 			return nil, true, nil
 		}
 		tdTA, tdErr1 := parseDateTimeValue(toString(tdA))
@@ -768,14 +686,11 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interfac
 		tdS := int(tdDiff.Seconds()) % 60
 		return fmt.Sprintf("%s%02d:%02d:%02d", tdNeg, tdH, tdM, tdS), true, nil
 	case "to_seconds":
-		if len(v.Exprs) < 1 {
-			return nil, true, nil
-		}
-		tsVal, err := e.evalExpr(v.Exprs[0])
+		tsVal, isNull, err := e.evalArg1Quiet(v.Exprs)
 		if err != nil {
 			return nil, true, err
 		}
-		if tsVal == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		tsT, tsErr := parseDateTimeValue(toString(tsVal))
@@ -785,18 +700,11 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interfac
 		tsDays := int64(tsT.Year())*365 + int64(tsT.YearDay()) + int64(tsT.Year())/4 - int64(tsT.Year())/100 + int64(tsT.Year())/400
 		return tsDays*86400 + int64(tsT.Hour())*3600 + int64(tsT.Minute())*60 + int64(tsT.Second()), true, nil
 	case "makedate":
-		if len(v.Exprs) < 2 {
-			return nil, true, fmt.Errorf("MAKEDATE requires 2 arguments")
-		}
-		mdYear, err := e.evalExpr(v.Exprs[0])
+		mdYear, mdDay, hasNull, err := e.evalArgs2(v.Exprs, "MAKEDATE")
 		if err != nil {
 			return nil, true, err
 		}
-		mdDay, err := e.evalExpr(v.Exprs[1])
-		if err != nil {
-			return nil, true, err
-		}
-		if mdYear == nil || mdDay == nil {
+		if hasNull {
 			return nil, true, nil
 		}
 		mdY := int(toInt64(mdYear))

--- a/executor/func_math.go
+++ b/executor/func_math.go
@@ -29,14 +29,11 @@ func evalMathFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		r := rand.New(rand.NewSource(toInt64(seedVal)))
 		return r.Float64(), true, nil
 	case "abs":
-		if len(v.Exprs) < 1 {
-			return nil, true, fmt.Errorf("ABS requires 1 argument")
-		}
-		val, err := e.evalExpr(v.Exprs[0])
+		val, isNull, err := e.evalArg1(v.Exprs, "ABS")
 		if err != nil {
 			return nil, true, err
 		}
-		if val == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		f := toFloat(val)
@@ -53,27 +50,21 @@ func evalMathFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		}
 		return math.Pi, true, nil
 	case "floor":
-		if len(v.Exprs) < 1 {
-			return nil, true, fmt.Errorf("FLOOR requires 1 argument")
-		}
-		val, err := e.evalExpr(v.Exprs[0])
+		val, isNull, err := e.evalArg1(v.Exprs, "FLOOR")
 		if err != nil {
 			return nil, true, err
 		}
-		if val == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		f := toFloat(val)
 		return int64(f), true, nil
 	case "ceil", "ceiling":
-		if len(v.Exprs) < 1 {
-			return nil, true, fmt.Errorf("CEIL requires 1 argument")
-		}
-		val, err := e.evalExpr(v.Exprs[0])
+		val, isNull, err := e.evalArg1(v.Exprs, "CEIL")
 		if err != nil {
 			return nil, true, err
 		}
-		if val == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		f := toFloat(val)
@@ -83,14 +74,11 @@ func evalMathFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		}
 		return n, true, nil
 	case "round":
-		if len(v.Exprs) < 1 {
-			return nil, true, fmt.Errorf("ROUND requires at least 1 argument")
-		}
-		val, err := e.evalExpr(v.Exprs[0])
+		val, isNull, err := e.evalArg1(v.Exprs, "ROUND")
 		if err != nil {
 			return nil, true, err
 		}
-		if val == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		f := toFloat(val)
@@ -124,11 +112,11 @@ func evalMathFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		if len(v.Exprs) < 2 {
 			return nil, true, fmt.Errorf("TRUNCATE requires 2 arguments")
 		}
-		val, err := e.evalExpr(v.Exprs[0])
+		val, isNull, err := e.evalArg1(v.Exprs, "TRUNCATE")
 		if err != nil {
 			return nil, true, err
 		}
-		if val == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		dv, err := e.evalExpr(v.Exprs[1])
@@ -171,18 +159,11 @@ func evalMathFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		}
 		return int64(f/factor) * int64(factor), true, nil
 	case "mod":
-		if len(v.Exprs) < 2 {
-			return nil, true, fmt.Errorf("MOD requires 2 arguments")
-		}
-		v0, err := e.evalExpr(v.Exprs[0])
+		v0, v1, hasNull, err := e.evalArgs2(v.Exprs, "MOD")
 		if err != nil {
 			return nil, true, err
 		}
-		v1, err := e.evalExpr(v.Exprs[1])
-		if err != nil {
-			return nil, true, err
-		}
-		if v0 == nil || v1 == nil {
+		if hasNull {
 			return nil, true, nil
 		}
 		d := toInt64(v1)
@@ -191,14 +172,11 @@ func evalMathFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		}
 		return toInt64(v0) % d, true, nil
 	case "sqrt":
-		if len(v.Exprs) < 1 {
-			return nil, true, fmt.Errorf("SQRT requires 1 argument")
-		}
-		sqrtVal, err := e.evalExpr(v.Exprs[0])
+		sqrtVal, isNull, err := e.evalArg1(v.Exprs, "SQRT")
 		if err != nil {
 			return nil, true, err
 		}
-		if sqrtVal == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		sqrtF := toFloat(sqrtVal)
@@ -207,14 +185,11 @@ func evalMathFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		}
 		return math.Sqrt(sqrtF), true, nil
 	case "sign":
-		if len(v.Exprs) < 1 {
-			return nil, true, fmt.Errorf("SIGN requires 1 argument")
-		}
-		signVal, err := e.evalExpr(v.Exprs[0])
+		signVal, isNull, err := e.evalArg1(v.Exprs, "SIGN")
 		if err != nil {
 			return nil, true, err
 		}
-		if signVal == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		signF := toFloat(signVal)
@@ -225,14 +200,11 @@ func evalMathFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		}
 		return int64(0), true, nil
 	case "ln":
-		if len(v.Exprs) < 1 {
-			return nil, true, fmt.Errorf("LN requires 1 argument")
-		}
-		lnVal, err := e.evalExpr(v.Exprs[0])
+		lnVal, isNull, err := e.evalArg1(v.Exprs, "LN")
 		if err != nil {
 			return nil, true, err
 		}
-		if lnVal == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		lnF := toFloat(lnVal)
@@ -275,14 +247,11 @@ func evalMathFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		}
 		return nil, true, fmt.Errorf("LOG requires 1 or 2 arguments")
 	case "log2":
-		if len(v.Exprs) < 1 {
-			return nil, true, fmt.Errorf("LOG2 requires 1 argument")
-		}
-		log2Val, err := e.evalExpr(v.Exprs[0])
+		log2Val, isNull, err := e.evalArg1(v.Exprs, "LOG2")
 		if err != nil {
 			return nil, true, err
 		}
-		if log2Val == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		log2F := toFloat(log2Val)
@@ -291,14 +260,11 @@ func evalMathFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		}
 		return math.Log2(log2F), true, nil
 	case "log10":
-		if len(v.Exprs) < 1 {
-			return nil, true, fmt.Errorf("LOG10 requires 1 argument")
-		}
-		log10Val, err := e.evalExpr(v.Exprs[0])
+		log10Val, isNull, err := e.evalArg1(v.Exprs, "LOG10")
 		if err != nil {
 			return nil, true, err
 		}
-		if log10Val == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		log10F := toFloat(log10Val)
@@ -307,42 +273,29 @@ func evalMathFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		}
 		return math.Log10(log10F), true, nil
 	case "exp":
-		if len(v.Exprs) < 1 {
-			return nil, true, fmt.Errorf("EXP requires 1 argument")
-		}
-		expVal, err := e.evalExpr(v.Exprs[0])
+		expVal, isNull, err := e.evalArg1(v.Exprs, "EXP")
 		if err != nil {
 			return nil, true, err
 		}
-		if expVal == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		return math.Exp(toFloat(expVal)), true, nil
 	case "pow", "power":
-		if len(v.Exprs) < 2 {
-			return nil, true, fmt.Errorf("POW requires 2 arguments")
-		}
-		powBase, err := e.evalExpr(v.Exprs[0])
+		powBase, powExp, hasNull, err := e.evalArgs2(v.Exprs, "POW")
 		if err != nil {
 			return nil, true, err
 		}
-		powExp, err := e.evalExpr(v.Exprs[1])
-		if err != nil {
-			return nil, true, err
-		}
-		if powBase == nil || powExp == nil {
+		if hasNull {
 			return nil, true, nil
 		}
 		return math.Pow(toFloat(powBase), toFloat(powExp)), true, nil
 	case "crc32":
-		if len(v.Exprs) < 1 {
-			return nil, true, fmt.Errorf("CRC32 requires 1 argument")
-		}
-		crcVal, err := e.evalExpr(v.Exprs[0])
+		crcVal, isNull, err := e.evalArg1(v.Exprs, "CRC32")
 		if err != nil {
 			return nil, true, err
 		}
-		if crcVal == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		crcS := toString(crcVal)
@@ -359,38 +312,29 @@ func evalMathFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		}
 		return int64(crcResult ^ 0xFFFFFFFF), true, nil
 	case "degrees":
-		if len(v.Exprs) < 1 {
-			return nil, true, nil
-		}
-		degVal, err := e.evalExpr(v.Exprs[0])
+		degVal, isNull, err := e.evalArg1Quiet(v.Exprs)
 		if err != nil {
 			return nil, true, err
 		}
-		if degVal == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		return toFloat(degVal) * 180 / math.Pi, true, nil
 	case "radians":
-		if len(v.Exprs) < 1 {
-			return nil, true, nil
-		}
-		radVal, err := e.evalExpr(v.Exprs[0])
+		radVal, isNull, err := e.evalArg1Quiet(v.Exprs)
 		if err != nil {
 			return nil, true, err
 		}
-		if radVal == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		return toFloat(radVal) * math.Pi / 180, true, nil
 	case "acos":
-		if len(v.Exprs) < 1 {
-			return nil, true, fmt.Errorf("ACOS requires 1 argument")
-		}
-		acosVal, err := e.evalExpr(v.Exprs[0])
+		acosVal, isNull, err := e.evalArg1(v.Exprs, "ACOS")
 		if err != nil {
 			return nil, true, err
 		}
-		if acosVal == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		acosF := toFloat(acosVal)
@@ -399,14 +343,11 @@ func evalMathFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		}
 		return math.Acos(acosF), true, nil
 	case "asin":
-		if len(v.Exprs) < 1 {
-			return nil, true, fmt.Errorf("ASIN requires 1 argument")
-		}
-		asinVal, err := e.evalExpr(v.Exprs[0])
+		asinVal, isNull, err := e.evalArg1(v.Exprs, "ASIN")
 		if err != nil {
 			return nil, true, err
 		}
-		if asinVal == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		asinF := toFloat(asinVal)
@@ -415,14 +356,11 @@ func evalMathFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		}
 		return math.Asin(asinF), true, nil
 	case "atan", "atan2":
-		if len(v.Exprs) < 1 {
-			return nil, true, nil
-		}
-		atanVal, err := e.evalExpr(v.Exprs[0])
+		atanVal, isNull, err := e.evalArg1Quiet(v.Exprs)
 		if err != nil {
 			return nil, true, err
 		}
-		if atanVal == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		if len(v.Exprs) >= 2 {
@@ -437,50 +375,38 @@ func evalMathFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		}
 		return math.Atan(toFloat(atanVal)), true, nil
 	case "sin":
-		if len(v.Exprs) < 1 {
-			return nil, true, nil
-		}
-		sinVal, err := e.evalExpr(v.Exprs[0])
+		sinVal, isNull, err := e.evalArg1Quiet(v.Exprs)
 		if err != nil {
 			return nil, true, err
 		}
-		if sinVal == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		return math.Sin(toFloat(sinVal)), true, nil
 	case "cos":
-		if len(v.Exprs) < 1 {
-			return nil, true, nil
-		}
-		cosVal, err := e.evalExpr(v.Exprs[0])
+		cosVal, isNull, err := e.evalArg1Quiet(v.Exprs)
 		if err != nil {
 			return nil, true, err
 		}
-		if cosVal == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		return math.Cos(toFloat(cosVal)), true, nil
 	case "tan":
-		if len(v.Exprs) < 1 {
-			return nil, true, nil
-		}
-		tanVal, err := e.evalExpr(v.Exprs[0])
+		tanVal, isNull, err := e.evalArg1Quiet(v.Exprs)
 		if err != nil {
 			return nil, true, err
 		}
-		if tanVal == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		return math.Tan(toFloat(tanVal)), true, nil
 	case "cot":
-		if len(v.Exprs) < 1 {
-			return nil, true, nil
-		}
-		cotVal, err := e.evalExpr(v.Exprs[0])
+		cotVal, isNull, err := e.evalArg1Quiet(v.Exprs)
 		if err != nil {
 			return nil, true, err
 		}
-		if cotVal == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		cotF := toFloat(cotVal)
@@ -490,14 +416,11 @@ func evalMathFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		}
 		return math.Cos(cotF) / sinV, true, nil
 	case "bit_count":
-		if len(v.Exprs) < 1 {
-			return nil, true, fmt.Errorf("BIT_COUNT requires 1 argument")
-		}
-		bcVal, err := e.evalExpr(v.Exprs[0])
+		bcVal, isNull, err := e.evalArg1(v.Exprs, "BIT_COUNT")
 		if err != nil {
 			return nil, true, err
 		}
-		if bcVal == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		bcU := uint64(toInt64(bcVal))
@@ -535,14 +458,11 @@ func evalMathFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		}
 		return strings.ToUpper(strconv.FormatInt(n, toBase)), true, nil
 	case "bin":
-		if len(v.Exprs) < 1 {
-			return nil, true, nil
-		}
-		val, err := e.evalExpr(v.Exprs[0])
+		val, isNull, err := e.evalArg1Quiet(v.Exprs)
 		if err != nil {
 			return nil, true, err
 		}
-		if val == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		n := toInt64(val)

--- a/executor/func_misc.go
+++ b/executor/func_misc.go
@@ -71,16 +71,14 @@ func evalMiscFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		r, err := e.evalExpr(v.Exprs[2])
 		return r, true, err
 	case "isnull":
-		if len(v.Exprs) < 1 {
-			return nil, true, fmt.Errorf("ISNULL requires 1 argument")
-		}
-		val, err := e.evalExpr(v.Exprs[0])
+		val, isNull, err := e.evalArg1(v.Exprs, "ISNULL")
 		if err != nil {
 			return nil, true, err
 		}
-		if val == nil {
+		if isNull {
 			return int64(1), true, nil
 		}
+		_ = val
 		return int64(0), true, nil
 	case "nullif":
 		if len(v.Exprs) < 2 {
@@ -292,18 +290,11 @@ func evalMiscFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 	case "user", "session_user", "system_user":
 		return "root@localhost", true, nil
 	case "regexp_like":
-		if len(v.Exprs) < 2 {
-			return nil, true, fmt.Errorf("REGEXP_LIKE requires at least 2 arguments")
-		}
-		rlVal, err := e.evalExpr(v.Exprs[0])
+		rlVal, rlPat, hasNull, err := e.evalArgs2(v.Exprs, "REGEXP_LIKE")
 		if err != nil {
 			return nil, true, err
 		}
-		rlPat, err := e.evalExpr(v.Exprs[1])
-		if err != nil {
-			return nil, true, err
-		}
-		if rlVal == nil || rlPat == nil {
+		if hasNull {
 			return nil, true, nil
 		}
 		rlFlags := ""
@@ -329,14 +320,11 @@ func evalMiscFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		}
 		return int64(0), true, nil
 	case "is_ipv4":
-		if len(v.Exprs) < 1 {
-			return nil, true, fmt.Errorf("IS_IPV4 requires 1 argument")
-		}
-		ipVal, err := e.evalExpr(v.Exprs[0])
+		ipVal, isNull, err := e.evalArg1(v.Exprs, "IS_IPV4")
 		if err != nil {
 			return nil, true, err
 		}
-		if ipVal == nil {
+		if isNull {
 			return int64(0), true, nil
 		}
 		ipStr := toString(ipVal)
@@ -359,27 +347,21 @@ func evalMiscFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 	case "current_role":
 		return "NONE", true, nil
 	case "inet_ntoa":
-		if len(v.Exprs) < 1 {
-			return nil, true, fmt.Errorf("INET_NTOA requires 1 argument")
-		}
-		inVal, err := e.evalExpr(v.Exprs[0])
+		inVal, isNull, err := e.evalArg1(v.Exprs, "INET_NTOA")
 		if err != nil {
 			return nil, true, err
 		}
-		if inVal == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		inN := uint32(toInt64(inVal))
 		return fmt.Sprintf("%d.%d.%d.%d", (inN>>24)&0xFF, (inN>>16)&0xFF, (inN>>8)&0xFF, inN&0xFF), true, nil
 	case "inet_aton":
-		if len(v.Exprs) < 1 {
-			return nil, true, fmt.Errorf("INET_ATON requires 1 argument")
-		}
-		iaVal, err := e.evalExpr(v.Exprs[0])
+		iaVal, isNull, err := e.evalArg1(v.Exprs, "INET_ATON")
 		if err != nil {
 			return nil, true, err
 		}
-		if iaVal == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		iaParts := strings.Split(toString(iaVal), ".")
@@ -398,30 +380,20 @@ func evalMiscFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 	case "coercibility":
 		return int64(4), true, nil
 	case "st_astext", "st_aswkt":
-		if len(v.Exprs) < 1 {
-			return nil, true, nil
-		}
-		stVal, err := e.evalExpr(v.Exprs[0])
+		stVal, isNull, err := e.evalArg1Quiet(v.Exprs)
 		if err != nil {
 			return nil, true, err
 		}
-		if stVal == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		return toString(stVal), true, nil
 	case "st_equals":
-		if len(v.Exprs) < 2 {
-			return nil, true, fmt.Errorf("ST_EQUALS requires 2 arguments")
-		}
-		steA, err := e.evalExpr(v.Exprs[0])
+		steA, steB, hasNull, err := e.evalArgs2(v.Exprs, "ST_EQUALS")
 		if err != nil {
 			return nil, true, err
 		}
-		steB, err := e.evalExpr(v.Exprs[1])
-		if err != nil {
-			return nil, true, err
-		}
-		if steA == nil || steB == nil {
+		if hasNull {
 			return nil, true, nil
 		}
 		if toString(steA) == toString(steB) {
@@ -429,18 +401,11 @@ func evalMiscFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		}
 		return int64(0), true, nil
 	case "mbrintersects", "st_intersects", "mbrwithin", "st_within", "mbrcontains", "st_contains":
-		if len(v.Exprs) < 2 {
-			return nil, true, fmt.Errorf("%s requires 2 arguments", strings.ToUpper(name))
-		}
-		g1Val, err := e.evalExpr(v.Exprs[0])
+		g1Val, g2Val, hasNull, err := e.evalArgs2(v.Exprs, strings.ToUpper(name))
 		if err != nil {
 			return nil, true, err
 		}
-		g2Val, err := e.evalExpr(v.Exprs[1])
-		if err != nil {
-			return nil, true, err
-		}
-		if g1Val == nil || g2Val == nil {
+		if hasNull {
 			return nil, true, nil
 		}
 		g1Str := toString(g1Val)
@@ -480,14 +445,11 @@ func evalMiscFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 			uint16(uuidB[8])<<8|uint16(uuidB[9]),
 			uint64(uuidB[10])<<40|uint64(uuidB[11])<<32|uint64(uuidB[12])<<24|uint64(uuidB[13])<<16|uint64(uuidB[14])<<8|uint64(uuidB[15])), true, nil
 	case "is_ipv6":
-		if len(v.Exprs) < 1 {
-			return nil, true, fmt.Errorf("IS_IPV6 requires 1 argument")
-		}
-		ip6Val, err := e.evalExpr(v.Exprs[0])
+		ip6Val, isNull, err := e.evalArg1(v.Exprs, "IS_IPV6")
 		if err != nil {
 			return nil, true, err
 		}
-		if ip6Val == nil {
+		if isNull {
 			return int64(0), true, nil
 		}
 		ip6Str := toString(ip6Val)
@@ -496,14 +458,11 @@ func evalMiscFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		}
 		return int64(0), true, nil
 	case "is_ipv4_mapped":
-		if len(v.Exprs) < 1 {
-			return nil, true, fmt.Errorf("IS_IPV4_MAPPED requires 1 argument")
-		}
-		imVal, err := e.evalExpr(v.Exprs[0])
+		imVal, isNull, err := e.evalArg1(v.Exprs, "IS_IPV4_MAPPED")
 		if err != nil {
 			return nil, true, err
 		}
-		if imVal == nil {
+		if isNull {
 			return int64(0), true, nil
 		}
 		imBytes := []byte(toString(imVal))
@@ -521,14 +480,11 @@ func evalMiscFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		}
 		return int64(0), true, nil
 	case "is_ipv4_compat":
-		if len(v.Exprs) < 1 {
-			return nil, true, fmt.Errorf("IS_IPV4_COMPAT requires 1 argument")
-		}
-		icVal, err := e.evalExpr(v.Exprs[0])
+		icVal, isNull, err := e.evalArg1(v.Exprs, "IS_IPV4_COMPAT")
 		if err != nil {
 			return nil, true, err
 		}
-		if icVal == nil {
+		if isNull {
 			return int64(0), true, nil
 		}
 		icBytes := []byte(toString(icVal))
@@ -546,14 +502,11 @@ func evalMiscFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		}
 		return int64(0), true, nil
 	case "sha", "sha1":
-		if len(v.Exprs) < 1 {
-			return nil, true, fmt.Errorf("SHA requires 1 argument")
-		}
-		shaVal, err := e.evalExpr(v.Exprs[0])
+		shaVal, isNull, err := e.evalArg1(v.Exprs, "SHA")
 		if err != nil {
 			return nil, true, err
 		}
-		if shaVal == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		return fmt.Sprintf("%x", md5.Sum([]byte(toString(shaVal)))), true, nil
@@ -562,14 +515,11 @@ func evalMiscFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 	case "master_pos_wait":
 		return int64(0), true, nil
 	case "statement_digest":
-		if len(v.Exprs) < 1 {
-			return nil, true, nil
-		}
-		sdVal, err := e.evalExpr(v.Exprs[0])
+		sdVal, isNull, err := e.evalArg1Quiet(v.Exprs)
 		if err != nil {
 			return nil, true, err
 		}
-		if sdVal == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		sdHash := md5.Sum([]byte(toString(sdVal)))
@@ -583,38 +533,29 @@ func evalMiscFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 	case "aes_encrypt", "aes_decrypt":
 		return nil, true, nil
 	case "uuid_to_bin":
-		if len(v.Exprs) < 1 {
-			return nil, true, nil
-		}
-		utbVal, err := e.evalExpr(v.Exprs[0])
+		utbVal, isNull, err := e.evalArg1Quiet(v.Exprs)
 		if err != nil {
 			return nil, true, err
 		}
-		if utbVal == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		return strings.ReplaceAll(toString(utbVal), "-", ""), true, nil
 	case "bin_to_uuid":
-		if len(v.Exprs) < 1 {
-			return nil, true, nil
-		}
-		btuVal, err := e.evalExpr(v.Exprs[0])
+		btuVal, isNull, err := e.evalArg1Quiet(v.Exprs)
 		if err != nil {
 			return nil, true, err
 		}
-		if btuVal == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		return toString(btuVal), true, nil
 	case "to_base64":
-		if len(v.Exprs) < 1 {
-			return nil, true, nil
-		}
-		tb64Val, err := e.evalExpr(v.Exprs[0])
+		tb64Val, isNull, err := e.evalArg1Quiet(v.Exprs)
 		if err != nil {
 			return nil, true, err
 		}
-		if tb64Val == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		tb64Src := []byte(toString(tb64Val))
@@ -644,26 +585,20 @@ func evalMiscFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		}
 		return string(tb64Buf), true, nil
 	case "from_base64":
-		if len(v.Exprs) < 1 {
-			return nil, true, nil
-		}
-		fb64Val, err := e.evalExpr(v.Exprs[0])
+		fb64Val, isNull, err := e.evalArg1Quiet(v.Exprs)
 		if err != nil {
 			return nil, true, err
 		}
-		if fb64Val == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		return toString(fb64Val), true, nil // simplified stub
 	case "random_bytes":
-		if len(v.Exprs) < 1 {
-			return nil, true, nil
-		}
-		rbVal, err := e.evalExpr(v.Exprs[0])
+		rbVal, isNull, err := e.evalArg1Quiet(v.Exprs)
 		if err != nil {
 			return nil, true, err
 		}
-		if rbVal == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		rbN := int(toInt64(rbVal))
@@ -684,14 +619,11 @@ func evalMiscFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 	case "uuid_short":
 		return int64(rand.Int63()), true, nil
 	case "is_uuid":
-		if len(v.Exprs) < 1 {
-			return nil, true, nil
-		}
-		iuVal, err := e.evalExpr(v.Exprs[0])
+		iuVal, isNull, err := e.evalArg1Quiet(v.Exprs)
 		if err != nil {
 			return nil, true, err
 		}
-		if iuVal == nil {
+		if isNull {
 			return int64(0), true, nil
 		}
 		iuStr := toString(iuVal)

--- a/executor/func_string.go
+++ b/executor/func_string.go
@@ -33,14 +33,11 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{
 		}
 		return sb.String(), true, nil
 	case "md5":
-		if len(v.Exprs) < 1 {
-			return nil, true, fmt.Errorf("MD5 requires 1 argument")
-		}
-		val, err := e.evalExpr(v.Exprs[0])
+		val, isNull, err := e.evalArg1(v.Exprs, "MD5")
 		if err != nil {
 			return nil, true, err
 		}
-		if val == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		sum := md5.Sum([]byte(toString(val)))
@@ -70,14 +67,11 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{
 		}
 		return strings.Join(parts, sep), true, nil
 	case "upper", "ucase":
-		if len(v.Exprs) < 1 {
-			return nil, true, fmt.Errorf("UPPER requires 1 argument")
-		}
-		val, err := e.evalExpr(v.Exprs[0])
+		val, isNull, err := e.evalArg1(v.Exprs, "UPPER")
 		if err != nil {
 			return nil, true, err
 		}
-		if val == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		s := toString(val)
@@ -89,14 +83,11 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{
 		}
 		return strings.ToUpper(s), true, nil
 	case "lower", "lcase":
-		if len(v.Exprs) < 1 {
-			return nil, true, fmt.Errorf("LOWER requires 1 argument")
-		}
-		val, err := e.evalExpr(v.Exprs[0])
+		val, isNull, err := e.evalArg1(v.Exprs, "LOWER")
 		if err != nil {
 			return nil, true, err
 		}
-		if val == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		if e.isBinaryExpr(v.Exprs[0]) {
@@ -104,14 +95,11 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{
 		}
 		return strings.ToLower(toString(val)), true, nil
 	case "length", "octet_length":
-		if len(v.Exprs) < 1 {
-			return nil, true, fmt.Errorf("LENGTH requires 1 argument")
-		}
-		val, err := e.evalExpr(v.Exprs[0])
+		val, isNull, err := e.evalArg1(v.Exprs, "LENGTH")
 		if err != nil {
 			return nil, true, err
 		}
-		if val == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		s := toString(val)
@@ -123,26 +111,20 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{
 		}
 		return int64(len(s)), true, nil
 	case "char_length", "character_length":
-		if len(v.Exprs) < 1 {
-			return nil, true, fmt.Errorf("CHAR_LENGTH requires 1 argument")
-		}
-		val, err := e.evalExpr(v.Exprs[0])
+		val, isNull, err := e.evalArg1(v.Exprs, "CHAR_LENGTH")
 		if err != nil {
 			return nil, true, err
 		}
-		if val == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		return int64(mysqlCharLen(toString(val))), true, nil
 	case "ascii", "ord":
-		if len(v.Exprs) < 1 {
-			return nil, true, fmt.Errorf("ASCII requires 1 argument")
-		}
-		val, err := e.evalExpr(v.Exprs[0])
+		val, isNull, err := e.evalArg1(v.Exprs, "ASCII")
 		if err != nil {
 			return nil, true, err
 		}
-		if val == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		s := toString(val)
@@ -151,14 +133,11 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{
 		}
 		return int64(s[0]), true, nil
 	case "load_file":
-		if len(v.Exprs) < 1 {
-			return nil, true, nil
-		}
-		val, err := e.evalExpr(v.Exprs[0])
+		val, isNull, err := e.evalArg1Quiet(v.Exprs)
 		if err != nil {
 			return nil, true, err
 		}
-		if val == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		filePath := toString(val)
@@ -240,38 +219,29 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{
 		}
 		return string(s[pos:]), true, nil
 	case "trim":
-		if len(v.Exprs) < 1 {
-			return nil, true, fmt.Errorf("TRIM requires 1 argument")
-		}
-		val, err := e.evalExpr(v.Exprs[0])
+		val, isNull, err := e.evalArg1(v.Exprs, "TRIM")
 		if err != nil {
 			return nil, true, err
 		}
-		if val == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		return strings.TrimSpace(toString(val)), true, nil
 	case "ltrim":
-		if len(v.Exprs) < 1 {
-			return nil, true, fmt.Errorf("LTRIM requires 1 argument")
-		}
-		val, err := e.evalExpr(v.Exprs[0])
+		val, isNull, err := e.evalArg1(v.Exprs, "LTRIM")
 		if err != nil {
 			return nil, true, err
 		}
-		if val == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		return strings.TrimLeft(toString(val), " \t\n\r"), true, nil
 	case "rtrim":
-		if len(v.Exprs) < 1 {
-			return nil, true, fmt.Errorf("RTRIM requires 1 argument")
-		}
-		val, err := e.evalExpr(v.Exprs[0])
+		val, isNull, err := e.evalArg1(v.Exprs, "RTRIM")
 		if err != nil {
 			return nil, true, err
 		}
-		if val == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		return strings.TrimRight(toString(val), " \t\n\r"), true, nil
@@ -352,14 +322,11 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{
 		}
 		return string(s[len(s)-n:]), true, nil
 	case "hex":
-		if len(v.Exprs) < 1 {
-			return nil, true, nil
-		}
-		val, err := e.evalExpr(v.Exprs[0])
+		val, isNull, err := e.evalArg1Quiet(v.Exprs)
 		if err != nil {
 			return nil, true, err
 		}
-		if val == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		switch tv := val.(type) {
@@ -376,14 +343,11 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{
 			return hexBuf.String(), true, nil
 		}
 	case "unhex":
-		if len(v.Exprs) < 1 {
-			return nil, true, nil
-		}
-		val, err := e.evalExpr(v.Exprs[0])
+		val, isNull, err := e.evalArg1Quiet(v.Exprs)
 		if err != nil {
 			return nil, true, err
 		}
-		if val == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		decoded, err := hex.DecodeString(toString(val))
@@ -392,18 +356,11 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{
 		}
 		return string(decoded), true, nil
 	case "strcmp":
-		if len(v.Exprs) < 2 {
-			return nil, true, fmt.Errorf("STRCMP requires 2 arguments")
-		}
-		v0, err := e.evalExpr(v.Exprs[0])
+		v0, v1, hasNull, err := e.evalArgs2(v.Exprs, "STRCMP")
 		if err != nil {
 			return nil, true, err
 		}
-		v1, err := e.evalExpr(v.Exprs[1])
-		if err != nil {
-			return nil, true, err
-		}
-		if v0 == nil || v1 == nil {
+		if hasNull {
 			return nil, true, nil
 		}
 		s0 := strings.ToLower(toString(v0))
@@ -415,14 +372,11 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{
 		}
 		return int64(0), true, nil
 	case "reverse":
-		if len(v.Exprs) < 1 {
-			return nil, true, nil
-		}
-		val, err := e.evalExpr(v.Exprs[0])
+		val, isNull, err := e.evalArg1Quiet(v.Exprs)
 		if err != nil {
 			return nil, true, err
 		}
-		if val == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		runes := []rune(toString(val))
@@ -431,14 +385,11 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{
 		}
 		return string(runes), true, nil
 	case "oct":
-		if len(v.Exprs) < 1 {
-			return nil, true, nil
-		}
-		val, err := e.evalExpr(v.Exprs[0])
+		val, isNull, err := e.evalArg1Quiet(v.Exprs)
 		if err != nil {
 			return nil, true, err
 		}
-		if val == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		n := toInt64(val)
@@ -468,18 +419,11 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{
 		}
 		return strings.Repeat(str, count), true, nil
 	case "instr":
-		if len(v.Exprs) < 2 {
-			return nil, true, fmt.Errorf("INSTR requires 2 arguments")
-		}
-		strVal, err := e.evalExpr(v.Exprs[0])
+		strVal, subVal, hasNull, err := e.evalArgs2(v.Exprs, "INSTR")
 		if err != nil {
 			return nil, true, err
 		}
-		subVal, err := e.evalExpr(v.Exprs[1])
-		if err != nil {
-			return nil, true, err
-		}
-		if strVal == nil || subVal == nil {
+		if hasNull {
 			return nil, true, nil
 		}
 		s := []rune(toString(strVal))
@@ -601,14 +545,11 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{
 		pad = pad[:needed]
 		return string(append(s, pad...)), true, nil
 	case "space":
-		if len(v.Exprs) < 1 {
-			return nil, true, fmt.Errorf("SPACE requires 1 argument")
-		}
-		spVal, err := e.evalExpr(v.Exprs[0])
+		spVal, isNull, err := e.evalArg1(v.Exprs, "SPACE")
 		if err != nil {
 			return nil, true, err
 		}
-		if spVal == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		spN := int(toInt64(spVal))
@@ -654,26 +595,20 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{
 		}
 		return strings.Join(siParts[len(siParts)-siN:], siD), true, nil
 	case "soundex":
-		if len(v.Exprs) < 1 {
-			return nil, true, fmt.Errorf("SOUNDEX requires 1 argument")
-		}
-		val, err := e.evalExpr(v.Exprs[0])
+		val, isNull, err := e.evalArg1(v.Exprs, "SOUNDEX")
 		if err != nil {
 			return nil, true, err
 		}
-		if val == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		return soundex(toString(val)), true, nil
 	case "bit_length":
-		if len(v.Exprs) < 1 {
-			return nil, true, fmt.Errorf("BIT_LENGTH requires 1 argument")
-		}
-		val, err := e.evalExpr(v.Exprs[0])
+		val, isNull, err := e.evalArg1(v.Exprs, "BIT_LENGTH")
 		if err != nil {
 			return nil, true, err
 		}
-		if val == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		return int64(len(toString(val))) * 8, true, nil
@@ -700,18 +635,11 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{
 		}
 		return int64(0), true, nil
 	case "find_in_set":
-		if len(v.Exprs) < 2 {
-			return nil, true, fmt.Errorf("FIND_IN_SET requires 2 arguments")
-		}
-		fisNeedle, err := e.evalExpr(v.Exprs[0])
+		fisNeedle, fisHaystack, hasNull, err := e.evalArgs2(v.Exprs, "FIND_IN_SET")
 		if err != nil {
 			return nil, true, err
 		}
-		fisHaystack, err := e.evalExpr(v.Exprs[1])
-		if err != nil {
-			return nil, true, err
-		}
-		if fisNeedle == nil || fisHaystack == nil {
+		if hasNull {
 			return nil, true, nil
 		}
 		fisNS := toString(fisNeedle)
@@ -816,14 +744,11 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{
 		}
 		return strings.Join(esParts, esSep), true, nil
 	case "quote":
-		if len(v.Exprs) < 1 {
-			return nil, true, nil
-		}
-		qVal, err := e.evalExpr(v.Exprs[0])
+		qVal, isNull, err := e.evalArg1Quiet(v.Exprs)
 		if err != nil {
 			return nil, true, err
 		}
-		if qVal == nil {
+		if isNull {
 			return "NULL", true, nil
 		}
 		qStr := toString(qVal)
@@ -831,14 +756,11 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{
 		qStr = strings.ReplaceAll(qStr, "'", "\\'")
 		return "'" + qStr + "'", true, nil
 	case "weight_string":
-		if len(v.Exprs) < 1 {
-			return nil, true, nil
-		}
-		wsVal, err := e.evalExpr(v.Exprs[0])
+		wsVal, isNull, err := e.evalArg1Quiet(v.Exprs)
 		if err != nil {
 			return nil, true, err
 		}
-		if wsVal == nil {
+		if isNull {
 			return nil, true, nil
 		}
 		return toString(wsVal), true, nil


### PR DESCRIPTION
## Summary
- Introduce `evalArg1`, `evalArg1Quiet`, `evalArgs2`, `evalArgs3` helper methods in `executor/eval_helpers.go` to consolidate the repeated arg-count-check + evalExpr + NULL-check pattern
- Replace 70+ instances of the boilerplate pattern across `func_math.go`, `func_string.go`, `func_datetime.go`, and `func_misc.go`
- Net reduction of ~320 lines (493 deleted, 175 added in func files + 87 in new helper file)

Closes #38

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./... -count=1` passes (88 tests)
- [x] `go run ./cmd/mtrrun` passes (1330 passed, 0 failed, no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)