### PR TITLE
feat: implement updatable views (INSERT/UPDATE/DELETE)

### DIFF
--- a/executor/dml_delete.go
+++ b/executor/dml_delete.go
@@ -104,6 +104,13 @@ func (e *Executor) execDelete(stmt *sqlparser.Delete) (*Result, error) {
 		return nil, fmt.Errorf("unsupported table expression: %T", te)
 	}
 
+	// Resolve views: if tableName is a view, replace with the underlying base table.
+	if baseTable, isView, err := e.resolveViewToBaseTable(tableName); err != nil {
+		return nil, err
+	} else if isView {
+		tableName = baseTable
+	}
+
 	// Handle performance_schema tables
 	if strings.EqualFold(deleteDB, "performance_schema") {
 		lowerTable := strings.ToLower(tableName)

--- a/executor/dml_insert.go
+++ b/executor/dml_insert.go
@@ -143,6 +143,13 @@ func (e *Executor) execInsert(stmt *sqlparser.Insert) (*Result, error) {
 		insertDB, tableName = resolveTableNameDB(tableName, e.CurrentDB)
 	}
 
+	// Resolve views: if tableName is a view, replace with the underlying base table.
+	if baseTable, isView, err := e.resolveViewToBaseTable(tableName); err != nil {
+		return nil, err
+	} else if isView {
+		tableName = baseTable
+	}
+
 	// Reject INSERT on performance_schema tables (except writable setup tables)
 	if strings.EqualFold(insertDB, "performance_schema") {
 		lowerTable := strings.ToLower(tableName)

--- a/executor/dml_update.go
+++ b/executor/dml_update.go
@@ -96,6 +96,13 @@ func (e *Executor) execUpdate(stmt *sqlparser.Update) (*Result, error) {
 		return nil, fmt.Errorf("unsupported table expression: %T", te)
 	}
 
+	// Resolve views: if tableName is a view, replace with the underlying base table.
+	if baseTable, isView, err := e.resolveViewToBaseTable(tableName); err != nil {
+		return nil, err
+	} else if isView {
+		tableName = baseTable
+	}
+
 	// Handle performance_schema tables
 	if strings.EqualFold(updateDB, "performance_schema") {
 		lowerTable := strings.ToLower(tableName)

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -10582,6 +10582,72 @@ func resolveTableNameDB(name, currentDB string) (string, string) {
 	return currentDB, name
 }
 
+// lookupView looks up a view by name (case-insensitive) and returns the
+// view SQL and the canonical name. Returns ("", "", false) if not found.
+func (e *Executor) lookupView(name string) (viewSQL string, canonicalName string, ok bool) {
+	if e.views == nil {
+		return "", "", false
+	}
+	if sql, found := e.views[name]; found {
+		return sql, name, true
+	}
+	for vn, sql := range e.views {
+		if strings.EqualFold(vn, name) {
+			return sql, vn, true
+		}
+	}
+	return "", "", false
+}
+
+// resolveViewToBaseTable checks if the given table name is a view, and if so,
+// returns the underlying base table name. It also validates that the view is
+// updatable (simple SELECT from a single table, no JOINs, GROUP BY, DISTINCT,
+// aggregates, UNION, or subqueries in FROM).
+// Returns (baseTable, isView, error). If isView is false, the caller should
+// proceed with normal table handling.
+func (e *Executor) resolveViewToBaseTable(tableName string) (string, bool, error) {
+	viewSQL, _, ok := e.lookupView(tableName)
+	if !ok {
+		return "", false, nil
+	}
+	stmt, err := e.parser().Parse(viewSQL)
+	if err != nil {
+		return "", true, fmt.Errorf("cannot parse view definition: %v", err)
+	}
+	sel, ok := stmt.(*sqlparser.Select)
+	if !ok {
+		// UNION or other non-simple SELECT
+		return "", true, mysqlError(1288, "HY000", "The target table of the statement is not updatable")
+	}
+	// Must have exactly one table in FROM (no JOINs)
+	if len(sel.From) != 1 {
+		return "", true, mysqlError(1288, "HY000", "The target table of the statement is not updatable")
+	}
+	ate, ok := sel.From[0].(*sqlparser.AliasedTableExpr)
+	if !ok {
+		// JOIN expression
+		return "", true, mysqlError(1288, "HY000", "The target table of the statement is not updatable")
+	}
+	tn, ok := ate.Expr.(sqlparser.TableName)
+	if !ok {
+		// Subquery in FROM
+		return "", true, mysqlError(1288, "HY000", "The target table of the statement is not updatable")
+	}
+	// Check for GROUP BY, HAVING, DISTINCT, aggregates, window functions
+	if sel.GroupBy != nil || sel.Having != nil || sel.Distinct {
+		return "", true, mysqlError(1288, "HY000", "The target table of the statement is not updatable")
+	}
+	// Check for aggregate functions in SELECT exprs
+	for _, expr := range sel.SelectExprs.Exprs {
+		if ae, ok := expr.(*sqlparser.AliasedExpr); ok {
+			if containsAggregate(ae.Expr) {
+				return "", true, mysqlError(1288, "HY000", "The target table of the statement is not updatable")
+			}
+		}
+	}
+	return tn.Name.String(), true, nil
+}
+
 // isMultiTableUpdate checks if an UPDATE statement involves multiple tables (join or comma-separated).
 // resolveColumnTable resolves an unqualified column name to a table name
 // by searching through the table expressions in the FROM clause.

--- a/executor/information_schema.go
+++ b/executor/information_schema.go
@@ -1021,6 +1021,40 @@ func (e *Executor) infoSchemaTables() []storage.Row {
 		}
 	}
 
+	// Add user-defined views as VIEW entries
+	if e.views != nil {
+		viewNames := make([]string, 0, len(e.views))
+		for n := range e.views {
+			viewNames = append(viewNames, n)
+		}
+		sort.Strings(viewNames)
+		for _, vName := range viewNames {
+			rows = append(rows, storage.Row{
+				"TABLE_CATALOG":   "def",
+				"TABLE_SCHEMA":    e.CurrentDB,
+				"TABLE_NAME":      vName,
+				"TABLE_TYPE":      "VIEW",
+				"ENGINE":          nil,
+				"VERSION":         nil,
+				"ROW_FORMAT":      nil,
+				"TABLE_ROWS":      nil,
+				"AVG_ROW_LENGTH":  nil,
+				"DATA_LENGTH":     nil,
+				"MAX_DATA_LENGTH": nil,
+				"INDEX_LENGTH":    nil,
+				"DATA_FREE":       nil,
+				"AUTO_INCREMENT":  nil,
+				"CREATE_TIME":     nil,
+				"UPDATE_TIME":     nil,
+				"CHECK_TIME":      nil,
+				"TABLE_COLLATION": nil,
+				"CHECKSUM":        nil,
+				"CREATE_OPTIONS":  nil,
+				"TABLE_COMMENT":   "VIEW",
+			})
+		}
+	}
+
 	// Add information_schema virtual tables as SYSTEM VIEW entries
 	// Order matches MySQL 8.0's utf8_general_ci collation ordering
 	isTableNames := []string{

--- a/executor/show.go
+++ b/executor/show.go
@@ -377,6 +377,12 @@ func (e *Executor) execShow(stmt *sqlparser.Show, query string) (*Result, error)
 				return nil, err
 			}
 			tables := db.ListTables()
+			// Include views in SHOW TABLES
+			if e.views != nil {
+				for vn := range e.views {
+					tables = append(tables, vn)
+				}
+			}
 			sort.Strings(tables)
 			rows := make([][]interface{}, 0, len(tables))
 			for _, t := range tables {
@@ -418,6 +424,12 @@ func (e *Executor) execShow(stmt *sqlparser.Show, query string) (*Result, error)
 			return nil, err
 		}
 		tables := db.ListTables()
+		// Include views in SHOW TABLES
+		if e.views != nil {
+			for vn := range e.views {
+				tables = append(tables, vn)
+			}
+		}
 		sort.Strings(tables)
 		rows := make([][]interface{}, 0, len(tables))
 		for _, t := range tables {


### PR DESCRIPTION
## Summary
- Resolve view names to underlying base tables for INSERT, UPDATE, and DELETE operations
- Validate view updatability: reject DML on views with JOINs, GROUP BY, DISTINCT, aggregates, UNIONs, or subqueries (MySQL error 1288)
- Add `lookupView` helper for case-insensitive view name resolution
- Include views in `SHOW TABLES` output and `INFORMATION_SCHEMA.TABLES` with `TABLE_TYPE='VIEW'`

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./... -count=1 -timeout 60s` passes (88 tests)
- [x] `go run ./cmd/mtrrun` passes (1330 passed, 0 failed, 0 regressions)

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)