### PR TITLE
refactor: unify evalXxxFunc / evalXxxFuncWithRow

### DIFF
--- a/executor/eval_helpers.go
+++ b/executor/eval_helpers.go
@@ -3,6 +3,7 @@ package executor
 import (
 	"fmt"
 
+	"github.com/myuon/mylite/storage"
 	"vitess.io/vitess/go/vt/sqlparser"
 )
 
@@ -10,11 +11,11 @@ import (
 // It checks the minimum argument count, evaluates the first expression,
 // and checks for NULL. Returns (value, isNull, error).
 // If isNull is true, the caller should return nil, true, nil.
-func (e *Executor) evalArg1(exprs []sqlparser.Expr, funcName string) (interface{}, bool, error) {
+func (e *Executor) evalArg1(exprs []sqlparser.Expr, funcName string, row *storage.Row) (interface{}, bool, error) {
 	if len(exprs) < 1 {
 		return nil, false, fmt.Errorf("%s requires 1 argument", funcName)
 	}
-	val, err := e.evalExpr(exprs[0])
+	val, err := e.evalExprMaybeRow(exprs[0], row)
 	if err != nil {
 		return nil, false, err
 	}
@@ -27,11 +28,11 @@ func (e *Executor) evalArg1(exprs []sqlparser.Expr, funcName string) (interface{
 // evalArg1Quiet evaluates a single argument without error on missing args
 // (returns nil, true, nil instead of error). Used by functions that return
 // NULL silently when no arguments are provided.
-func (e *Executor) evalArg1Quiet(exprs []sqlparser.Expr) (interface{}, bool, error) {
+func (e *Executor) evalArg1Quiet(exprs []sqlparser.Expr, row *storage.Row) (interface{}, bool, error) {
 	if len(exprs) < 1 {
 		return nil, true, nil
 	}
-	val, err := e.evalExpr(exprs[0])
+	val, err := e.evalExprMaybeRow(exprs[0], row)
 	if err != nil {
 		return nil, false, err
 	}
@@ -44,15 +45,15 @@ func (e *Executor) evalArg1Quiet(exprs []sqlparser.Expr) (interface{}, bool, err
 // evalArgs2 evaluates exactly 2 required arguments.
 // Returns (val0, val1, hasNull, error). If hasNull is true and error is nil,
 // at least one argument was NULL.
-func (e *Executor) evalArgs2(exprs []sqlparser.Expr, funcName string) (interface{}, interface{}, bool, error) {
+func (e *Executor) evalArgs2(exprs []sqlparser.Expr, funcName string, row *storage.Row) (interface{}, interface{}, bool, error) {
 	if len(exprs) < 2 {
 		return nil, nil, false, fmt.Errorf("%s requires 2 arguments", funcName)
 	}
-	v0, err := e.evalExpr(exprs[0])
+	v0, err := e.evalExprMaybeRow(exprs[0], row)
 	if err != nil {
 		return nil, nil, false, err
 	}
-	v1, err := e.evalExpr(exprs[1])
+	v1, err := e.evalExprMaybeRow(exprs[1], row)
 	if err != nil {
 		return nil, nil, false, err
 	}
@@ -64,19 +65,19 @@ func (e *Executor) evalArgs2(exprs []sqlparser.Expr, funcName string) (interface
 
 // evalArgs3 evaluates exactly 3 required arguments.
 // Returns (val0, val1, val2, hasNull, error).
-func (e *Executor) evalArgs3(exprs []sqlparser.Expr, funcName string) (interface{}, interface{}, interface{}, bool, error) {
+func (e *Executor) evalArgs3(exprs []sqlparser.Expr, funcName string, row *storage.Row) (interface{}, interface{}, interface{}, bool, error) {
 	if len(exprs) < 3 {
 		return nil, nil, nil, false, fmt.Errorf("%s requires 3 arguments", funcName)
 	}
-	v0, err := e.evalExpr(exprs[0])
+	v0, err := e.evalExprMaybeRow(exprs[0], row)
 	if err != nil {
 		return nil, nil, nil, false, err
 	}
-	v1, err := e.evalExpr(exprs[1])
+	v1, err := e.evalExprMaybeRow(exprs[1], row)
 	if err != nil {
 		return nil, nil, nil, false, err
 	}
-	v2, err := e.evalExpr(exprs[2])
+	v2, err := e.evalExprMaybeRow(exprs[2], row)
 	if err != nil {
 		return nil, nil, nil, false, err
 	}

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -7804,16 +7804,16 @@ func (e *Executor) evalFuncExpr(v *sqlparser.FuncExpr) (interface{}, error) {
 	name := strings.ToLower(v.Name.String())
 
 	// Dispatch to category-specific handlers
-	if result, handled, err := evalStringFunc(e, name, v); handled {
+	if result, handled, err := evalStringFunc(e, name, v, nil); handled {
 		return result, err
 	}
-	if result, handled, err := evalDatetimeFunc(e, name, v); handled {
+	if result, handled, err := evalDatetimeFunc(e, name, v, nil); handled {
 		return result, err
 	}
-	if result, handled, err := evalMathFunc(e, name, v); handled {
+	if result, handled, err := evalMathFunc(e, name, v, nil); handled {
 		return result, err
 	}
-	if result, handled, err := evalMiscFunc(e, name, v); handled {
+	if result, handled, err := evalMiscFunc(e, name, v, nil); handled {
 		return result, err
 	}
 
@@ -8623,6 +8623,14 @@ func isTruthy(v interface{}) bool {
 	return false
 }
 
+// evalExprMaybeRow evaluates an expression, using row context if row is non-nil.
+func (e *Executor) evalExprMaybeRow(expr sqlparser.Expr, row *storage.Row) (interface{}, error) {
+	if row != nil {
+		return e.evalRowExpr(expr, *row)
+	}
+	return e.evalExpr(expr)
+}
+
 // evalRowExpr evaluates an expression in the context of a table row.
 // It handles column lookups and delegates other expressions to e.evalExpr.
 func (e *Executor) evalRowExpr(expr sqlparser.Expr, row storage.Row) (interface{}, error) {
@@ -8993,30 +9001,19 @@ func (e *Executor) evalFuncExprWithRow(v *sqlparser.FuncExpr, row storage.Row) (
 	// Evaluate function arguments with row context to resolve column references
 	name := strings.ToLower(v.Name.String())
 
-	// Helper to evaluate args with row context
-	evalArgs := func() ([]interface{}, error) {
-		args := make([]interface{}, len(v.Exprs))
-		for i, argExpr := range v.Exprs {
-			val, err := e.evalRowExpr(argExpr, row)
-			if err != nil {
-				return nil, err
-			}
-			args[i] = val
-		}
-		return args, nil
-	}
+	rowPtr := &row
 
 	// Dispatch to category-specific handlers
-	if result, handled, err := evalStringFuncWithRow(e, name, v, row, evalArgs); handled {
+	if result, handled, err := evalStringFunc(e, name, v, rowPtr); handled {
 		return result, err
 	}
-	if result, handled, err := evalDatetimeFuncWithRow(e, name, v, row, evalArgs); handled {
+	if result, handled, err := evalDatetimeFunc(e, name, v, rowPtr); handled {
 		return result, err
 	}
-	if result, handled, err := evalMathFuncWithRow(e, name, v, row, evalArgs); handled {
+	if result, handled, err := evalMathFunc(e, name, v, rowPtr); handled {
 		return result, err
 	}
-	if result, handled, err := evalMiscFuncWithRow(e, name, v, row, evalArgs); handled {
+	if result, handled, err := evalMiscFunc(e, name, v, rowPtr); handled {
 		return result, err
 	}
 

--- a/executor/func_datetime.go
+++ b/executor/func_datetime.go
@@ -10,9 +10,10 @@ import (
 	"vitess.io/vitess/go/vt/sqlparser"
 )
 
-// evalDatetimeFunc dispatches date/time-related functions from evalFuncExpr.
+// evalDatetimeFunc dispatches date/time-related functions.
+// When row is non-nil, expressions are evaluated with row context.
 // Returns (result, handled, error).
-func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{}, bool, error) {
+func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr, row *storage.Row) (interface{}, bool, error) {
 	switch name {
 	case "now", "current_timestamp", "sysdate":
 		return e.nowTime().Format("2006-01-02 15:04:05"), true, nil
@@ -30,7 +31,7 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interfac
 		if len(v.Exprs) == 0 {
 			return int64(e.nowTime().Unix()), true, nil
 		}
-		val, err := e.evalExpr(v.Exprs[0])
+		val, err := e.evalExprMaybeRow(v.Exprs[0], row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -43,14 +44,14 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interfac
 		if len(v.Exprs) < 1 {
 			return nil, true, fmt.Errorf("FROM_UNIXTIME requires 1 argument")
 		}
-		val, err := e.evalExpr(v.Exprs[0])
+		val, err := e.evalExprMaybeRow(v.Exprs[0], row)
 		if err != nil {
 			return nil, true, err
 		}
 		ts := toInt64(val)
 		t := time.Unix(ts, 0)
 		if len(v.Exprs) >= 2 {
-			fmtVal, err := e.evalExpr(v.Exprs[1])
+			fmtVal, err := e.evalExprMaybeRow(v.Exprs[1], row)
 			if err != nil {
 				return nil, true, err
 			}
@@ -61,9 +62,15 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interfac
 		if len(v.Exprs) < 1 {
 			return nil, true, fmt.Errorf("YEAR requires 1 argument")
 		}
-		val, err := e.evalExpr(v.Exprs[0])
+		val, err := e.evalExprMaybeRow(v.Exprs[0], row)
 		if err != nil {
 			return nil, true, err
+		}
+		if val == nil {
+			return nil, true, nil
+		}
+		if isZeroDate(val) {
+			return int64(0), true, nil
 		}
 		t, err := parseDateTimeValue(val)
 		if err != nil {
@@ -74,9 +81,15 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interfac
 		if len(v.Exprs) < 1 {
 			return nil, true, fmt.Errorf("MONTH requires 1 argument")
 		}
-		val, err := e.evalExpr(v.Exprs[0])
+		val, err := e.evalExprMaybeRow(v.Exprs[0], row)
 		if err != nil {
 			return nil, true, err
+		}
+		if val == nil {
+			return nil, true, nil
+		}
+		if isZeroDate(val) {
+			return int64(0), true, nil
 		}
 		t, err := parseDateTimeValue(val)
 		if err != nil {
@@ -87,9 +100,15 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interfac
 		if len(v.Exprs) < 1 {
 			return nil, true, fmt.Errorf("DAY requires 1 argument")
 		}
-		val, err := e.evalExpr(v.Exprs[0])
+		val, err := e.evalExprMaybeRow(v.Exprs[0], row)
 		if err != nil {
 			return nil, true, err
+		}
+		if val == nil {
+			return nil, true, nil
+		}
+		if isZeroDate(val) {
+			return int64(0), true, nil
 		}
 		t, err := parseDateTimeValue(val)
 		if err != nil {
@@ -100,9 +119,12 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interfac
 		if len(v.Exprs) < 1 {
 			return nil, true, fmt.Errorf("HOUR requires 1 argument")
 		}
-		val, err := e.evalExpr(v.Exprs[0])
+		val, err := e.evalExprMaybeRow(v.Exprs[0], row)
 		if err != nil {
 			return nil, true, err
+		}
+		if val == nil {
+			return nil, true, nil
 		}
 		t, err := parseDateTimeValue(val)
 		if err != nil {
@@ -113,9 +135,12 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interfac
 		if len(v.Exprs) < 1 {
 			return nil, true, fmt.Errorf("MINUTE requires 1 argument")
 		}
-		val, err := e.evalExpr(v.Exprs[0])
+		val, err := e.evalExprMaybeRow(v.Exprs[0], row)
 		if err != nil {
 			return nil, true, err
+		}
+		if val == nil {
+			return nil, true, nil
 		}
 		t, err := parseDateTimeValue(val)
 		if err != nil {
@@ -126,9 +151,12 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interfac
 		if len(v.Exprs) < 1 {
 			return nil, true, fmt.Errorf("SECOND requires 1 argument")
 		}
-		val, err := e.evalExpr(v.Exprs[0])
+		val, err := e.evalExprMaybeRow(v.Exprs[0], row)
 		if err != nil {
 			return nil, true, err
+		}
+		if val == nil {
+			return nil, true, nil
 		}
 		t, err := parseDateTimeValue(val)
 		if err != nil {
@@ -136,7 +164,7 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interfac
 		}
 		return int64(t.Second()), true, nil
 	case "date":
-		val, isNull, err := e.evalArg1(v.Exprs, "DATE")
+		val, isNull, err := e.evalArg1(v.Exprs, "DATE", row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -155,9 +183,12 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interfac
 		if len(v.Exprs) < 1 {
 			return nil, true, fmt.Errorf("TIME requires 1 argument")
 		}
-		val, err := e.evalExpr(v.Exprs[0])
+		val, err := e.evalExprMaybeRow(v.Exprs[0], row)
 		if err != nil {
 			return nil, true, err
+		}
+		if val == nil {
+			return nil, true, nil
 		}
 		t, err := parseDateTimeValue(val)
 		if err != nil {
@@ -165,7 +196,7 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interfac
 		}
 		return t.Format("15:04:05"), true, nil
 	case "datediff":
-		v0, v1, hasNull, err := e.evalArgs2(v.Exprs, "DATEDIFF")
+		v0, v1, hasNull, err := e.evalArgs2(v.Exprs, "DATEDIFF", row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -188,11 +219,11 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interfac
 		if len(v.Exprs) < 2 {
 			return nil, true, fmt.Errorf("DATE_FORMAT requires 2 arguments")
 		}
-		dateVal, err := e.evalExpr(v.Exprs[0])
+		dateVal, err := e.evalExprMaybeRow(v.Exprs[0], row)
 		if err != nil {
 			return nil, true, err
 		}
-		fmtVal, err := e.evalExpr(v.Exprs[1])
+		fmtVal, err := e.evalExprMaybeRow(v.Exprs[1], row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -205,11 +236,11 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interfac
 		if len(v.Exprs) < 2 {
 			return nil, true, fmt.Errorf("STR_TO_DATE requires 2 arguments")
 		}
-		strVal, err := e.evalExpr(v.Exprs[0])
+		strVal, err := e.evalExprMaybeRow(v.Exprs[0], row)
 		if err != nil {
 			return nil, true, err
 		}
-		fmtVal2, err := e.evalExpr(v.Exprs[1])
+		fmtVal2, err := e.evalExprMaybeRow(v.Exprs[1], row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -225,11 +256,11 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interfac
 		if len(v.Exprs) < 2 {
 			return nil, true, fmt.Errorf("GET_FORMAT requires 2 arguments")
 		}
-		typeVal, err := e.evalExpr(v.Exprs[0])
+		typeVal, err := e.evalExprMaybeRow(v.Exprs[0], row)
 		if err != nil {
 			return nil, true, err
 		}
-		localeVal, err := e.evalExpr(v.Exprs[1])
+		localeVal, err := e.evalExprMaybeRow(v.Exprs[1], row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -241,9 +272,12 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interfac
 		if len(v.Exprs) < 1 {
 			return nil, true, nil
 		}
-		val, err := e.evalExpr(v.Exprs[0])
+		val, err := e.evalExprMaybeRow(v.Exprs[0], row)
 		if err != nil {
 			return nil, true, err
+		}
+		if val == nil {
+			return nil, true, nil
 		}
 		if isZeroDate(val) {
 			return nil, true, nil
@@ -257,9 +291,12 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interfac
 		if len(v.Exprs) < 1 {
 			return nil, true, nil
 		}
-		val, err := e.evalExpr(v.Exprs[0])
+		val, err := e.evalExprMaybeRow(v.Exprs[0], row)
 		if err != nil {
 			return nil, true, err
+		}
+		if val == nil {
+			return nil, true, nil
 		}
 		if isZeroDate(val) {
 			return nil, true, nil
@@ -273,9 +310,12 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interfac
 		if len(v.Exprs) < 1 {
 			return nil, true, nil
 		}
-		val, err := e.evalExpr(v.Exprs[0])
+		val, err := e.evalExprMaybeRow(v.Exprs[0], row)
 		if err != nil {
 			return nil, true, err
+		}
+		if val == nil {
+			return nil, true, nil
 		}
 		if isZeroDate(val) {
 			return nil, true, nil
@@ -293,9 +333,12 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interfac
 		if len(v.Exprs) < 1 {
 			return nil, true, nil
 		}
-		val, err := e.evalExpr(v.Exprs[0])
+		val, err := e.evalExprMaybeRow(v.Exprs[0], row)
 		if err != nil {
 			return nil, true, err
+		}
+		if val == nil {
+			return nil, true, nil
 		}
 		if isZeroDate(val) {
 			return nil, true, nil
@@ -309,9 +352,15 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interfac
 		if len(v.Exprs) < 1 {
 			return nil, true, nil
 		}
-		val, err := e.evalExpr(v.Exprs[0])
+		val, err := e.evalExprMaybeRow(v.Exprs[0], row)
 		if err != nil {
 			return nil, true, err
+		}
+		if val == nil {
+			return nil, true, nil
+		}
+		if isZeroDate(val) {
+			return nil, true, nil
 		}
 		t, err := parseDateTimeValue(val)
 		if err != nil {
@@ -322,11 +371,11 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interfac
 		if len(v.Exprs) < 2 {
 			return nil, true, nil
 		}
-		base, err := e.evalExpr(v.Exprs[0])
+		base, err := e.evalExprMaybeRow(v.Exprs[0], row)
 		if err != nil {
 			return nil, true, err
 		}
-		interval, err := e.evalExpr(v.Exprs[1])
+		interval, err := e.evalExprMaybeRow(v.Exprs[1], row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -343,11 +392,11 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interfac
 		if len(v.Exprs) < 2 {
 			return nil, true, nil
 		}
-		base, err := e.evalExpr(v.Exprs[0])
+		base, err := e.evalExprMaybeRow(v.Exprs[0], row)
 		if err != nil {
 			return nil, true, err
 		}
-		interval, err := e.evalExpr(v.Exprs[1])
+		interval, err := e.evalExprMaybeRow(v.Exprs[1], row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -361,7 +410,7 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interfac
 		}
 		return t.Add(-dur).Format("2006-01-02 15:04:05"), true, nil
 	case "from_days":
-		val, isNull, err := e.evalArg1Quiet(v.Exprs)
+		val, isNull, err := e.evalArg1Quiet(v.Exprs, row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -375,7 +424,7 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interfac
 		t := time.Date(1, 1, 1, 0, 0, 0, 0, time.UTC).AddDate(0, 0, days-1)
 		return t.Format("2006-01-02"), true, nil
 	case "to_days":
-		val, isNull, err := e.evalArg1Quiet(v.Exprs)
+		val, isNull, err := e.evalArg1Quiet(v.Exprs, row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -391,11 +440,14 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interfac
 		}
 		return mysqlToDays(t), true, nil
 	case "last_day":
-		val, isNull, err := e.evalArg1Quiet(v.Exprs)
+		val, isNull, err := e.evalArg1Quiet(v.Exprs, row)
 		if err != nil {
 			return nil, true, err
 		}
 		if isNull {
+			return nil, true, nil
+		}
+		if isZeroDate(val) {
 			return nil, true, nil
 		}
 		t, parseErr := parseDateTimeValue(val)
@@ -406,12 +458,15 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interfac
 		lastDay := firstOfNextMonth.AddDate(0, 0, -1)
 		return lastDay.Format("2006-01-02"), true, nil
 	case "quarter":
-		val, isNull, err := e.evalArg1Quiet(v.Exprs)
+		val, isNull, err := e.evalArg1Quiet(v.Exprs, row)
 		if err != nil {
 			return nil, true, err
 		}
 		if isNull {
 			return nil, true, nil
+		}
+		if isZeroDate(val) {
+			return int64(0), true, nil
 		}
 		t, parseErr := parseDateTimeValue(val)
 		if parseErr != nil {
@@ -419,7 +474,7 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interfac
 		}
 		return int64((t.Month()-1)/3 + 1), true, nil
 	case "week":
-		val, isNull, err := e.evalArg1Quiet(v.Exprs)
+		val, isNull, err := e.evalArg1Quiet(v.Exprs, row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -435,7 +490,8 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interfac
 		}
 		mode := int64(0)
 		if len(v.Exprs) >= 2 {
-			if modeVal, modeErr := e.evalExpr(v.Exprs[1]); modeErr == nil && modeVal != nil {
+			modeVal, modeErr := e.evalExprMaybeRow(v.Exprs[1], row)
+			if modeErr == nil && modeVal != nil {
 				mode = toInt64(modeVal)
 			}
 		}
@@ -445,7 +501,7 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interfac
 		_, wk := t.ISOWeek()
 		return int64(wk), true, nil
 	case "weekofyear":
-		val, isNull, err := e.evalArg1Quiet(v.Exprs)
+		val, isNull, err := e.evalArg1Quiet(v.Exprs, row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -462,11 +518,14 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interfac
 		_, wk := t.ISOWeek()
 		return int64(wk), true, nil
 	case "yearweek":
-		val, isNull, err := e.evalArg1Quiet(v.Exprs)
+		val, isNull, err := e.evalArg1Quiet(v.Exprs, row)
 		if err != nil {
 			return nil, true, err
 		}
 		if isNull {
+			return nil, true, nil
+		}
+		if isZeroDate(val) {
 			return nil, true, nil
 		}
 		t, parseErr := parseDateTimeValue(val)
@@ -476,12 +535,15 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interfac
 		yr, wk := mysqlYearWeek(t, 0)
 		return int64(yr*100 + wk), true, nil
 	case "timestamp":
-		val, isNull, err := e.evalArg1Quiet(v.Exprs)
+		val, isNull, err := e.evalArg1Quiet(v.Exprs, row)
 		if err != nil {
 			return nil, true, err
 		}
 		if isNull {
 			return nil, true, nil
+		}
+		if isZeroDate(val) {
+			return "0000-00-00 00:00:00", true, nil
 		}
 		t, parseErr := parseDateTimeValue(val)
 		if parseErr != nil {
@@ -489,7 +551,7 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interfac
 		}
 		return t.Format("2006-01-02 15:04:05"), true, nil
 	case "sec_to_time":
-		arg, isNull, err := e.evalArg1Quiet(v.Exprs)
+		arg, isNull, err := e.evalArg1Quiet(v.Exprs, row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -498,7 +560,7 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interfac
 		}
 		return secToTimeValue(arg), true, nil
 	case "time_to_sec":
-		ttsVal, isNull, err := e.evalArg1(v.Exprs, "TIME_TO_SEC")
+		ttsVal, isNull, err := e.evalArg1(v.Exprs, "TIME_TO_SEC", row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -532,7 +594,7 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interfac
 		}
 		return ttsSecs, true, nil
 	case "period_add":
-		paP, paN, hasNull, err := e.evalArgs2(v.Exprs, "PERIOD_ADD")
+		paP, paN, hasNull, err := e.evalArgs2(v.Exprs, "PERIOD_ADD", row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -556,7 +618,7 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interfac
 		paNewM := paTotalM%12 + 1
 		return paNewY*100 + paNewM, true, nil
 	case "period_diff":
-		pdP1, pdP2, hasNull, err := e.evalArgs2(v.Exprs, "PERIOD_DIFF")
+		pdP1, pdP2, hasNull, err := e.evalArgs2(v.Exprs, "PERIOD_DIFF", row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -575,7 +637,7 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interfac
 		}
 		return pdToMonths(toInt64(pdP1)) - pdToMonths(toInt64(pdP2)), true, nil
 	case "maketime":
-		mtH, mtM, mtSec, hasNull, err := e.evalArgs3(v.Exprs, "MAKETIME")
+		mtH, mtM, mtSec, hasNull, err := e.evalArgs3(v.Exprs, "MAKETIME", row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -595,7 +657,7 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interfac
 		}
 		return fmt.Sprintf("%s%02d:%02d:%02d", mtNeg, mtHi, mtMi, mtSi), true, nil
 	case "microsecond":
-		usVal, isNull, err := e.evalArg1(v.Exprs, "MICROSECOND")
+		usVal, isNull, err := e.evalArg1(v.Exprs, "MICROSECOND", row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -613,7 +675,7 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interfac
 		}
 		return int64(0), true, nil
 	case "time_format":
-		tfTime, tfFmt, hasNull, err := e.evalArgs2(v.Exprs, "TIME_FORMAT")
+		tfTime, tfFmt, hasNull, err := e.evalArgs2(v.Exprs, "TIME_FORMAT", row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -654,7 +716,7 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interfac
 		if len(v.Exprs) < 3 {
 			return nil, true, fmt.Errorf("CONVERT_TZ requires 3 arguments")
 		}
-		ctzVal, isNull, err := e.evalArg1Quiet(v.Exprs)
+		ctzVal, isNull, err := e.evalArg1Quiet(v.Exprs, row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -663,7 +725,7 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interfac
 		}
 		return toString(ctzVal), true, nil
 	case "timediff":
-		tdA, tdB, hasNull, err := e.evalArgs2(v.Exprs, "TIMEDIFF")
+		tdA, tdB, hasNull, err := e.evalArgs2(v.Exprs, "TIMEDIFF", row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -686,7 +748,7 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interfac
 		tdS := int(tdDiff.Seconds()) % 60
 		return fmt.Sprintf("%s%02d:%02d:%02d", tdNeg, tdH, tdM, tdS), true, nil
 	case "to_seconds":
-		tsVal, isNull, err := e.evalArg1Quiet(v.Exprs)
+		tsVal, isNull, err := e.evalArg1Quiet(v.Exprs, row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -700,7 +762,7 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interfac
 		tsDays := int64(tsT.Year())*365 + int64(tsT.YearDay()) + int64(tsT.Year())/4 - int64(tsT.Year())/100 + int64(tsT.Year())/400
 		return tsDays*86400 + int64(tsT.Hour())*3600 + int64(tsT.Minute())*60 + int64(tsT.Second()), true, nil
 	case "makedate":
-		mdYear, mdDay, hasNull, err := e.evalArgs2(v.Exprs, "MAKEDATE")
+		mdYear, mdDay, hasNull, err := e.evalArgs2(v.Exprs, "MAKEDATE", row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -714,361 +776,6 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interfac
 		}
 		mdT := time.Date(mdY, 1, mdD, 0, 0, 0, 0, time.UTC)
 		return mdT.Format("2006-01-02"), true, nil
-	default:
-		return nil, false, nil
-	}
-}
-
-// evalDatetimeFuncWithRow dispatches date/time-related functions from evalFuncExprWithRow.
-func evalDatetimeFuncWithRow(e *Executor, name string, v *sqlparser.FuncExpr, row storage.Row, evalArgs func() ([]interface{}, error)) (interface{}, bool, error) {
-	switch name {
-	case "date":
-		args, err := evalArgs()
-		if err != nil {
-			return nil, true, err
-		}
-		if len(args) < 1 || args[0] == nil {
-			return nil, true, nil
-		}
-		if isZeroDate(args[0]) {
-			return "0000-00-00", true, nil
-		}
-		t, err := parseDateTimeValue(args[0])
-		if err != nil {
-			return nil, true, nil
-		}
-		return t.Format("2006-01-02"), true, nil
-	case "year":
-		args, err := evalArgs()
-		if err != nil {
-			return nil, true, err
-		}
-		if len(args) < 1 || args[0] == nil {
-			return nil, true, nil
-		}
-		if isZeroDate(args[0]) {
-			return int64(0), true, nil
-		}
-		t, err := parseDateTimeValue(args[0])
-		if err != nil {
-			return nil, true, nil
-		}
-		return int64(t.Year()), true, nil
-	case "month":
-		args, err := evalArgs()
-		if err != nil {
-			return nil, true, err
-		}
-		if len(args) < 1 || args[0] == nil {
-			return nil, true, nil
-		}
-		if isZeroDate(args[0]) {
-			return int64(0), true, nil
-		}
-		t, err := parseDateTimeValue(args[0])
-		if err != nil {
-			return nil, true, nil
-		}
-		return int64(t.Month()), true, nil
-	case "day", "dayofmonth":
-		args, err := evalArgs()
-		if err != nil {
-			return nil, true, err
-		}
-		if len(args) < 1 || args[0] == nil {
-			return nil, true, nil
-		}
-		if isZeroDate(args[0]) {
-			return int64(0), true, nil
-		}
-		t, err := parseDateTimeValue(args[0])
-		if err != nil {
-			return nil, true, nil
-		}
-		return int64(t.Day()), true, nil
-	case "hour":
-		args, err := evalArgs()
-		if err != nil {
-			return nil, true, err
-		}
-		if len(args) < 1 || args[0] == nil {
-			return nil, true, nil
-		}
-		t, err := parseDateTimeValue(args[0])
-		if err != nil {
-			return nil, true, nil
-		}
-		return int64(t.Hour()), true, nil
-	case "minute":
-		args, err := evalArgs()
-		if err != nil {
-			return nil, true, err
-		}
-		if len(args) < 1 || args[0] == nil {
-			return nil, true, nil
-		}
-		t, err := parseDateTimeValue(args[0])
-		if err != nil {
-			return nil, true, nil
-		}
-		return int64(t.Minute()), true, nil
-	case "second":
-		args, err := evalArgs()
-		if err != nil {
-			return nil, true, err
-		}
-		if len(args) < 1 || args[0] == nil {
-			return nil, true, nil
-		}
-		t, err := parseDateTimeValue(args[0])
-		if err != nil {
-			return nil, true, nil
-		}
-		return int64(t.Second()), true, nil
-	case "dayname":
-		args, err := evalArgs()
-		if err != nil {
-			return nil, true, err
-		}
-		if len(args) < 1 || args[0] == nil {
-			return nil, true, nil
-		}
-		if isZeroDate(args[0]) {
-			return nil, true, nil
-		}
-		t, err := parseDateTimeValue(args[0])
-		if err != nil {
-			return nil, true, nil
-		}
-		return t.Format("Monday"), true, nil
-	case "dayofweek":
-		args, err := evalArgs()
-		if err != nil {
-			return nil, true, err
-		}
-		if len(args) < 1 || args[0] == nil {
-			return nil, true, nil
-		}
-		if isZeroDate(args[0]) {
-			return nil, true, nil
-		}
-		t, err := parseDateTimeValue(args[0])
-		if err != nil {
-			return nil, true, nil
-		}
-		return int64(t.Weekday()) + 1, true, nil
-	case "dayofyear":
-		args, err := evalArgs()
-		if err != nil {
-			return nil, true, err
-		}
-		if len(args) < 1 || args[0] == nil {
-			return nil, true, nil
-		}
-		if isZeroDate(args[0]) {
-			return nil, true, nil
-		}
-		t, err := parseDateTimeValue(args[0])
-		if err != nil {
-			return nil, true, nil
-		}
-		return int64(t.YearDay()), true, nil
-	case "monthname":
-		args, err := evalArgs()
-		if err != nil {
-			return nil, true, err
-		}
-		if len(args) < 1 || args[0] == nil {
-			return nil, true, nil
-		}
-		if isZeroDate(args[0]) {
-			return nil, true, nil
-		}
-		t, err := parseDateTimeValue(args[0])
-		if err != nil {
-			return nil, true, nil
-		}
-		return t.Format("January"), true, nil
-	case "weekday":
-		args, err := evalArgs()
-		if err != nil {
-			return nil, true, err
-		}
-		if len(args) < 1 || args[0] == nil {
-			return nil, true, nil
-		}
-		if isZeroDate(args[0]) {
-			return nil, true, nil
-		}
-		t, err := parseDateTimeValue(args[0])
-		if err != nil {
-			return nil, true, nil
-		}
-		wd := int64(t.Weekday()) - 1
-		if wd < 0 {
-			wd = 6
-		}
-		return wd, true, nil
-	case "time":
-		args, err := evalArgs()
-		if err != nil {
-			return nil, true, err
-		}
-		if len(args) < 1 || args[0] == nil {
-			return nil, true, nil
-		}
-		t, err := parseDateTimeValue(args[0])
-		if err != nil {
-			return nil, true, nil
-		}
-		return t.Format("15:04:05"), true, nil
-	case "from_days":
-		args, err := evalArgs()
-		if err != nil {
-			return nil, true, err
-		}
-		if len(args) < 1 || args[0] == nil {
-			return nil, true, nil
-		}
-		days := int(toInt64(args[0]))
-		if days <= 0 {
-			return "0000-00-00", true, nil
-		}
-		t := time.Date(1, 1, 1, 0, 0, 0, 0, time.UTC).AddDate(0, 0, days-1)
-		return t.Format("2006-01-02"), true, nil
-	case "to_days":
-		args, err := evalArgs()
-		if err != nil {
-			return nil, true, err
-		}
-		if len(args) < 1 || args[0] == nil {
-			return nil, true, nil
-		}
-		if isZeroDate(args[0]) {
-			return nil, true, nil
-		}
-		t, parseErr := parseDateTimeValue(args[0])
-		if parseErr != nil {
-			return nil, true, nil
-		}
-		return mysqlToDays(t), true, nil
-	case "last_day":
-		args, err := evalArgs()
-		if err != nil {
-			return nil, true, err
-		}
-		if len(args) < 1 || args[0] == nil {
-			return nil, true, nil
-		}
-		if isZeroDate(args[0]) {
-			return nil, true, nil
-		}
-		t, parseErr := parseDateTimeValue(args[0])
-		if parseErr != nil {
-			return nil, true, nil
-		}
-		firstOfNextMonth := time.Date(t.Year(), t.Month()+1, 1, 0, 0, 0, 0, time.UTC)
-		lastDay := firstOfNextMonth.AddDate(0, 0, -1)
-		return lastDay.Format("2006-01-02"), true, nil
-	case "quarter":
-		args, err := evalArgs()
-		if err != nil {
-			return nil, true, err
-		}
-		if len(args) < 1 || args[0] == nil {
-			return nil, true, nil
-		}
-		if isZeroDate(args[0]) {
-			return int64(0), true, nil
-		}
-		t, parseErr := parseDateTimeValue(args[0])
-		if parseErr != nil {
-			return nil, true, nil
-		}
-		return int64((t.Month()-1)/3 + 1), true, nil
-	case "week":
-		args, err := evalArgs()
-		if err != nil {
-			return nil, true, err
-		}
-		if len(args) < 1 || args[0] == nil {
-			return nil, true, nil
-		}
-		if isZeroDate(args[0]) {
-			return nil, true, nil
-		}
-		t, parseErr := parseDateTimeValue(args[0])
-		if parseErr != nil {
-			return nil, true, nil
-		}
-		mode := int64(0)
-		if len(args) >= 2 && args[1] != nil {
-			mode = toInt64(args[1])
-		}
-		if mode == 0 {
-			return mysqlWeekMode0(t), true, nil
-		}
-		_, wk := t.ISOWeek()
-		return int64(wk), true, nil
-	case "weekofyear":
-		args, err := evalArgs()
-		if err != nil {
-			return nil, true, err
-		}
-		if len(args) < 1 || args[0] == nil {
-			return nil, true, nil
-		}
-		if isZeroDate(args[0]) {
-			return nil, true, nil
-		}
-		t, parseErr := parseDateTimeValue(args[0])
-		if parseErr != nil {
-			return nil, true, nil
-		}
-		_, wk := t.ISOWeek()
-		return int64(wk), true, nil
-	case "yearweek":
-		args, err := evalArgs()
-		if err != nil {
-			return nil, true, err
-		}
-		if len(args) < 1 || args[0] == nil {
-			return nil, true, nil
-		}
-		if isZeroDate(args[0]) {
-			return nil, true, nil
-		}
-		t, parseErr := parseDateTimeValue(args[0])
-		if parseErr != nil {
-			return nil, true, nil
-		}
-		yr, wk := mysqlYearWeek(t, 0)
-		return int64(yr*100 + wk), true, nil
-	case "timestamp":
-		args, err := evalArgs()
-		if err != nil {
-			return nil, true, err
-		}
-		if len(args) < 1 || args[0] == nil {
-			return nil, true, nil
-		}
-		if isZeroDate(args[0]) {
-			return "0000-00-00 00:00:00", true, nil
-		}
-		t, parseErr := parseDateTimeValue(args[0])
-		if parseErr != nil {
-			return nil, true, nil
-		}
-		return t.Format("2006-01-02 15:04:05"), true, nil
-	case "sec_to_time":
-		args, err := evalArgs()
-		if err != nil {
-			return nil, true, err
-		}
-		if len(args) < 1 || args[0] == nil {
-			return nil, true, nil
-		}
-		return secToTimeValue(args[0]), true, nil
 	default:
 		return nil, false, nil
 	}

--- a/executor/func_math.go
+++ b/executor/func_math.go
@@ -11,15 +11,16 @@ import (
 	"vitess.io/vitess/go/vt/sqlparser"
 )
 
-// evalMathFunc dispatches math-related functions from evalFuncExpr.
+// evalMathFunc dispatches math-related functions.
+// When row is non-nil, expressions are evaluated with row context.
 // Returns (result, handled, error).
-func evalMathFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{}, bool, error) {
+func evalMathFunc(e *Executor, name string, v *sqlparser.FuncExpr, row *storage.Row) (interface{}, bool, error) {
 	switch name {
 	case "rand":
 		if len(v.Exprs) == 0 {
 			return rand.Float64(), true, nil
 		}
-		seedVal, err := e.evalExpr(v.Exprs[0])
+		seedVal, err := e.evalExprMaybeRow(v.Exprs[0], row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -29,7 +30,7 @@ func evalMathFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		r := rand.New(rand.NewSource(toInt64(seedVal)))
 		return r.Float64(), true, nil
 	case "abs":
-		val, isNull, err := e.evalArg1(v.Exprs, "ABS")
+		val, isNull, err := e.evalArg1(v.Exprs, "ABS", row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -50,7 +51,7 @@ func evalMathFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		}
 		return math.Pi, true, nil
 	case "floor":
-		val, isNull, err := e.evalArg1(v.Exprs, "FLOOR")
+		val, isNull, err := e.evalArg1(v.Exprs, "FLOOR", row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -60,7 +61,7 @@ func evalMathFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		f := toFloat(val)
 		return int64(f), true, nil
 	case "ceil", "ceiling":
-		val, isNull, err := e.evalArg1(v.Exprs, "CEIL")
+		val, isNull, err := e.evalArg1(v.Exprs, "CEIL", row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -74,7 +75,7 @@ func evalMathFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		}
 		return n, true, nil
 	case "round":
-		val, isNull, err := e.evalArg1(v.Exprs, "ROUND")
+		val, isNull, err := e.evalArg1(v.Exprs, "ROUND", row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -84,7 +85,7 @@ func evalMathFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		f := toFloat(val)
 		decimals := int64(0)
 		if len(v.Exprs) >= 2 {
-			dv, err := e.evalExpr(v.Exprs[1])
+			dv, err := e.evalExprMaybeRow(v.Exprs[1], row)
 			if err != nil {
 				return nil, true, err
 			}
@@ -112,14 +113,14 @@ func evalMathFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		if len(v.Exprs) < 2 {
 			return nil, true, fmt.Errorf("TRUNCATE requires 2 arguments")
 		}
-		val, isNull, err := e.evalArg1(v.Exprs, "TRUNCATE")
+		val, isNull, err := e.evalArg1(v.Exprs, "TRUNCATE", row)
 		if err != nil {
 			return nil, true, err
 		}
 		if isNull {
 			return nil, true, nil
 		}
-		dv, err := e.evalExpr(v.Exprs[1])
+		dv, err := e.evalExprMaybeRow(v.Exprs[1], row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -159,7 +160,7 @@ func evalMathFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		}
 		return int64(f/factor) * int64(factor), true, nil
 	case "mod":
-		v0, v1, hasNull, err := e.evalArgs2(v.Exprs, "MOD")
+		v0, v1, hasNull, err := e.evalArgs2(v.Exprs, "MOD", row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -172,7 +173,7 @@ func evalMathFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		}
 		return toInt64(v0) % d, true, nil
 	case "sqrt":
-		sqrtVal, isNull, err := e.evalArg1(v.Exprs, "SQRT")
+		sqrtVal, isNull, err := e.evalArg1(v.Exprs, "SQRT", row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -185,7 +186,7 @@ func evalMathFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		}
 		return math.Sqrt(sqrtF), true, nil
 	case "sign":
-		signVal, isNull, err := e.evalArg1(v.Exprs, "SIGN")
+		signVal, isNull, err := e.evalArg1(v.Exprs, "SIGN", row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -200,7 +201,7 @@ func evalMathFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		}
 		return int64(0), true, nil
 	case "ln":
-		lnVal, isNull, err := e.evalArg1(v.Exprs, "LN")
+		lnVal, isNull, err := e.evalArg1(v.Exprs, "LN", row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -214,7 +215,7 @@ func evalMathFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		return math.Log(lnF), true, nil
 	case "log":
 		if len(v.Exprs) == 1 {
-			logVal, err := e.evalExpr(v.Exprs[0])
+			logVal, err := e.evalExprMaybeRow(v.Exprs[0], row)
 			if err != nil {
 				return nil, true, err
 			}
@@ -227,11 +228,11 @@ func evalMathFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 			}
 			return math.Log(logF), true, nil
 		} else if len(v.Exprs) == 2 {
-			logBase, err := e.evalExpr(v.Exprs[0])
+			logBase, err := e.evalExprMaybeRow(v.Exprs[0], row)
 			if err != nil {
 				return nil, true, err
 			}
-			logVal, err := e.evalExpr(v.Exprs[1])
+			logVal, err := e.evalExprMaybeRow(v.Exprs[1], row)
 			if err != nil {
 				return nil, true, err
 			}
@@ -247,7 +248,7 @@ func evalMathFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		}
 		return nil, true, fmt.Errorf("LOG requires 1 or 2 arguments")
 	case "log2":
-		log2Val, isNull, err := e.evalArg1(v.Exprs, "LOG2")
+		log2Val, isNull, err := e.evalArg1(v.Exprs, "LOG2", row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -260,7 +261,7 @@ func evalMathFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		}
 		return math.Log2(log2F), true, nil
 	case "log10":
-		log10Val, isNull, err := e.evalArg1(v.Exprs, "LOG10")
+		log10Val, isNull, err := e.evalArg1(v.Exprs, "LOG10", row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -273,7 +274,7 @@ func evalMathFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		}
 		return math.Log10(log10F), true, nil
 	case "exp":
-		expVal, isNull, err := e.evalArg1(v.Exprs, "EXP")
+		expVal, isNull, err := e.evalArg1(v.Exprs, "EXP", row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -282,7 +283,7 @@ func evalMathFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		}
 		return math.Exp(toFloat(expVal)), true, nil
 	case "pow", "power":
-		powBase, powExp, hasNull, err := e.evalArgs2(v.Exprs, "POW")
+		powBase, powExp, hasNull, err := e.evalArgs2(v.Exprs, "POW", row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -291,7 +292,7 @@ func evalMathFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		}
 		return math.Pow(toFloat(powBase), toFloat(powExp)), true, nil
 	case "crc32":
-		crcVal, isNull, err := e.evalArg1(v.Exprs, "CRC32")
+		crcVal, isNull, err := e.evalArg1(v.Exprs, "CRC32", row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -312,7 +313,7 @@ func evalMathFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		}
 		return int64(crcResult ^ 0xFFFFFFFF), true, nil
 	case "degrees":
-		degVal, isNull, err := e.evalArg1Quiet(v.Exprs)
+		degVal, isNull, err := e.evalArg1Quiet(v.Exprs, row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -321,7 +322,7 @@ func evalMathFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		}
 		return toFloat(degVal) * 180 / math.Pi, true, nil
 	case "radians":
-		radVal, isNull, err := e.evalArg1Quiet(v.Exprs)
+		radVal, isNull, err := e.evalArg1Quiet(v.Exprs, row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -330,7 +331,7 @@ func evalMathFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		}
 		return toFloat(radVal) * math.Pi / 180, true, nil
 	case "acos":
-		acosVal, isNull, err := e.evalArg1(v.Exprs, "ACOS")
+		acosVal, isNull, err := e.evalArg1(v.Exprs, "ACOS", row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -343,7 +344,7 @@ func evalMathFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		}
 		return math.Acos(acosF), true, nil
 	case "asin":
-		asinVal, isNull, err := e.evalArg1(v.Exprs, "ASIN")
+		asinVal, isNull, err := e.evalArg1(v.Exprs, "ASIN", row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -356,7 +357,7 @@ func evalMathFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		}
 		return math.Asin(asinF), true, nil
 	case "atan", "atan2":
-		atanVal, isNull, err := e.evalArg1Quiet(v.Exprs)
+		atanVal, isNull, err := e.evalArg1Quiet(v.Exprs, row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -364,7 +365,7 @@ func evalMathFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 			return nil, true, nil
 		}
 		if len(v.Exprs) >= 2 {
-			atanVal2, err := e.evalExpr(v.Exprs[1])
+			atanVal2, err := e.evalExprMaybeRow(v.Exprs[1], row)
 			if err != nil {
 				return nil, true, err
 			}
@@ -375,7 +376,7 @@ func evalMathFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		}
 		return math.Atan(toFloat(atanVal)), true, nil
 	case "sin":
-		sinVal, isNull, err := e.evalArg1Quiet(v.Exprs)
+		sinVal, isNull, err := e.evalArg1Quiet(v.Exprs, row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -384,7 +385,7 @@ func evalMathFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		}
 		return math.Sin(toFloat(sinVal)), true, nil
 	case "cos":
-		cosVal, isNull, err := e.evalArg1Quiet(v.Exprs)
+		cosVal, isNull, err := e.evalArg1Quiet(v.Exprs, row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -393,7 +394,7 @@ func evalMathFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		}
 		return math.Cos(toFloat(cosVal)), true, nil
 	case "tan":
-		tanVal, isNull, err := e.evalArg1Quiet(v.Exprs)
+		tanVal, isNull, err := e.evalArg1Quiet(v.Exprs, row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -402,7 +403,7 @@ func evalMathFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		}
 		return math.Tan(toFloat(tanVal)), true, nil
 	case "cot":
-		cotVal, isNull, err := e.evalArg1Quiet(v.Exprs)
+		cotVal, isNull, err := e.evalArg1Quiet(v.Exprs, row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -416,7 +417,7 @@ func evalMathFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		}
 		return math.Cos(cotF) / sinV, true, nil
 	case "bit_count":
-		bcVal, isNull, err := e.evalArg1(v.Exprs, "BIT_COUNT")
+		bcVal, isNull, err := e.evalArg1(v.Exprs, "BIT_COUNT", row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -434,15 +435,15 @@ func evalMathFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		if len(v.Exprs) < 3 {
 			return nil, true, nil
 		}
-		val, err := e.evalExpr(v.Exprs[0])
+		val, err := e.evalExprMaybeRow(v.Exprs[0], row)
 		if err != nil {
 			return nil, true, err
 		}
-		fromBaseVal, err := e.evalExpr(v.Exprs[1])
+		fromBaseVal, err := e.evalExprMaybeRow(v.Exprs[1], row)
 		if err != nil {
 			return nil, true, err
 		}
-		toBaseVal, err := e.evalExpr(v.Exprs[2])
+		toBaseVal, err := e.evalExprMaybeRow(v.Exprs[2], row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -452,87 +453,6 @@ func evalMathFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		s := toString(val)
 		fromBase := int(toInt64(fromBaseVal))
 		toBase := int(toInt64(toBaseVal))
-		n, parseErr := strconv.ParseInt(s, fromBase, 64)
-		if parseErr != nil {
-			return nil, true, nil
-		}
-		return strings.ToUpper(strconv.FormatInt(n, toBase)), true, nil
-	case "bin":
-		val, isNull, err := e.evalArg1Quiet(v.Exprs)
-		if err != nil {
-			return nil, true, err
-		}
-		if isNull {
-			return nil, true, nil
-		}
-		n := toInt64(val)
-		return fmt.Sprintf("%b", n), true, nil
-	default:
-		return nil, false, nil
-	}
-}
-
-// evalMathFuncWithRow dispatches math-related functions from evalFuncExprWithRow.
-func evalMathFuncWithRow(e *Executor, name string, v *sqlparser.FuncExpr, row storage.Row, evalArgs func() ([]interface{}, error)) (interface{}, bool, error) {
-	switch name {
-	case "rand":
-		if len(v.Exprs) == 0 {
-			return rand.Float64(), true, nil
-		}
-		args, err := evalArgs()
-		if err != nil {
-			return nil, true, err
-		}
-		if len(args) < 1 || args[0] == nil {
-			return rand.Float64(), true, nil
-		}
-		r := rand.New(rand.NewSource(toInt64(args[0])))
-		return r.Float64(), true, nil
-	case "abs":
-		args, err := evalArgs()
-		if err != nil {
-			return nil, true, err
-		}
-		if len(args) < 1 || args[0] == nil {
-			return nil, true, nil
-		}
-		f := toFloat(args[0])
-		if f < 0 {
-			f = -f
-		}
-		if f == float64(int64(f)) {
-			return int64(f), true, nil
-		}
-		return f, true, nil
-	case "pi":
-		if len(v.Exprs) != 0 {
-			return nil, true, mysqlError(1582, "42000", "Incorrect parameter count in the call to native function 'pi'")
-		}
-		return math.Pi, true, nil
-	case "mod":
-		args, err := evalArgs()
-		if err != nil {
-			return nil, true, err
-		}
-		if len(args) < 2 || args[0] == nil || args[1] == nil {
-			return nil, true, nil
-		}
-		d := toInt64(args[1])
-		if d == 0 {
-			return nil, true, nil
-		}
-		return toInt64(args[0]) % d, true, nil
-	case "conv":
-		args, err := evalArgs()
-		if err != nil {
-			return nil, true, err
-		}
-		if len(args) < 3 || args[0] == nil {
-			return nil, true, nil
-		}
-		s := toString(args[0])
-		fromBase := int(toInt64(args[1]))
-		toBase := int(toInt64(args[2]))
 		if fromBase < 2 || fromBase > 36 || toBase < 2 || toBase > 36 {
 			return nil, true, nil
 		}
@@ -542,109 +462,18 @@ func evalMathFuncWithRow(e *Executor, name string, v *sqlparser.FuncExpr, row st
 		}
 		return strings.ToUpper(strconv.FormatInt(n, toBase)), true, nil
 	case "bin":
-		args, err := evalArgs()
+		val, isNull, err := e.evalArg1Quiet(v.Exprs, row)
 		if err != nil {
 			return nil, true, err
 		}
-		if len(args) < 1 || args[0] == nil {
+		if isNull {
 			return nil, true, nil
 		}
-		n := toInt64(args[0])
+		n := toInt64(val)
 		if n < 0 {
 			return fmt.Sprintf("%b", uint64(n)), true, nil
 		}
 		return fmt.Sprintf("%b", n), true, nil
-	case "truncate":
-		args, err := evalArgs()
-		if err != nil {
-			return nil, true, err
-		}
-		if len(args) < 2 || args[0] == nil {
-			return nil, true, nil
-		}
-		f := toFloat(args[0])
-		decimals := toInt64(args[1])
-		if decimals == 0 {
-			if f >= 0 {
-				return int64(f), true, nil
-			}
-			return -int64(-f), true, nil
-		}
-		if decimals > 0 {
-			factor := 1.0
-			for j := int64(0); j < decimals; j++ {
-				factor *= 10
-			}
-			outScale := int(decimals)
-			if s, ok := args[0].(string); ok {
-				if dot := strings.IndexByte(s, '.'); dot >= 0 {
-					inScale := len(s) - dot - 1
-					if inScale > outScale {
-						outScale = inScale
-					}
-				}
-			}
-			if f >= 0 {
-				trunc := float64(int64(f*factor)) / factor
-				return fmt.Sprintf("%.*f", outScale, trunc), true, nil
-			}
-			trunc := -float64(int64(-f*factor)) / factor
-			return fmt.Sprintf("%.*f", outScale, trunc), true, nil
-		}
-		factor := 1.0
-		for j := int64(0); j < -decimals; j++ {
-			factor *= 10
-		}
-		return int64(f/factor) * int64(factor), true, nil
-	case "round":
-		args, err := evalArgs()
-		if err != nil {
-			return nil, true, err
-		}
-		if len(args) < 1 || args[0] == nil {
-			return nil, true, nil
-		}
-		f := toFloat(args[0])
-		decimals := int64(0)
-		if len(args) >= 2 {
-			decimals = toInt64(args[1])
-		}
-		if decimals == 0 {
-			return int64(f + 0.5), true, nil
-		}
-		factor := 1.0
-		for j := int64(0); j < decimals; j++ {
-			factor *= 10
-		}
-		rounded := float64(int64(f*factor+0.5)) / factor
-		outScale := int(decimals)
-		if s, ok := args[0].(string); ok {
-			if dot := strings.IndexByte(s, '.'); dot >= 0 {
-				inScale := len(s) - dot - 1
-				if inScale > outScale {
-					outScale = inScale
-				}
-			}
-		}
-		return fmt.Sprintf("%.*f", outScale, rounded), true, nil
-	case "bit_count":
-		args, err := evalArgs()
-		if err != nil {
-			return nil, true, err
-		}
-		if len(args) < 1 {
-			return nil, true, fmt.Errorf("BIT_COUNT requires 1 argument")
-		}
-		if args[0] == nil {
-			return nil, true, nil
-		}
-		bcU := uint64(toInt64(args[0]))
-		bcCount := int64(0)
-		for bcU != 0 {
-			bcCount += int64(bcU & 1)
-			bcU >>= 1
-		}
-		return bcCount, true, nil
 	default:
 		return nil, false, nil
 	}

--- a/executor/func_misc.go
+++ b/executor/func_misc.go
@@ -14,13 +14,14 @@ import (
 	"vitess.io/vitess/go/vt/sqlparser"
 )
 
-// evalMiscFunc dispatches miscellaneous functions from evalFuncExpr.
+// evalMiscFunc dispatches miscellaneous functions.
+// When row is non-nil, expressions are evaluated with row context.
 // Returns (result, handled, error).
-func evalMiscFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{}, bool, error) {
+func evalMiscFunc(e *Executor, name string, v *sqlparser.FuncExpr, row *storage.Row) (interface{}, bool, error) {
 	switch name {
 	case "last_insert_id":
 		if len(v.Exprs) > 0 {
-			val, err := e.evalExpr(v.Exprs[0])
+			val, err := e.evalExprMaybeRow(v.Exprs[0], row)
 			if err != nil {
 				return nil, true, err
 			}
@@ -36,18 +37,18 @@ func evalMiscFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		if len(v.Exprs) < 2 {
 			return nil, true, fmt.Errorf("IFNULL requires 2 arguments")
 		}
-		val, err := e.evalExpr(v.Exprs[0])
+		val, err := e.evalExprMaybeRow(v.Exprs[0], row)
 		if err != nil {
 			return nil, true, err
 		}
 		if val != nil {
 			return val, true, nil
 		}
-		r, err := e.evalExpr(v.Exprs[1])
+		r, err := e.evalExprMaybeRow(v.Exprs[1], row)
 		return r, true, err
 	case "coalesce":
 		for _, argExpr := range v.Exprs {
-			val, err := e.evalExpr(argExpr)
+			val, err := e.evalExprMaybeRow(argExpr, row)
 			if err != nil {
 				return nil, true, err
 			}
@@ -60,18 +61,18 @@ func evalMiscFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		if len(v.Exprs) < 3 {
 			return nil, true, fmt.Errorf("IF requires 3 arguments")
 		}
-		cond, err := e.evalExpr(v.Exprs[0])
+		cond, err := e.evalExprMaybeRow(v.Exprs[0], row)
 		if err != nil {
 			return nil, true, err
 		}
 		if isTruthy(cond) {
-			r, err := e.evalExpr(v.Exprs[1])
+			r, err := e.evalExprMaybeRow(v.Exprs[1], row)
 			return r, true, err
 		}
-		r, err := e.evalExpr(v.Exprs[2])
+		r, err := e.evalExprMaybeRow(v.Exprs[2], row)
 		return r, true, err
 	case "isnull":
-		val, isNull, err := e.evalArg1(v.Exprs, "ISNULL")
+		val, isNull, err := e.evalArg1(v.Exprs, "ISNULL", row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -84,11 +85,11 @@ func evalMiscFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		if len(v.Exprs) < 2 {
 			return nil, true, fmt.Errorf("NULLIF requires 2 arguments")
 		}
-		v0, err := e.evalExpr(v.Exprs[0])
+		v0, err := e.evalExprMaybeRow(v.Exprs[0], row)
 		if err != nil {
 			return nil, true, err
 		}
-		v1, err := e.evalExpr(v.Exprs[1])
+		v1, err := e.evalExprMaybeRow(v.Exprs[1], row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -98,7 +99,7 @@ func evalMiscFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		return v0, true, nil
 	case "cast", "convert":
 		if len(v.Exprs) >= 1 {
-			r, err := e.evalExpr(v.Exprs[0])
+			r, err := e.evalExprMaybeRow(v.Exprs[0], row)
 			return r, true, err
 		}
 		return nil, true, nil
@@ -109,20 +110,22 @@ func evalMiscFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		if cue, ok := v.Exprs[0].(*sqlparser.ConvertUsingExpr); ok {
 			return strings.ToLower(cue.Type), true, nil
 		}
-		val, err := e.evalExpr(v.Exprs[0])
+		val, err := e.evalExprMaybeRow(v.Exprs[0], row)
 		if err != nil {
 			return nil, true, err
 		}
 		if val == nil {
 			return "binary", true, nil
 		}
-		colStr := ""
 		if colName, ok := v.Exprs[0].(*sqlparser.ColName); ok {
-			colStr = colName.Name.String()
 			cs := e.getColumnCharset(colName)
 			if cs != "" {
 				return cs, true, nil
 			}
+		}
+		colStr := ""
+		if colName, ok := v.Exprs[0].(*sqlparser.ColName); ok {
+			colStr = colName.Name.String()
 		}
 		if colStr != "" {
 			if db, err2 := e.Catalog.GetDatabase(e.CurrentDB); err2 == nil {
@@ -160,7 +163,7 @@ func evalMiscFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 				return cs + "_general_ci", true, nil
 			}
 		}
-		val, err := e.evalExpr(v.Exprs[0])
+		val, err := e.evalExprMaybeRow(v.Exprs[0], row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -192,7 +195,7 @@ func evalMiscFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		var result interface{}
 		allNull := true
 		for _, argExpr := range v.Exprs {
-			val, err := e.evalExpr(argExpr)
+			val, err := e.evalExprMaybeRow(argExpr, row)
 			if err != nil {
 				return nil, true, err
 			}
@@ -220,7 +223,7 @@ func evalMiscFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		var result interface{}
 		allNull := true
 		for _, argExpr := range v.Exprs {
-			val, err := e.evalExpr(argExpr)
+			val, err := e.evalExprMaybeRow(argExpr, row)
 			if err != nil {
 				return nil, true, err
 			}
@@ -251,7 +254,7 @@ func evalMiscFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		if len(v.Exprs) < 2 {
 			return int64(-1), true, nil
 		}
-		ivN, err := e.evalExpr(v.Exprs[0])
+		ivN, err := e.evalExprMaybeRow(v.Exprs[0], row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -261,7 +264,7 @@ func evalMiscFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		ivNF := toFloat(ivN)
 		ivResult := int64(0)
 		for ivi := 1; ivi < len(v.Exprs); ivi++ {
-			ivVal, err := e.evalExpr(v.Exprs[ivi])
+			ivVal, err := e.evalExprMaybeRow(v.Exprs[ivi], row)
 			if err != nil {
 				return nil, true, err
 			}
@@ -277,7 +280,7 @@ func evalMiscFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		return ivResult, true, nil
 	case "sleep":
 		if len(v.Exprs) > 0 {
-			dur, err := e.evalExpr(v.Exprs[0])
+			dur, err := e.evalExprMaybeRow(v.Exprs[0], row)
 			if err != nil {
 				return nil, true, err
 			}
@@ -290,7 +293,7 @@ func evalMiscFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 	case "user", "session_user", "system_user":
 		return "root@localhost", true, nil
 	case "regexp_like":
-		rlVal, rlPat, hasNull, err := e.evalArgs2(v.Exprs, "REGEXP_LIKE")
+		rlVal, rlPat, hasNull, err := e.evalArgs2(v.Exprs, "REGEXP_LIKE", row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -299,7 +302,7 @@ func evalMiscFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		}
 		rlFlags := ""
 		if len(v.Exprs) >= 3 {
-			rlFv, err := e.evalExpr(v.Exprs[2])
+			rlFv, err := e.evalExprMaybeRow(v.Exprs[2], row)
 			if err != nil {
 				return nil, true, err
 			}
@@ -320,7 +323,7 @@ func evalMiscFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		}
 		return int64(0), true, nil
 	case "is_ipv4":
-		ipVal, isNull, err := e.evalArg1(v.Exprs, "IS_IPV4")
+		ipVal, isNull, err := e.evalArg1(v.Exprs, "IS_IPV4", row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -347,7 +350,7 @@ func evalMiscFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 	case "current_role":
 		return "NONE", true, nil
 	case "inet_ntoa":
-		inVal, isNull, err := e.evalArg1(v.Exprs, "INET_NTOA")
+		inVal, isNull, err := e.evalArg1(v.Exprs, "INET_NTOA", row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -357,7 +360,7 @@ func evalMiscFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		inN := uint32(toInt64(inVal))
 		return fmt.Sprintf("%d.%d.%d.%d", (inN>>24)&0xFF, (inN>>16)&0xFF, (inN>>8)&0xFF, inN&0xFF), true, nil
 	case "inet_aton":
-		iaVal, isNull, err := e.evalArg1(v.Exprs, "INET_ATON")
+		iaVal, isNull, err := e.evalArg1(v.Exprs, "INET_ATON", row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -380,7 +383,7 @@ func evalMiscFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 	case "coercibility":
 		return int64(4), true, nil
 	case "st_astext", "st_aswkt":
-		stVal, isNull, err := e.evalArg1Quiet(v.Exprs)
+		stVal, isNull, err := e.evalArg1Quiet(v.Exprs, row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -389,7 +392,7 @@ func evalMiscFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		}
 		return toString(stVal), true, nil
 	case "st_equals":
-		steA, steB, hasNull, err := e.evalArgs2(v.Exprs, "ST_EQUALS")
+		steA, steB, hasNull, err := e.evalArgs2(v.Exprs, "ST_EQUALS", row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -401,7 +404,7 @@ func evalMiscFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		}
 		return int64(0), true, nil
 	case "mbrintersects", "st_intersects", "mbrwithin", "st_within", "mbrcontains", "st_contains":
-		g1Val, g2Val, hasNull, err := e.evalArgs2(v.Exprs, strings.ToUpper(name))
+		g1Val, g2Val, hasNull, err := e.evalArgs2(v.Exprs, strings.ToUpper(name), row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -445,7 +448,7 @@ func evalMiscFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 			uint16(uuidB[8])<<8|uint16(uuidB[9]),
 			uint64(uuidB[10])<<40|uint64(uuidB[11])<<32|uint64(uuidB[12])<<24|uint64(uuidB[13])<<16|uint64(uuidB[14])<<8|uint64(uuidB[15])), true, nil
 	case "is_ipv6":
-		ip6Val, isNull, err := e.evalArg1(v.Exprs, "IS_IPV6")
+		ip6Val, isNull, err := e.evalArg1(v.Exprs, "IS_IPV6", row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -458,7 +461,7 @@ func evalMiscFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		}
 		return int64(0), true, nil
 	case "is_ipv4_mapped":
-		imVal, isNull, err := e.evalArg1(v.Exprs, "IS_IPV4_MAPPED")
+		imVal, isNull, err := e.evalArg1(v.Exprs, "IS_IPV4_MAPPED", row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -480,7 +483,7 @@ func evalMiscFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		}
 		return int64(0), true, nil
 	case "is_ipv4_compat":
-		icVal, isNull, err := e.evalArg1(v.Exprs, "IS_IPV4_COMPAT")
+		icVal, isNull, err := e.evalArg1(v.Exprs, "IS_IPV4_COMPAT", row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -502,7 +505,7 @@ func evalMiscFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		}
 		return int64(0), true, nil
 	case "sha", "sha1":
-		shaVal, isNull, err := e.evalArg1(v.Exprs, "SHA")
+		shaVal, isNull, err := e.evalArg1(v.Exprs, "SHA", row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -515,7 +518,7 @@ func evalMiscFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 	case "master_pos_wait":
 		return int64(0), true, nil
 	case "statement_digest":
-		sdVal, isNull, err := e.evalArg1Quiet(v.Exprs)
+		sdVal, isNull, err := e.evalArg1Quiet(v.Exprs, row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -528,12 +531,12 @@ func evalMiscFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		if len(v.Exprs) < 2 {
 			return nil, true, nil
 		}
-		r, err := e.evalExpr(v.Exprs[1])
+		r, err := e.evalExprMaybeRow(v.Exprs[1], row)
 		return r, true, err
 	case "aes_encrypt", "aes_decrypt":
 		return nil, true, nil
 	case "uuid_to_bin":
-		utbVal, isNull, err := e.evalArg1Quiet(v.Exprs)
+		utbVal, isNull, err := e.evalArg1Quiet(v.Exprs, row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -542,7 +545,7 @@ func evalMiscFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		}
 		return strings.ReplaceAll(toString(utbVal), "-", ""), true, nil
 	case "bin_to_uuid":
-		btuVal, isNull, err := e.evalArg1Quiet(v.Exprs)
+		btuVal, isNull, err := e.evalArg1Quiet(v.Exprs, row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -551,7 +554,7 @@ func evalMiscFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		}
 		return toString(btuVal), true, nil
 	case "to_base64":
-		tb64Val, isNull, err := e.evalArg1Quiet(v.Exprs)
+		tb64Val, isNull, err := e.evalArg1Quiet(v.Exprs, row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -585,7 +588,7 @@ func evalMiscFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		}
 		return string(tb64Buf), true, nil
 	case "from_base64":
-		fb64Val, isNull, err := e.evalArg1Quiet(v.Exprs)
+		fb64Val, isNull, err := e.evalArg1Quiet(v.Exprs, row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -594,7 +597,7 @@ func evalMiscFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		}
 		return toString(fb64Val), true, nil // simplified stub
 	case "random_bytes":
-		rbVal, isNull, err := e.evalArg1Quiet(v.Exprs)
+		rbVal, isNull, err := e.evalArg1Quiet(v.Exprs, row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -619,7 +622,7 @@ func evalMiscFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 	case "uuid_short":
 		return int64(rand.Int63()), true, nil
 	case "is_uuid":
-		iuVal, isNull, err := e.evalArg1Quiet(v.Exprs)
+		iuVal, isNull, err := e.evalArg1Quiet(v.Exprs, row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -636,112 +639,6 @@ func evalMiscFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{},
 		return nil, true, nil
 	case "inet6_ntoa":
 		return nil, true, nil
-	default:
-		return nil, false, nil
-	}
-}
-
-// evalMiscFuncWithRow dispatches miscellaneous functions from evalFuncExprWithRow.
-func evalMiscFuncWithRow(e *Executor, name string, v *sqlparser.FuncExpr, row storage.Row, evalArgs func() ([]interface{}, error)) (interface{}, bool, error) {
-	switch name {
-	case "last_insert_id":
-		if len(v.Exprs) > 0 {
-			args, err := evalArgs()
-			if err != nil {
-				return nil, true, err
-			}
-			e.lastInsertID = toInt64(args[0])
-			return e.lastInsertID, true, nil
-		}
-		return e.lastInsertID, true, nil
-	case "if":
-		if len(v.Exprs) < 3 {
-			return nil, true, fmt.Errorf("IF requires 3 arguments")
-		}
-		cond, err := e.evalRowExpr(v.Exprs[0], row)
-		if err != nil {
-			return nil, true, err
-		}
-		if isTruthy(cond) {
-			r, err := e.evalRowExpr(v.Exprs[1], row)
-			return r, true, err
-		}
-		r, err := e.evalRowExpr(v.Exprs[2], row)
-		return r, true, err
-	case "ifnull", "nvl":
-		if len(v.Exprs) < 2 {
-			return nil, true, nil
-		}
-		val, err := e.evalRowExpr(v.Exprs[0], row)
-		if err != nil {
-			return nil, true, err
-		}
-		if val != nil {
-			return val, true, nil
-		}
-		r, err := e.evalRowExpr(v.Exprs[1], row)
-		return r, true, err
-	case "coalesce":
-		for _, argExpr := range v.Exprs {
-			val, err := e.evalRowExpr(argExpr, row)
-			if err != nil {
-				return nil, true, err
-			}
-			if val != nil {
-				return val, true, nil
-			}
-		}
-		return nil, true, nil
-	case "isnull":
-		args, err := evalArgs()
-		if err != nil {
-			return nil, true, err
-		}
-		if len(args) < 1 || args[0] == nil {
-			return int64(1), true, nil
-		}
-		return int64(0), true, nil
-	case "charset":
-		if len(v.Exprs) < 1 {
-			return nil, true, nil
-		}
-		if cue, ok := v.Exprs[0].(*sqlparser.ConvertUsingExpr); ok {
-			return strings.ToLower(cue.Type), true, nil
-		}
-		val, err := e.evalRowExpr(v.Exprs[0], row)
-		if err != nil {
-			return nil, true, err
-		}
-		if val == nil {
-			return "binary", true, nil
-		}
-		if colName, ok := v.Exprs[0].(*sqlparser.ColName); ok {
-			cs := e.getColumnCharset(colName)
-			if cs != "" {
-				return cs, true, nil
-			}
-		}
-		colStr := ""
-		if cn, ok := v.Exprs[0].(*sqlparser.ColName); ok {
-			colStr = cn.Name.String()
-		}
-		if colStr != "" {
-			if db, err2 := e.Catalog.GetDatabase(e.CurrentDB); err2 == nil {
-				for _, tblDef := range db.Tables {
-					if tblDef.Charset != "" {
-						for _, col := range tblDef.Columns {
-							if strings.EqualFold(col.Name, colStr) {
-								return tblDef.Charset, true, nil
-							}
-						}
-					}
-				}
-			}
-		}
-		if cs, ok := e.getSysVar("character_set_connection"); ok && cs != "" {
-			return strings.ToLower(cs), true, nil
-		}
-		return "utf8", true, nil
 	default:
 		return nil, false, nil
 	}

--- a/executor/func_string.go
+++ b/executor/func_string.go
@@ -15,14 +15,15 @@ import (
 	"vitess.io/vitess/go/vt/sqlparser"
 )
 
-// evalStringFunc dispatches string-related functions from evalFuncExpr.
+// evalStringFunc dispatches string-related functions.
+// When row is non-nil, expressions are evaluated with row context.
 // Returns (result, handled, error). If handled is false, the caller should try other dispatchers.
-func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{}, bool, error) {
+func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr, row *storage.Row) (interface{}, bool, error) {
 	switch name {
 	case "concat":
 		var sb strings.Builder
 		for _, argExpr := range v.Exprs {
-			val, err := e.evalExpr(argExpr)
+			val, err := e.evalExprMaybeRow(argExpr, row)
 			if err != nil {
 				return nil, true, err
 			}
@@ -33,7 +34,7 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{
 		}
 		return sb.String(), true, nil
 	case "md5":
-		val, isNull, err := e.evalArg1(v.Exprs, "MD5")
+		val, isNull, err := e.evalArg1(v.Exprs, "MD5", row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -46,7 +47,7 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{
 		if len(v.Exprs) < 1 {
 			return nil, true, nil
 		}
-		sepVal, err := e.evalExpr(v.Exprs[0])
+		sepVal, err := e.evalExprMaybeRow(v.Exprs[0], row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -56,7 +57,7 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{
 		sep := toString(sepVal)
 		var parts []string
 		for _, argExpr := range v.Exprs[1:] {
-			val, err := e.evalExpr(argExpr)
+			val, err := e.evalExprMaybeRow(argExpr, row)
 			if err != nil {
 				return nil, true, err
 			}
@@ -67,7 +68,7 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{
 		}
 		return strings.Join(parts, sep), true, nil
 	case "upper", "ucase":
-		val, isNull, err := e.evalArg1(v.Exprs, "UPPER")
+		val, isNull, err := e.evalArg1(v.Exprs, "UPPER", row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -75,27 +76,25 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{
 			return nil, true, nil
 		}
 		s := toString(val)
-		if strings.ContainsRune(s, '\x00') {
-			return s, true, nil
-		}
-		if e.isBinaryExpr(v.Exprs[0]) {
+		if strings.ContainsRune(s, '\x00') || e.isBinaryExpr(v.Exprs[0]) {
 			return s, true, nil
 		}
 		return strings.ToUpper(s), true, nil
 	case "lower", "lcase":
-		val, isNull, err := e.evalArg1(v.Exprs, "LOWER")
+		val, isNull, err := e.evalArg1(v.Exprs, "LOWER", row)
 		if err != nil {
 			return nil, true, err
 		}
 		if isNull {
 			return nil, true, nil
 		}
-		if e.isBinaryExpr(v.Exprs[0]) {
-			return toString(val), true, nil
+		s := toString(val)
+		if strings.ContainsRune(s, '\x00') || e.isBinaryExpr(v.Exprs[0]) {
+			return s, true, nil
 		}
-		return strings.ToLower(toString(val)), true, nil
+		return strings.ToLower(s), true, nil
 	case "length", "octet_length":
-		val, isNull, err := e.evalArg1(v.Exprs, "LENGTH")
+		val, isNull, err := e.evalArg1(v.Exprs, "LENGTH", row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -105,13 +104,13 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{
 		s := toString(val)
 		if colName, ok := v.Exprs[0].(*sqlparser.ColName); ok {
 			cs := e.getColumnCharset(colName)
-			if byteLen, err := charsetByteLength(s, cs); err == nil {
+			if byteLen, err2 := charsetByteLength(s, cs); err2 == nil {
 				return byteLen, true, nil
 			}
 		}
 		return int64(len(s)), true, nil
 	case "char_length", "character_length":
-		val, isNull, err := e.evalArg1(v.Exprs, "CHAR_LENGTH")
+		val, isNull, err := e.evalArg1(v.Exprs, "CHAR_LENGTH", row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -120,7 +119,7 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{
 		}
 		return int64(mysqlCharLen(toString(val))), true, nil
 	case "ascii", "ord":
-		val, isNull, err := e.evalArg1(v.Exprs, "ASCII")
+		val, isNull, err := e.evalArg1(v.Exprs, "ASCII", row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -133,7 +132,7 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{
 		}
 		return int64(s[0]), true, nil
 	case "load_file":
-		val, isNull, err := e.evalArg1Quiet(v.Exprs)
+		val, isNull, err := e.evalArg1Quiet(v.Exprs, row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -144,21 +143,21 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{
 		if !filepath.IsAbs(filePath) && len(e.SearchPaths) > 0 {
 			for _, sp := range e.SearchPaths {
 				candidate := filepath.Join(sp, filePath)
-				if _, err := os.Stat(candidate); err == nil {
+				if _, statErr := os.Stat(candidate); statErr == nil {
 					filePath = candidate
 					break
 				}
 			}
 		}
-		data, err := os.ReadFile(filePath)
-		if err != nil {
+		data, readErr := os.ReadFile(filePath)
+		if readErr != nil {
 			return nil, true, nil // MySQL returns NULL if file cannot be read
 		}
 		return string(data), true, nil
 	case "char":
 		var sb strings.Builder
 		for _, argExpr := range v.Exprs {
-			val, err := e.evalExpr(argExpr)
+			val, err := e.evalExprMaybeRow(argExpr, row)
 			if err != nil {
 				return nil, true, err
 			}
@@ -175,7 +174,7 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{
 		if len(v.Exprs) < 2 {
 			return nil, true, fmt.Errorf("SUBSTRING requires at least 2 arguments")
 		}
-		strVal, err := e.evalExpr(v.Exprs[0])
+		strVal, err := e.evalExprMaybeRow(v.Exprs[0], row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -183,7 +182,7 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{
 			return nil, true, nil
 		}
 		s := []rune(toString(strVal))
-		posVal, err := e.evalExpr(v.Exprs[1])
+		posVal, err := e.evalExprMaybeRow(v.Exprs[1], row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -203,7 +202,7 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{
 			return "", true, nil
 		}
 		if len(v.Exprs) >= 3 {
-			lenVal, err := e.evalExpr(v.Exprs[2])
+			lenVal, err := e.evalExprMaybeRow(v.Exprs[2], row)
 			if err != nil {
 				return nil, true, err
 			}
@@ -219,7 +218,7 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{
 		}
 		return string(s[pos:]), true, nil
 	case "trim":
-		val, isNull, err := e.evalArg1(v.Exprs, "TRIM")
+		val, isNull, err := e.evalArg1(v.Exprs, "TRIM", row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -228,7 +227,7 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{
 		}
 		return strings.TrimSpace(toString(val)), true, nil
 	case "ltrim":
-		val, isNull, err := e.evalArg1(v.Exprs, "LTRIM")
+		val, isNull, err := e.evalArg1(v.Exprs, "LTRIM", row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -237,7 +236,7 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{
 		}
 		return strings.TrimLeft(toString(val), " \t\n\r"), true, nil
 	case "rtrim":
-		val, isNull, err := e.evalArg1(v.Exprs, "RTRIM")
+		val, isNull, err := e.evalArg1(v.Exprs, "RTRIM", row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -249,15 +248,15 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{
 		if len(v.Exprs) < 3 {
 			return nil, true, fmt.Errorf("REPLACE requires 3 arguments")
 		}
-		strVal, err := e.evalExpr(v.Exprs[0])
+		strVal, err := e.evalExprMaybeRow(v.Exprs[0], row)
 		if err != nil {
 			return nil, true, err
 		}
-		fromVal, err := e.evalExpr(v.Exprs[1])
+		fromVal, err := e.evalExprMaybeRow(v.Exprs[1], row)
 		if err != nil {
 			return nil, true, err
 		}
-		toVal, err := e.evalExpr(v.Exprs[2])
+		toVal, err := e.evalExprMaybeRow(v.Exprs[2], row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -269,14 +268,14 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{
 		if len(v.Exprs) < 2 {
 			return nil, true, fmt.Errorf("LEFT requires 2 arguments")
 		}
-		strVal, err := e.evalExpr(v.Exprs[0])
+		strVal, err := e.evalExprMaybeRow(v.Exprs[0], row)
 		if err != nil {
 			return nil, true, err
 		}
 		if strVal == nil {
 			return nil, true, nil
 		}
-		lenVal, err := e.evalExpr(v.Exprs[1])
+		lenVal, err := e.evalExprMaybeRow(v.Exprs[1], row)
 		if err != nil {
 			var ov *intOverflowError
 			if errors.As(err, &ov) {
@@ -297,14 +296,14 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{
 		if len(v.Exprs) < 2 {
 			return nil, true, fmt.Errorf("RIGHT requires 2 arguments")
 		}
-		strVal, err := e.evalExpr(v.Exprs[0])
+		strVal, err := e.evalExprMaybeRow(v.Exprs[0], row)
 		if err != nil {
 			return nil, true, err
 		}
 		if strVal == nil {
 			return nil, true, nil
 		}
-		lenVal, err := e.evalExpr(v.Exprs[1])
+		lenVal, err := e.evalExprMaybeRow(v.Exprs[1], row)
 		if err != nil {
 			var ov *intOverflowError
 			if errors.As(err, &ov) {
@@ -322,7 +321,7 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{
 		}
 		return string(s[len(s)-n:]), true, nil
 	case "hex":
-		val, isNull, err := e.evalArg1Quiet(v.Exprs)
+		val, isNull, err := e.evalArg1Quiet(v.Exprs, row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -336,14 +335,10 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{
 			return strings.ToUpper(fmt.Sprintf("%X", int64(tv))), true, nil
 		default:
 			s := toString(val)
-			var hexBuf strings.Builder
-			for _, b := range []byte(s) {
-				fmt.Fprintf(&hexBuf, "%02X", b)
-			}
-			return hexBuf.String(), true, nil
+			return strings.ToUpper(hex.EncodeToString([]byte(s))), true, nil
 		}
 	case "unhex":
-		val, isNull, err := e.evalArg1Quiet(v.Exprs)
+		val, isNull, err := e.evalArg1Quiet(v.Exprs, row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -356,7 +351,7 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{
 		}
 		return string(decoded), true, nil
 	case "strcmp":
-		v0, v1, hasNull, err := e.evalArgs2(v.Exprs, "STRCMP")
+		v0, v1, hasNull, err := e.evalArgs2(v.Exprs, "STRCMP", row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -372,7 +367,7 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{
 		}
 		return int64(0), true, nil
 	case "reverse":
-		val, isNull, err := e.evalArg1Quiet(v.Exprs)
+		val, isNull, err := e.evalArg1Quiet(v.Exprs, row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -385,7 +380,7 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{
 		}
 		return string(runes), true, nil
 	case "oct":
-		val, isNull, err := e.evalArg1Quiet(v.Exprs)
+		val, isNull, err := e.evalArg1Quiet(v.Exprs, row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -401,25 +396,25 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{
 		if len(v.Exprs) < 2 {
 			return nil, true, nil
 		}
-		s, err := e.evalExpr(v.Exprs[0])
+		sVal, err := e.evalExprMaybeRow(v.Exprs[0], row)
 		if err != nil {
 			return nil, true, err
 		}
-		n, err := e.evalExpr(v.Exprs[1])
+		nVal, err := e.evalExprMaybeRow(v.Exprs[1], row)
 		if err != nil {
 			return nil, true, err
 		}
-		count := int(math.Round(toFloat(n)))
-		if count <= 0 || s == nil {
+		count := int(math.Round(toFloat(nVal)))
+		if count <= 0 || sVal == nil {
 			return "", true, nil
 		}
-		str := toString(s)
+		str := toString(sVal)
 		if int64(count)*int64(len(str)) > 67108864 {
 			return nil, true, nil
 		}
 		return strings.Repeat(str, count), true, nil
 	case "instr":
-		strVal, subVal, hasNull, err := e.evalArgs2(v.Exprs, "INSTR")
+		strVal, subVal, hasNull, err := e.evalArgs2(v.Exprs, "INSTR", row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -448,11 +443,11 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{
 		if len(v.Exprs) < 3 {
 			return nil, true, fmt.Errorf("LPAD requires 3 arguments")
 		}
-		strVal, err := e.evalExpr(v.Exprs[0])
+		strVal, err := e.evalExprMaybeRow(v.Exprs[0], row)
 		if err != nil {
 			return nil, true, err
 		}
-		lenVal, err := e.evalExpr(v.Exprs[1])
+		lenVal, err := e.evalExprMaybeRow(v.Exprs[1], row)
 		if err != nil {
 			var ov *intOverflowError
 			if errors.As(err, &ov) {
@@ -461,10 +456,11 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{
 						return nil, true, nil
 					}
 				}
+				return nil, true, nil
 			}
 			return nil, true, err
 		}
-		padVal, err := e.evalExpr(v.Exprs[2])
+		padVal, err := e.evalExprMaybeRow(v.Exprs[2], row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -498,11 +494,11 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{
 		if len(v.Exprs) < 3 {
 			return nil, true, fmt.Errorf("RPAD requires 3 arguments")
 		}
-		strVal, err := e.evalExpr(v.Exprs[0])
+		strVal, err := e.evalExprMaybeRow(v.Exprs[0], row)
 		if err != nil {
 			return nil, true, err
 		}
-		lenVal, err := e.evalExpr(v.Exprs[1])
+		lenVal, err := e.evalExprMaybeRow(v.Exprs[1], row)
 		if err != nil {
 			var ov *intOverflowError
 			if errors.As(err, &ov) {
@@ -511,10 +507,11 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{
 						return nil, true, nil
 					}
 				}
+				return nil, true, nil
 			}
 			return nil, true, err
 		}
-		padVal, err := e.evalExpr(v.Exprs[2])
+		padVal, err := e.evalExprMaybeRow(v.Exprs[2], row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -545,7 +542,7 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{
 		pad = pad[:needed]
 		return string(append(s, pad...)), true, nil
 	case "space":
-		spVal, isNull, err := e.evalArg1(v.Exprs, "SPACE")
+		spVal, isNull, err := e.evalArg1(v.Exprs, "SPACE", row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -564,15 +561,15 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{
 		if len(v.Exprs) < 3 {
 			return nil, true, fmt.Errorf("SUBSTRING_INDEX requires 3 arguments")
 		}
-		siStr, err := e.evalExpr(v.Exprs[0])
+		siStr, err := e.evalExprMaybeRow(v.Exprs[0], row)
 		if err != nil {
 			return nil, true, err
 		}
-		siDelim, err := e.evalExpr(v.Exprs[1])
+		siDelim, err := e.evalExprMaybeRow(v.Exprs[1], row)
 		if err != nil {
 			return nil, true, err
 		}
-		siCnt, err := e.evalExpr(v.Exprs[2])
+		siCnt, err := e.evalExprMaybeRow(v.Exprs[2], row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -595,7 +592,7 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{
 		}
 		return strings.Join(siParts[len(siParts)-siN:], siD), true, nil
 	case "soundex":
-		val, isNull, err := e.evalArg1(v.Exprs, "SOUNDEX")
+		val, isNull, err := e.evalArg1(v.Exprs, "SOUNDEX", row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -604,7 +601,7 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{
 		}
 		return soundex(toString(val)), true, nil
 	case "bit_length":
-		val, isNull, err := e.evalArg1(v.Exprs, "BIT_LENGTH")
+		val, isNull, err := e.evalArg1(v.Exprs, "BIT_LENGTH", row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -616,7 +613,7 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{
 		if len(v.Exprs) < 2 {
 			return int64(0), true, nil
 		}
-		fieldTarget, err := e.evalExpr(v.Exprs[0])
+		fieldTarget, err := e.evalExprMaybeRow(v.Exprs[0], row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -625,7 +622,7 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{
 		}
 		fieldTS := toString(fieldTarget)
 		for fi := 1; fi < len(v.Exprs); fi++ {
-			fieldVal, err := e.evalExpr(v.Exprs[fi])
+			fieldVal, err := e.evalExprMaybeRow(v.Exprs[fi], row)
 			if err != nil {
 				return nil, true, err
 			}
@@ -635,7 +632,7 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{
 		}
 		return int64(0), true, nil
 	case "find_in_set":
-		fisNeedle, fisHaystack, hasNull, err := e.evalArgs2(v.Exprs, "FIND_IN_SET")
+		fisNeedle, fisHaystack, hasNull, err := e.evalArgs2(v.Exprs, "FIND_IN_SET", row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -654,7 +651,7 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{
 		if len(v.Exprs) < 2 {
 			return nil, true, nil
 		}
-		eltIdx, err := e.evalExpr(v.Exprs[0])
+		eltIdx, err := e.evalExprMaybeRow(v.Exprs[0], row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -665,13 +662,13 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{
 		if eltN < 1 || eltN >= len(v.Exprs) {
 			return nil, true, nil
 		}
-		r, err := e.evalExpr(v.Exprs[eltN])
+		r, err := e.evalExprMaybeRow(v.Exprs[eltN], row)
 		return r, true, err
 	case "make_set":
 		if len(v.Exprs) < 2 {
 			return nil, true, fmt.Errorf("MAKE_SET requires at least 2 arguments")
 		}
-		msB, err := e.evalExpr(v.Exprs[0])
+		msB, err := e.evalExprMaybeRow(v.Exprs[0], row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -682,7 +679,7 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{
 		var msParts []string
 		for msi := 1; msi < len(v.Exprs); msi++ {
 			if msBits&(1<<uint(msi-1)) != 0 {
-				msVal, err := e.evalExpr(v.Exprs[msi])
+				msVal, err := e.evalExprMaybeRow(v.Exprs[msi], row)
 				if err != nil {
 					return nil, true, err
 				}
@@ -696,15 +693,15 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{
 		if len(v.Exprs) < 3 {
 			return nil, true, fmt.Errorf("EXPORT_SET requires at least 3 arguments")
 		}
-		esBits, err := e.evalExpr(v.Exprs[0])
+		esBits, err := e.evalExprMaybeRow(v.Exprs[0], row)
 		if err != nil {
 			return nil, true, err
 		}
-		esOn, err := e.evalExpr(v.Exprs[1])
+		esOn, err := e.evalExprMaybeRow(v.Exprs[1], row)
 		if err != nil {
 			return nil, true, err
 		}
-		esOff, err := e.evalExpr(v.Exprs[2])
+		esOff, err := e.evalExprMaybeRow(v.Exprs[2], row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -714,7 +711,7 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{
 		esSep := ","
 		esCount := 64
 		if len(v.Exprs) >= 4 {
-			esSepVal, err := e.evalExpr(v.Exprs[3])
+			esSepVal, err := e.evalExprMaybeRow(v.Exprs[3], row)
 			if err != nil {
 				return nil, true, err
 			}
@@ -723,7 +720,7 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{
 			}
 		}
 		if len(v.Exprs) >= 5 {
-			esCntVal, err := e.evalExpr(v.Exprs[4])
+			esCntVal, err := e.evalExprMaybeRow(v.Exprs[4], row)
 			if err != nil {
 				return nil, true, err
 			}
@@ -744,7 +741,7 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{
 		}
 		return strings.Join(esParts, esSep), true, nil
 	case "quote":
-		qVal, isNull, err := e.evalArg1Quiet(v.Exprs)
+		qVal, isNull, err := e.evalArg1Quiet(v.Exprs, row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -756,7 +753,7 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{
 		qStr = strings.ReplaceAll(qStr, "'", "\\'")
 		return "'" + qStr + "'", true, nil
 	case "weight_string":
-		wsVal, isNull, err := e.evalArg1Quiet(v.Exprs)
+		wsVal, isNull, err := e.evalArg1Quiet(v.Exprs, row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -768,11 +765,11 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{
 		if len(v.Exprs) < 2 {
 			return nil, true, fmt.Errorf("FORMAT requires 2 arguments")
 		}
-		fmtVal, err := e.evalExpr(v.Exprs[0])
+		fmtVal, err := e.evalExprMaybeRow(v.Exprs[0], row)
 		if err != nil {
 			return nil, true, err
 		}
-		fmtDec, err := e.evalExpr(v.Exprs[1])
+		fmtDec, err := e.evalExprMaybeRow(v.Exprs[1], row)
 		if err != nil {
 			return nil, true, err
 		}
@@ -807,417 +804,6 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr) (interface{
 			fmtS = fmtS + "." + fmtParts[1]
 		}
 		return fmtS, true, nil
-	default:
-		return nil, false, nil
-	}
-}
-
-// evalStringFuncWithRow dispatches string-related functions from evalFuncExprWithRow.
-func evalStringFuncWithRow(e *Executor, name string, v *sqlparser.FuncExpr, row storage.Row, evalArgs func() ([]interface{}, error)) (interface{}, bool, error) {
-	switch name {
-	case "upper", "ucase":
-		args, err := evalArgs()
-		if err != nil {
-			return nil, true, err
-		}
-		if len(args) < 1 || args[0] == nil {
-			return nil, true, nil
-		}
-		s := toString(args[0])
-		if strings.ContainsRune(s, '\x00') || (len(v.Exprs) > 0 && e.isBinaryExpr(v.Exprs[0])) {
-			return s, true, nil
-		}
-		return strings.ToUpper(s), true, nil
-	case "lower", "lcase":
-		args, err := evalArgs()
-		if err != nil {
-			return nil, true, err
-		}
-		if len(args) < 1 || args[0] == nil {
-			return nil, true, nil
-		}
-		s := toString(args[0])
-		if strings.ContainsRune(s, '\x00') || (len(v.Exprs) > 0 && e.isBinaryExpr(v.Exprs[0])) {
-			return s, true, nil
-		}
-		return strings.ToLower(s), true, nil
-	case "repeat":
-		args, err := evalArgs()
-		if err != nil {
-			return nil, true, err
-		}
-		if len(args) < 2 || args[0] == nil {
-			return nil, true, nil
-		}
-		count := int(math.Round(toFloat(args[1])))
-		if count <= 0 {
-			return "", true, nil
-		}
-		str := toString(args[0])
-		if int64(count)*int64(len(str)) > 67108864 {
-			return nil, true, nil
-		}
-		return strings.Repeat(str, count), true, nil
-	case "concat":
-		args, err := evalArgs()
-		if err != nil {
-			return nil, true, err
-		}
-		var sb strings.Builder
-		for _, a := range args {
-			if a == nil {
-				return nil, true, nil
-			}
-			sb.WriteString(toString(a))
-		}
-		return sb.String(), true, nil
-	case "md5":
-		args, err := evalArgs()
-		if err != nil {
-			return nil, true, err
-		}
-		if len(args) < 1 || args[0] == nil {
-			return nil, true, nil
-		}
-		sum := md5.Sum([]byte(toString(args[0])))
-		return hex.EncodeToString(sum[:]), true, nil
-	case "length", "octet_length":
-		args, err := evalArgs()
-		if err != nil {
-			return nil, true, err
-		}
-		if len(args) < 1 || args[0] == nil {
-			return nil, true, nil
-		}
-		s := toString(args[0])
-		if colName, ok := v.Exprs[0].(*sqlparser.ColName); ok {
-			cs := e.getColumnCharset(colName)
-			if byteLen, err2 := charsetByteLength(s, cs); err2 == nil {
-				return byteLen, true, nil
-			}
-		}
-		return int64(len(s)), true, nil
-	case "char_length", "character_length":
-		args, err := evalArgs()
-		if err != nil {
-			return nil, true, err
-		}
-		if len(args) < 1 || args[0] == nil {
-			return nil, true, nil
-		}
-		return int64(mysqlCharLen(toString(args[0]))), true, nil
-	case "replace":
-		args, err := evalArgs()
-		if err != nil {
-			return nil, true, err
-		}
-		if len(args) < 3 || args[0] == nil {
-			return nil, true, nil
-		}
-		return strings.ReplaceAll(toString(args[0]), toString(args[1]), toString(args[2])), true, nil
-	case "left":
-		args, err := evalArgs()
-		if err != nil {
-			return nil, true, err
-		}
-		if len(args) < 2 || args[0] == nil {
-			return nil, true, nil
-		}
-		s := []rune(toString(args[0]))
-		n := int(toInt64(args[1]))
-		if n <= 0 {
-			return "", true, nil
-		}
-		if n > len(s) {
-			n = len(s)
-		}
-		return string(s[:n]), true, nil
-	case "right":
-		args, err := evalArgs()
-		if err != nil {
-			return nil, true, err
-		}
-		if len(args) < 2 || args[0] == nil {
-			return nil, true, nil
-		}
-		s := []rune(toString(args[0]))
-		n := int(toInt64(args[1]))
-		if n <= 0 {
-			return "", true, nil
-		}
-		if n > len(s) {
-			n = len(s)
-		}
-		return string(s[len(s)-n:]), true, nil
-	case "hex":
-		args, err := evalArgs()
-		if err != nil {
-			return nil, true, err
-		}
-		if len(args) < 1 || args[0] == nil {
-			return nil, true, nil
-		}
-		switch tv := args[0].(type) {
-		case int64:
-			return strings.ToUpper(fmt.Sprintf("%X", tv)), true, nil
-		case float64:
-			return strings.ToUpper(fmt.Sprintf("%X", int64(tv))), true, nil
-		default:
-			s := toString(args[0])
-			return strings.ToUpper(hex.EncodeToString([]byte(s))), true, nil
-		}
-	case "instr":
-		args, err := evalArgs()
-		if err != nil {
-			return nil, true, err
-		}
-		if len(args) < 2 || args[0] == nil || args[1] == nil {
-			return nil, true, nil
-		}
-		s := []rune(toString(args[0]))
-		sub := []rune(toString(args[1]))
-		if len(sub) == 0 {
-			return int64(1), true, nil
-		}
-		for i := 0; i <= len(s)-len(sub); i++ {
-			match := true
-			for j := 0; j < len(sub); j++ {
-				if s[i+j] != sub[j] {
-					match = false
-					break
-				}
-			}
-			if match {
-				return int64(i + 1), true, nil
-			}
-		}
-		return int64(0), true, nil
-	case "reverse":
-		args, err := evalArgs()
-		if err != nil {
-			return nil, true, err
-		}
-		if len(args) < 1 || args[0] == nil {
-			return nil, true, nil
-		}
-		runes := []rune(toString(args[0]))
-		for i, j := 0, len(runes)-1; i < j; i, j = i+1, j-1 {
-			runes[i], runes[j] = runes[j], runes[i]
-		}
-		return string(runes), true, nil
-	case "lpad":
-		args, err := evalArgs()
-		if err != nil {
-			var ov *intOverflowError
-			if errors.As(err, &ov) {
-				return nil, true, nil
-			}
-			return nil, true, err
-		}
-		if len(args) < 3 || args[0] == nil || args[1] == nil || args[2] == nil {
-			return nil, true, nil
-		}
-		s := []rune(toString(args[0]))
-		targetLen64 := toInt64(args[1])
-		if targetLen64 < 0 {
-			return nil, true, nil
-		}
-		if targetLen64 > 67108864 {
-			return nil, true, nil
-		}
-		targetLen := int(targetLen64)
-		padStr := []rune(toString(args[2]))
-		if targetLen <= len(s) {
-			return string(s[:targetLen]), true, nil
-		}
-		if len(padStr) == 0 {
-			return "", true, nil
-		}
-		needed := targetLen - len(s)
-		var pad []rune
-		for len(pad) < needed {
-			pad = append(pad, padStr...)
-		}
-		pad = pad[:needed]
-		return string(append(pad, s...)), true, nil
-	case "rpad":
-		args, err := evalArgs()
-		if err != nil {
-			var ov *intOverflowError
-			if errors.As(err, &ov) {
-				return nil, true, nil
-			}
-			return nil, true, err
-		}
-		if len(args) < 3 || args[0] == nil || args[1] == nil || args[2] == nil {
-			return nil, true, nil
-		}
-		s := []rune(toString(args[0]))
-		targetLen64 := toInt64(args[1])
-		if targetLen64 < 0 {
-			return nil, true, nil
-		}
-		if targetLen64 > 67108864 {
-			return nil, true, nil
-		}
-		targetLen := int(targetLen64)
-		padStr := []rune(toString(args[2]))
-		if targetLen <= len(s) {
-			return string(s[:targetLen]), true, nil
-		}
-		if len(padStr) == 0 {
-			return "", true, nil
-		}
-		needed := targetLen - len(s)
-		var pad []rune
-		for len(pad) < needed {
-			pad = append(pad, padStr...)
-		}
-		pad = pad[:needed]
-		return string(append(s, pad...)), true, nil
-	case "substring", "substr", "mid":
-		args, err := evalArgs()
-		if err != nil {
-			return nil, true, err
-		}
-		if len(args) < 2 || args[0] == nil {
-			return nil, true, nil
-		}
-		s := []rune(toString(args[0]))
-		pos := int(toInt64(args[1]))
-		if pos == 0 {
-			return "", true, nil
-		}
-		if pos > 0 {
-			pos--
-		} else if pos < 0 {
-			pos = len(s) + pos
-		}
-		if pos < 0 {
-			pos = 0
-		}
-		if pos >= len(s) {
-			return "", true, nil
-		}
-		if len(args) >= 3 {
-			length := int(toInt64(args[2]))
-			if length <= 0 {
-				return "", true, nil
-			}
-			end := pos + length
-			if end > len(s) {
-				end = len(s)
-			}
-			return string(s[pos:end]), true, nil
-		}
-		return string(s[pos:]), true, nil
-	case "trim":
-		args, err := evalArgs()
-		if err != nil {
-			return nil, true, err
-		}
-		if len(args) < 1 || args[0] == nil {
-			return nil, true, nil
-		}
-		return strings.TrimSpace(toString(args[0])), true, nil
-	case "ltrim":
-		args, err := evalArgs()
-		if err != nil {
-			return nil, true, err
-		}
-		if len(args) < 1 || args[0] == nil {
-			return nil, true, nil
-		}
-		return strings.TrimLeft(toString(args[0]), " \t\n\r"), true, nil
-	case "rtrim":
-		args, err := evalArgs()
-		if err != nil {
-			return nil, true, err
-		}
-		if len(args) < 1 || args[0] == nil {
-			return nil, true, nil
-		}
-		return strings.TrimRight(toString(args[0]), " \t\n\r"), true, nil
-	case "ascii", "ord":
-		args, err := evalArgs()
-		if err != nil {
-			return nil, true, err
-		}
-		if len(args) < 1 || args[0] == nil {
-			return nil, true, nil
-		}
-		s := toString(args[0])
-		if len(s) == 0 {
-			return int64(0), true, nil
-		}
-		return int64(s[0]), true, nil
-	case "char":
-		args, err := evalArgs()
-		if err != nil {
-			return nil, true, err
-		}
-		var sb strings.Builder
-		for _, arg := range args {
-			if arg == nil {
-				continue
-			}
-			n := toInt64(arg)
-			if n >= 0 && n <= 255 {
-				sb.WriteByte(byte(n))
-			}
-		}
-		return sb.String(), true, nil
-	case "strcmp":
-		args, err := evalArgs()
-		if err != nil {
-			return nil, true, err
-		}
-		if len(args) < 2 || args[0] == nil || args[1] == nil {
-			return nil, true, nil
-		}
-		s0, s1 := strings.ToLower(toString(args[0])), strings.ToLower(toString(args[1]))
-		if s0 < s1 {
-			return int64(-1), true, nil
-		} else if s0 > s1 {
-			return int64(1), true, nil
-		}
-		return int64(0), true, nil
-	case "oct":
-		args, err := evalArgs()
-		if err != nil {
-			return nil, true, err
-		}
-		if len(args) < 1 || args[0] == nil {
-			return nil, true, nil
-		}
-		n := toInt64(args[0])
-		if n < 0 {
-			return fmt.Sprintf("%o", uint64(n)), true, nil
-		}
-		return fmt.Sprintf("%o", n), true, nil
-	case "load_file":
-		args, err := evalArgs()
-		if err != nil {
-			return nil, true, err
-		}
-		if len(args) < 1 || args[0] == nil {
-			return nil, true, nil
-		}
-		filePath := toString(args[0])
-		if !filepath.IsAbs(filePath) && len(e.SearchPaths) > 0 {
-			for _, sp := range e.SearchPaths {
-				candidate := filepath.Join(sp, filePath)
-				if _, statErr := os.Stat(candidate); statErr == nil {
-					filePath = candidate
-					break
-				}
-			}
-		}
-		data, readErr := os.ReadFile(filePath)
-		if readErr != nil {
-			return nil, true, nil
-		}
-		return string(data), true, nil
 	default:
 		return nil, false, nil
 	}


### PR DESCRIPTION
## Summary
- Add `evalExprMaybeRow` helper that dispatches to `evalRowExpr` or `evalExpr` based on whether a `*storage.Row` is provided
- Merge each `evalXxxFunc` / `evalXxxFuncWithRow` pair into a single function accepting `*storage.Row`
- Remove ~1000 lines of duplicated code across `func_string.go`, `func_datetime.go`, `func_math.go`, `func_misc.go`
- Preserve behavioral differences from WithRow variants (e.g., `isZeroDate` checks, `conv` base range validation, negative `bin` handling)

Closes #37

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./... -count=1` passes (88 tests)
- [x] All `evalXxxFuncWithRow` functions deleted
- [x] Call sites in `executor.go` updated to pass `nil` or `&row`

🤖 Generated with [Claude Code](https://claude.com/claude-code)