### PR TITLE
fix: RENAME TABLE self-rename and multi-step conflict detection

### DIFF
--- a/executor/ddl.go
+++ b/executor/ddl.go
@@ -123,11 +123,14 @@ func (e *Executor) execRenameTable(stmt *sqlparser.RenameTable) (*Result, error)
 
 	tableExists := func(db, name string) bool {
 		k := tableKey{db, name}
-		if removed[k] {
-			return false
-		}
+		// Check "added" before "removed": a name can be in both if it was
+		// used as a source (added to removed) and later re-introduced as a
+		// target (added to added). In that case it exists as a target.
 		if added[k] {
 			return true
+		}
+		if removed[k] {
+			return false
 		}
 		catDB, err := e.Catalog.GetDatabase(db)
 		if err != nil {
@@ -169,20 +172,13 @@ func (e *Executor) execRenameTable(stmt *sqlparser.RenameTable) (*Result, error)
 			return nil, mysqlError(1049, "42000", fmt.Sprintf("Unknown database '%s'", srcDB))
 		}
 
-		// Skip validation for no-op renames (same table, same db) - MySQL allows this
-		isSameTable := strings.EqualFold(srcDB, targetDB) && strings.EqualFold(oldName, newName)
 		// Validate target doesn't exist first (MySQL checks destination conflicts before source existence)
-		if !isSameTable && tableExists(targetDB, newName) {
+		if tableExists(targetDB, newName) {
 			return nil, mysqlError(1050, "42S01", fmt.Sprintf("Table '%s' already exists", newName))
 		}
 		// Validate source exists (considering prior simulated renames)
 		if !tableExists(srcDB, oldName) {
 			return nil, mysqlError(1146, "42S02", fmt.Sprintf("Table '%s.%s' doesn't exist", srcDB, oldName))
-		}
-
-		// Skip no-op renames (same table, same db) - MySQL allows this silently
-		if isSameTable {
-			continue
 		}
 
 		// Simulate this rename for subsequent validations

--- a/executor/ddl.go
+++ b/executor/ddl.go
@@ -181,13 +181,14 @@ func (e *Executor) execRenameTable(stmt *sqlparser.RenameTable) (*Result, error)
 			return nil, mysqlError(1146, "42S02", fmt.Sprintf("Table '%s.%s' doesn't exist", srcDB, oldName))
 		}
 
-		// Simulate this rename for subsequent validations
-		removed[tableKey{srcDB, oldName}] = true
-		added[tableKey{targetDB, newName}] = true
-		// If we had previously "added" the source, remove it from added too
+		// Simulate this rename for subsequent validations.
+		// Order matters: clean up added[src] first, then mark removed/added,
+		// so that src==target (self-rename) and multi-step chains are handled correctly.
 		if added[tableKey{srcDB, oldName}] {
 			delete(added, tableKey{srcDB, oldName})
 		}
+		removed[tableKey{srcDB, oldName}] = true
+		added[tableKey{targetDB, newName}] = true
 
 		pairs = append(pairs, renamePair{srcDB, oldName, targetDB, newName})
 	}

--- a/executor/ddl_test.go
+++ b/executor/ddl_test.go
@@ -1,0 +1,79 @@
+package executor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/myuon/mylite/catalog"
+	"github.com/myuon/mylite/storage"
+)
+
+// newDDLTestExecutor creates an Executor with a "test" database for DDL tests.
+func newDDLTestExecutor(t *testing.T) *Executor {
+	t.Helper()
+	cat := catalog.New()
+	store := storage.NewEngine()
+	e := New(cat, store)
+	if _, err := e.Execute("CREATE DATABASE IF NOT EXISTS test"); err != nil {
+		t.Fatalf("create db: %v", err)
+	}
+	e.CurrentDB = "test"
+	return e
+}
+
+// TestRenameTable_SelfRename verifies that renaming a table to itself returns Error 1050.
+func TestRenameTable_SelfRename(t *testing.T) {
+	e := newDDLTestExecutor(t)
+
+	if _, err := e.Execute("CREATE TABLE t1 (id INT PRIMARY KEY)"); err != nil {
+		t.Fatalf("create t1: %v", err)
+	}
+
+	_, err := e.Execute("RENAME TABLE t1 TO t1")
+	if err == nil {
+		t.Fatal("expected error 1050 for self-rename, got nil")
+	}
+	if !strings.Contains(err.Error(), "1050") {
+		t.Errorf("expected error 1050 (Table already exists), got: %v", err)
+	}
+}
+
+// TestRenameTable_MultiStepConflict verifies that multi-step renames detect conflicts
+// where an intermediate name collides with a later target.
+// e.g. RENAME TABLE a TO b, c TO b — the second pair targets "b" which was just created.
+func TestRenameTable_MultiStepConflict(t *testing.T) {
+	e := newDDLTestExecutor(t)
+
+	if _, err := e.Execute("CREATE TABLE a (id INT PRIMARY KEY)"); err != nil {
+		t.Fatalf("create a: %v", err)
+	}
+	if _, err := e.Execute("CREATE TABLE c (id INT PRIMARY KEY)"); err != nil {
+		t.Fatalf("create c: %v", err)
+	}
+
+	// a -> b is valid, but c -> b conflicts because b now exists (from a -> b)
+	_, err := e.Execute("RENAME TABLE a TO b, c TO b")
+	if err == nil {
+		t.Fatal("expected error 1050 for conflicting multi-step rename, got nil")
+	}
+	if !strings.Contains(err.Error(), "1050") {
+		t.Errorf("expected error 1050 (Table already exists), got: %v", err)
+	}
+}
+
+// TestRenameTable_MultiStepChain verifies that a valid chain rename (a->b, b->c) succeeds.
+func TestRenameTable_MultiStepChain(t *testing.T) {
+	e := newDDLTestExecutor(t)
+
+	if _, err := e.Execute("CREATE TABLE a (id INT PRIMARY KEY)"); err != nil {
+		t.Fatalf("create a: %v", err)
+	}
+	if _, err := e.Execute("CREATE TABLE b (id INT PRIMARY KEY)"); err != nil {
+		t.Fatalf("create b: %v", err)
+	}
+
+	// a -> b_new, b -> c: both valid (a's old name freed, b moved to c)
+	if _, err := e.Execute("RENAME TABLE a TO a_new, b TO c"); err != nil {
+		t.Fatalf("expected valid chain rename to succeed: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- `RELEASE SAVEPOINT` was already implemented in `executor/executor.go` (case `*sqlparser.Release`); no change needed
- Fixed two bugs in `RENAME TABLE` validation:
  1. `RENAME TABLE t1 TO t1` (self-rename) now correctly returns `Error 1050 (42S01): Table 't1' already exists`, matching MySQL behavior
  2. Multi-step rename conflict detection: fixed `tableExists` simulation to check `added` before `removed`, so a target name re-introduced by a prior rename step is correctly detected as conflicting (e.g. `RENAME TABLE t3 TO t4, t2 TO t3, t1 TO t2, t4 TO t2` now errors)

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./... -count=1` passes (executor + harness)
- [x] Manual test confirms `rename table t1 to t1` → Error 1050
- [x] Manual test confirms `rename table t3 to t4, t2 to t3, t1 to t2, t4 to t2` → Error 1050
- [x] Multi-step rotation `rename table t3 to t4, t2 to t3, t1 to t2, t4 to t1` still succeeds
- [x] `other/rename` test progresses past the initial rename validations (times out on multi-connection section, which is pre-existing)

Closes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)