### PR TITLE
fix: EXPLAIN select_type for subquery PRIMARY/SUBQUERY

### DIFF
--- a/executor/explain.go
+++ b/executor/explain.go
@@ -1132,6 +1132,21 @@ func (e *Executor) queryCanBeSemijoinFlattened(sel *sqlparser.Select) bool {
 					allFlattenable = false
 					return false, nil
 				}
+				// If the EXISTS inner SELECT itself contains nested subqueries (e.g. correlated
+				// scalar subqueries in WHERE), MySQL cannot flatten it into a simple anti-join
+				// at the outer id level — it produces a separate anti-join row plus new subquery ids.
+				innerHasNestedSubquery := false
+				_ = sqlparser.Walk(func(n2 sqlparser.SQLNode) (bool, error) {
+					if _, ok2 := n2.(*sqlparser.Subquery); ok2 {
+						innerHasNestedSubquery = true
+						return false, nil
+					}
+					return true, nil
+				}, inner.SelectExprs, inner.Where, inner.Having)
+				if innerHasNestedSubquery {
+					allFlattenable = false
+					return false, nil
+				}
 				hasAny = true
 			}
 			return false, nil
@@ -3196,8 +3211,79 @@ func (e *Executor) walkForSubqueries(node sqlparser.SQLNode, idCounter *int64, r
 	if node == nil {
 		return
 	}
+	outerQueryID := *idCounter
 	_ = sqlparser.Walk(func(n sqlparser.SQLNode) (bool, error) {
 		switch sub := n.(type) {
+		case *sqlparser.ExistsExpr:
+			// Handle NOT EXISTS / EXISTS anti-join pattern when semijoin-flattening is disabled.
+			// When the outer query cannot be semijoin-flattened (outerCanSemijoin=false),
+			// MySQL emits anti-join rows at the outer query id, not as a new SUBQUERY block.
+			if !outerCanSemijoin {
+				if inner, ok := sub.Subquery.Select.(*sqlparser.Select); ok {
+					var innerFromTables []string
+					for _, te := range inner.From {
+						for _, tn := range e.extractAllTableNames(te) {
+							if !strings.EqualFold(tn, "dual") {
+								innerFromTables = append(innerFromTables, tn)
+							}
+						}
+					}
+					if len(innerFromTables) > 0 {
+						// "Use up" an id slot for the EXISTS wrapper (it doesn't appear in output).
+						*idCounter++
+						outerST := outerSelectTypeOuter
+						if outerST == "" {
+							outerST = "PRIMARY"
+						}
+						for _, tblName := range innerFromTables {
+							var rowCount int64 = 1
+							if e.Storage != nil {
+								if tbl, err2 := e.Storage.GetTable(e.CurrentDB, tblName); err2 == nil && len(tbl.Rows) > 0 {
+									rowCount = int64(len(tbl.Rows))
+								}
+							}
+							ai := e.explainDetectAccessType(inner, tblName)
+							var extra interface{} = "Using where; Not exists"
+							*result = append(*result, explainSelectType{
+								id:           outerQueryID,
+								selectType:   outerST,
+								table:        tblName,
+								accessType:   ai.accessType,
+								possibleKeys: nilIfEmpty(ai.possibleKeys),
+								key:          nilIfEmpty(ai.key),
+								keyLen:       nilIfEmpty(ai.keyLen),
+								ref:          nilIfEmpty(ai.ref),
+								rows:         rowCount,
+								filtered:     "100.00",
+								extra:        extra,
+							})
+						}
+						// Recursively walk nested subqueries inside the EXISTS inner SELECT.
+						allTables := make(map[string]bool)
+						for k, v := range outerTables {
+							allTables[k] = v
+						}
+						for _, tn := range innerFromTables {
+							allTables[strings.ToLower(tn)] = true
+						}
+						var nestedNodes []sqlparser.SQLNode
+						if inner.SelectExprs != nil {
+							nestedNodes = append(nestedNodes, inner.SelectExprs)
+						}
+						if inner.Where != nil {
+							nestedNodes = append(nestedNodes, inner.Where)
+						}
+						if inner.Having != nil {
+							nestedNodes = append(nestedNodes, inner.Having)
+						}
+						for _, nestedNode := range nestedNodes {
+							e.walkForSubqueries(nestedNode, idCounter, result, allTables, false, false, inner, outerST)
+						}
+						return false, nil
+					}
+				}
+			}
+			return true, nil
 		case *sqlparser.Subquery:
 			outerIDBeforeIncrement := *idCounter
 			*idCounter++

--- a/executor/explain.go
+++ b/executor/explain.go
@@ -3215,11 +3215,27 @@ func (e *Executor) walkForSubqueries(node sqlparser.SQLNode, idCounter *int64, r
 	_ = sqlparser.Walk(func(n sqlparser.SQLNode) (bool, error) {
 		switch sub := n.(type) {
 		case *sqlparser.ExistsExpr:
-			// Handle NOT EXISTS / EXISTS anti-join pattern when semijoin-flattening is disabled.
-			// When the outer query cannot be semijoin-flattened (outerCanSemijoin=false),
-			// MySQL emits anti-join rows at the outer query id, not as a new SUBQUERY block.
+			// Handle NOT EXISTS / EXISTS anti-join pattern: only when the EXISTS inner SELECT
+			// contains nested scalar subqueries. In that case, MySQL cannot use a simple
+			// semijoin/anti-join and instead emits the inner tables at the outer query id
+			// level (id=outerQueryID, PRIMARY/SIMPLE) with "Using where; Not exists",
+			// while the nested scalar subquery gets a new id.
+			// A simple EXISTS without nested subqueries is NOT handled here — it falls
+			// through to the regular Subquery case via return true, nil.
 			if !outerCanSemijoin {
 				if inner, ok := sub.Subquery.Select.(*sqlparser.Select); ok {
+					// Only apply anti-join handling if the EXISTS inner SELECT has nested subqueries.
+					innerHasNestedSubquery := false
+					_ = sqlparser.Walk(func(n2 sqlparser.SQLNode) (bool, error) {
+						if _, ok2 := n2.(*sqlparser.Subquery); ok2 {
+							innerHasNestedSubquery = true
+							return false, nil
+						}
+						return true, nil
+					}, inner.SelectExprs, inner.Where, inner.Having)
+					if !innerHasNestedSubquery {
+						return true, nil
+					}
 					var innerFromTables []string
 					for _, te := range inner.From {
 						for _, tn := range e.extractAllTableNames(te) {


### PR DESCRIPTION
## Summary

- `NOT EXISTS` subqueries containing nested scalar subqueries were incorrectly showing `select_type = SIMPLE` instead of the correct MySQL 8.0 anti-join output (`id=1, PRIMARY` for inner table + `DEPENDENT SUBQUERY` for nested scalar).
- Root cause: `queryCanBeSemijoinFlattened()` did not check whether the EXISTS inner SELECT contained nested subqueries, so it incorrectly flattened everything into SIMPLE.
- Fix: two changes to `executor/explain.go`:
  1. **`queryCanBeSemijoinFlattened`**: when an EXISTS inner SELECT has nested `*sqlparser.Subquery` nodes in SelectExprs/Where/Having, set `allFlattenable=false` so the query is not semijoin-flattened.
  2. **`walkForSubqueries`**: add a `case *sqlparser.ExistsExpr` before `case *sqlparser.Subquery`. When `outerCanSemijoin=false` AND the EXISTS inner SELECT has nested subqueries, emit the inner FROM tables as `PRIMARY` rows at the outer query id with `extra="Using where; Not exists"`, use up an id slot for the EXISTS wrapper, and recursively walk nested subqueries.

The anti-join handler correctly restricts to the case where the EXISTS body contains nested scalar subqueries — simple EXISTS without nesting still produces `id=N, SUBQUERY` as before.

## Results

Baseline (before): Pass=1676, Fail=303, Error=119, Skip=1247  
After: Pass=1677, Fail=302, Error=119, Skip=1247

- `other/subselect_innodb`: FAIL → PASS ✓
- Zero regressions

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./... -count=1` passes (all executor and harness tests)
- [x] `go run ./cmd/mtrrun -force -test other/subselect_innodb` — PASS
- [x] Full suite run: Pass=1677 (+1), Fail=302 (-1), no regressions

Refs #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)