### PR TITLE
fix: handle tuple IN subquery in evalComparisonExpr

### DIFF
--- a/executor/expr_eval.go
+++ b/executor/expr_eval.go
@@ -440,6 +440,14 @@ func (e *Executor) evalBinaryOp(v *sqlparser.BinaryExpr) (interface{}, error) {
 func (e *Executor) evalComparisonExpr(v *sqlparser.ComparisonExpr) (interface{}, error) {
 	// Handle IN / NOT IN specially: right side is a ValTuple
 	if v.Operator == sqlparser.InOp || v.Operator == sqlparser.NotInOp {
+		// When left is a tuple and right is a subquery, delegate directly to
+		// evalInSubquery which handles tuple evaluation internally. Evaluating
+		// v.Left via evalExpr would fail with "Operand should contain 1 column(s)".
+		if _, leftIsTuple := v.Left.(sqlparser.ValTuple); leftIsTuple {
+			if sub, ok := v.Right.(*sqlparser.Subquery); ok {
+				return e.evalInSubquery(nil, v.Left, sub, v.Operator)
+			}
+		}
 		left, err := e.evalExpr(v.Left)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
## Summary
- Fix `(d1, d2) IN (SELECT d1, d2 FROM x2)` failing with `Error 1241: Operand should contain 1 column(s)`
- In `evalComparisonExpr`, check for tuple left + subquery right before calling `evalExpr` on the left side, and delegate directly to `evalInSubquery` which handles tuple evaluation internally

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./... -count=1 -timeout 60s` passes (all 99 tests)

Closes #61

🤖 Generated with [Claude Code](https://claude.com/claude-code)