### PR TITLE
fix: resolve LOAD DATA INFILE symlink and add CHARACTER SET parsing

### DIFF
--- a/cmd/mtrrun/main.go
+++ b/cmd/mtrrun/main.go
@@ -281,6 +281,12 @@ func newWorker(searchPaths []string) (*worker, error) {
 		if fi, err := os.Stat(stdData); err == nil && fi.IsDir() {
 			target := filepath.Join(tmpDir, "std_data")
 			if _, err := os.Lstat(target); os.IsNotExist(err) {
+				// Use absolute path for symlink target so it resolves correctly
+				// from the temp directory.
+				absStdData, absErr := filepath.Abs(stdData)
+				if absErr == nil {
+					stdData = absStdData
+				}
 				os.Symlink(stdData, target) //nolint:errcheck
 			}
 			break
@@ -628,6 +634,9 @@ func indent(s string) string {
 func resolveTestdataRoot() string {
 	local := "testdata/dolt-mysql-tests/files"
 	if fi, err := os.Stat(filepath.Join(local, "suite")); err == nil && fi.IsDir() {
+		if abs, err := filepath.Abs(local); err == nil {
+			return abs
+		}
 		return local
 	}
 	gitPath := ".git"

--- a/executor/select.go
+++ b/executor/select.go
@@ -4232,6 +4232,7 @@ type loadDataOptions struct {
 	setExprs          string   // raw SET clause
 	isReplace         bool
 	isIgnore          bool
+	charset           string // CHARACTER SET clause (e.g. "latin1", "utf8")
 }
 
 // reLoadData matches LOAD DATA [LOCAL] INFILE 'file' [REPLACE|IGNORE] INTO TABLE tablename ...
@@ -4440,6 +4441,21 @@ func parseLoadDataSQL(query string) (*loadDataOptions, error) {
 	opts.isReplace = reLoadReplace.MatchString(query)
 	opts.isIgnore = reLoadIgnore.MatchString(query)
 
+	// Parse CHARACTER SET clause
+	if csIdx := strings.Index(upper, "CHARACTER SET "); csIdx >= 0 {
+		afterCS := query[csIdx+len("CHARACTER SET "):]
+		fields := strings.Fields(afterCS)
+		if len(fields) > 0 {
+			opts.charset = strings.ToLower(strings.TrimRight(fields[0], ";"))
+		}
+	} else if csIdx := strings.Index(upper, "CHARSET "); csIdx >= 0 {
+		afterCS := query[csIdx+len("CHARSET "):]
+		fields := strings.Fields(afterCS)
+		if len(fields) > 0 {
+			opts.charset = strings.ToLower(strings.TrimRight(fields[0], ";"))
+		}
+	}
+
 	if idx := findColumnListStart(query); idx >= 0 {
 		end := strings.Index(query[idx:], ")")
 		if end >= 0 {
@@ -4541,20 +4557,35 @@ func (e *Executor) execLoadData(query string) (*Result, error) {
 		return nil, mysqlError(29, "HY000", fmt.Sprintf("File '%s' not found (OS errno 2 - No such file or directory)", opts.filePath))
 	}
 
-	// Convert encoding for non-UTF-8 data files (SJIS, EUC-JP, UCS2)
-	baseName := strings.ToLower(filepath.Base(filePath))
-	if strings.Contains(baseName, "ucs2") {
+	// Convert encoding for non-UTF-8 data files based on CHARACTER SET clause or filename heuristic
+	cs := opts.charset
+	if cs == "" {
+		// Fall back to filename-based heuristic
+		baseName := strings.ToLower(filepath.Base(filePath))
+		if strings.Contains(baseName, "ucs2") {
+			cs = "ucs2"
+		} else if strings.Contains(baseName, "sjis") || strings.Contains(baseName, "cp932") {
+			cs = "sjis"
+		} else if strings.Contains(baseName, "ujis") || strings.Contains(baseName, "eucjp") {
+			cs = "eucjp"
+		}
+	}
+	switch cs {
+	case "ucs2":
 		if decoded, err := decodeUCS2(data); err == nil {
 			data = decoded
 		}
-	} else if strings.Contains(baseName, "sjis") || strings.Contains(baseName, "cp932") {
+	case "sjis", "cp932":
 		if decoded, err := decodeSJIS(data); err == nil {
 			data = decoded
 		}
-	} else if strings.Contains(baseName, "ujis") || strings.Contains(baseName, "eucjp") {
+	case "ujis", "eucjp", "eucjpms":
 		if decoded, err := decodeEUCJP(data); err == nil {
 			data = decoded
 		}
+	case "latin1", "utf8", "utf8mb3", "utf8mb4", "binary", "ascii":
+		// latin1 is a superset of ASCII; Go strings handle bytes directly.
+		// utf8/utf8mb4 is Go's native encoding. No conversion needed.
 	}
 
 	content := string(data)


### PR DESCRIPTION
## Summary
- Fix relative symlink for `std_data` directory in MTR temp dirs, which caused "File not found (OS errno 2)" errors when LOAD DATA INFILE used `$MYSQLTEST_VARDIR/std_data/...` paths
- Make `resolveTestdataRoot()` return absolute paths consistently
- Add CHARACTER SET clause parsing to LOAD DATA statements, replacing filename-based encoding heuristics when the clause is present

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./... -count=1 -timeout 60s` passes (88 tests)
- [x] All `engine_funcs/ld_*` LOAD DATA tests pass (15 tests)
- [x] Full `go run ./cmd/mtrrun` shows no regressions (1328 passed, 3 failed, 2014 skipped -- same as baseline)
- [x] Verified symlink now uses absolute path in temp directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)