### PR TITLE
fix: GROUP_CONCAT ORDER BY collation-aware sort and DISTINCT dedup (#80)

### DIFF
--- a/executor/expr_eval.go
+++ b/executor/expr_eval.go
@@ -8019,6 +8019,40 @@ func extractFromDatabase(expr sqlparser.TableExpr) string {
 	return ""
 }
 
+// compareByCollationNoTieBreak compares two values using the given collation,
+// but unlike compareByCollation it does NOT apply a secondary tie-break based on
+// the raw string when collation keys are equal. This is used for GROUP_CONCAT ORDER BY
+// where MySQL relies on stable sort to preserve insertion order for equal elements
+// (e.g. 'D' and 'd' under utf8mb4_0900_ai_ci should be considered truly equal).
+func compareByCollationNoTieBreak(a, b interface{}, collation string) int {
+	if a == nil && b == nil {
+		return 0
+	}
+	if a == nil {
+		return -1
+	}
+	if b == nil {
+		return 1
+	}
+
+	aIsStr := isStringValue(a)
+	bIsStr := isStringValue(b)
+	if aIsStr || bIsStr {
+		aStr := toString(a)
+		bStr := toString(b)
+		sa := normalizeCollationKey(aStr, collation)
+		sb := normalizeCollationKey(bStr, collation)
+		if sa < sb {
+			return -1
+		}
+		if sa > sb {
+			return 1
+		}
+		return 0 // no tie-break: equal collation keys are treated as equal
+	}
+	return compareNumeric(a, b)
+}
+
 func compareByCollation(a, b interface{}, collation string) int {
 	if a == nil && b == nil {
 		return 0

--- a/executor/group_concat_order_test.go
+++ b/executor/group_concat_order_test.go
@@ -1,0 +1,145 @@
+package executor
+
+import (
+	"testing"
+
+	"github.com/myuon/mylite/catalog"
+	"github.com/myuon/mylite/storage"
+)
+
+func TestGroupConcatOrderByAscCI(t *testing.T) {
+	cat := catalog.New()
+	st := storage.NewEngine()
+	exec := New(cat, st)
+
+	queries := []string{
+		"create table t1 (grp int, c char(10) not null)",
+		"insert into t1 values (3,'E')",
+		"insert into t1 values (3,'C')",
+		"insert into t1 values (3,'D')",
+		"insert into t1 values (3,'d')",
+		"insert into t1 values (3,'d')",
+		"insert into t1 values (3,'D')",
+	}
+	for _, q := range queries {
+		_, err := exec.Execute(q)
+		if err != nil {
+			t.Fatalf("setup query %q failed: %v", q, err)
+		}
+	}
+
+	// Test GROUP_CONCAT ORDER BY c ASC (case-insensitive)
+	result, err := exec.Execute("select group_concat(c order by c) from t1 group by grp")
+	if err != nil {
+		t.Fatalf("query failed: %v", err)
+	}
+	if len(result.Rows) == 0 {
+		t.Fatal("no rows returned")
+	}
+	got := toString(result.Rows[0][0])
+	// Under utf8mb4_0900_ai_ci: C=c, D=d, so sorted: C,D,d,d,D,E (stable sort preserves insertion order for equal)
+	if got != "C,D,d,d,D,E" {
+		t.Errorf("expected 'C,D,d,d,D,E', got %q", got)
+	}
+}
+
+func TestGroupConcatOrderByDescCI(t *testing.T) {
+	cat := catalog.New()
+	st := storage.NewEngine()
+	exec := New(cat, st)
+
+	queries := []string{
+		"create table t1 (grp int, c char(10) not null)",
+		"insert into t1 values (2,'b')",
+		"insert into t1 values (2,'c')",
+	}
+	for _, q := range queries {
+		_, err := exec.Execute(q)
+		if err != nil {
+			t.Fatalf("setup query %q failed: %v", q, err)
+		}
+	}
+
+	result, err := exec.Execute(`select group_concat(distinct c order by c desc separator ",") from t1 group by grp`)
+	if err != nil {
+		t.Fatalf("query failed: %v", err)
+	}
+	if len(result.Rows) == 0 {
+		t.Fatal("no rows returned")
+	}
+	got := toString(result.Rows[0][0])
+	if got != "c,b" {
+		t.Errorf("expected 'c,b', got %q", got)
+	}
+}
+
+func TestGroupConcatDistinctCI(t *testing.T) {
+	cat := catalog.New()
+	st := storage.NewEngine()
+	exec := New(cat, st)
+
+	queries := []string{
+		"create table t1 (grp int, c char(10) not null)",
+		"insert into t1 values (3,'E')",
+		"insert into t1 values (3,'C')",
+		"insert into t1 values (3,'D')",
+		"insert into t1 values (3,'d')",
+		"insert into t1 values (3,'d')",
+		"insert into t1 values (3,'D')",
+	}
+	for _, q := range queries {
+		_, err := exec.Execute(q)
+		if err != nil {
+			t.Fatalf("setup query %q failed: %v", q, err)
+		}
+	}
+
+	// DISTINCT with ORDER BY ASC: unique values (C, D, E) sorted ascending
+	result, err := exec.Execute("select group_concat(distinct c order by c) from t1 group by grp")
+	if err != nil {
+		t.Fatalf("query failed: %v", err)
+	}
+	if len(result.Rows) == 0 {
+		t.Fatal("no rows returned")
+	}
+	got := toString(result.Rows[0][0])
+	if got != "C,D,E" {
+		t.Errorf("expected 'C,D,E', got %q", got)
+	}
+}
+
+func TestGroupConcatNullValues(t *testing.T) {
+	cat := catalog.New()
+	st := storage.NewEngine()
+	exec := New(cat, st)
+
+	queries := []string{
+		"create table t1 (grp int, c char(10))",
+		"insert into t1 values (1,NULL)",
+		"insert into t1 values (2,'b')",
+		"insert into t1 values (2,NULL)",
+	}
+	for _, q := range queries {
+		_, err := exec.Execute(q)
+		if err != nil {
+			t.Fatalf("setup query %q failed: %v", q, err)
+		}
+	}
+
+	result, err := exec.Execute("select grp, group_concat(c order by c) from t1 group by grp")
+	if err != nil {
+		t.Fatalf("query failed: %v", err)
+	}
+	if len(result.Rows) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(result.Rows))
+	}
+	// grp=1: all NULL → result should be NULL
+	if result.Rows[0][1] != nil {
+		t.Errorf("grp=1 expected NULL, got %v", result.Rows[0][1])
+	}
+	// grp=2: has 'b' (non-NULL) → result should be 'b'
+	got2 := toString(result.Rows[1][1])
+	if got2 != "b" {
+		t.Errorf("grp=2 expected 'b', got %q", got2)
+	}
+}

--- a/executor/select.go
+++ b/executor/select.go
@@ -4974,20 +4974,38 @@ func evalAggregateExpr(expr sqlparser.Expr, groupRows []storage.Row, repRow stor
 		// Apply ORDER BY if present
 		sortedRows := make([]storage.Row, len(groupRows))
 		copy(sortedRows, groupRows)
+		// Determine the collation to use for sorting and distinct deduplication.
+		// Use the session's collation_connection (default: utf8mb4_0900_ai_ci).
+		gcCollation := "utf8mb4_0900_ai_ci"
+		if exec != nil {
+			if cv, ok := exec.getSysVar("collation_connection"); ok && cv != "" {
+				gcCollation = cv
+			}
+		}
 		if len(e.OrderBy) > 0 {
 			sort.SliceStable(sortedRows, func(i, j int) bool {
 				for _, ord := range e.OrderBy {
-					vi, _ := evalRowExpr(ord.Expr, sortedRows[i])
-					vj, _ := evalRowExpr(ord.Expr, sortedRows[j])
-					lt, _ := compareValues(vi, vj, sqlparser.LessThanOp)
-					eq, _ := compareValues(vi, vj, sqlparser.EqualOp)
-					if eq {
+					// Resolve positional ORDER BY (e.g. ORDER BY 1 refers to the first
+					// expression in the GROUP_CONCAT expression list).
+					ordExpr := ord.Expr
+					if lit, ok := ordExpr.(*sqlparser.Literal); ok && lit.Type == sqlparser.IntVal {
+						if pos, err2 := strconv.Atoi(lit.Val); err2 == nil && pos >= 1 && pos <= len(e.Exprs) {
+							ordExpr = e.Exprs[pos-1]
+						}
+					}
+					vi, _ := evalRowExpr(ordExpr, sortedRows[i])
+					vj, _ := evalRowExpr(ordExpr, sortedRows[j])
+					// Use collation-aware comparison without tie-breaking on raw string value.
+					// For equal collation-key values (e.g. D and d under _ci), the stable
+					// sort preserves insertion order, matching MySQL behavior.
+					cmp := compareByCollationNoTieBreak(vi, vj, gcCollation)
+					if cmp == 0 {
 						continue
 					}
 					if ord.Direction == sqlparser.DescOrder {
-						return !lt
+						return cmp > 0
 					}
-					return lt
+					return cmp < 0
 				}
 				return false
 			})
@@ -5013,12 +5031,19 @@ func evalAggregateExpr(expr sqlparser.Expr, groupRows []storage.Row, repRow stor
 			}
 			s := part.String()
 			if e.Distinct {
-				if _, ok := distinct[s]; ok {
+				// Use collation key for deduplication so that case-insensitive
+				// collations treat 'D' and 'd' as the same value (matching MySQL behavior).
+				distinctKey := normalizeCollationKey(s, gcCollation)
+				if _, ok := distinct[distinctKey]; ok {
 					continue
 				}
-				distinct[s] = struct{}{}
+				distinct[distinctKey] = struct{}{}
 			}
 			out = append(out, s)
+		}
+		// MySQL returns NULL when all input values were NULL (i.e., no non-NULL values contributed).
+		if len(out) == 0 {
+			return nil, nil
 		}
 		result := strings.Join(out, sep)
 		// Apply group_concat_max_len limit.


### PR DESCRIPTION
## Summary

- **GROUP_CONCAT ORDER BY**: replaced case-sensitive `compareValues()` with collation-aware `compareByCollationNoTieBreak()`, so that `'D'` and `'d'` sort as equal under `utf8mb4_0900_ai_ci` (MySQL default), and stable sort preserves insertion order for equal elements
- **GROUP_CONCAT DISTINCT**: apply collation-aware deduplication, treating `'D'` and `'d'` as the same value under case-insensitive collations (matching MySQL behavior)
- **Positional ORDER BY**: resolve `ORDER BY N` in GROUP_CONCAT to the N-th expression in the GROUP_CONCAT argument list (e.g. `GROUP_CONCAT(c ORDER BY 1)` = `ORDER BY c`)
- **NULL handling**: return `NULL` when all input values to GROUP_CONCAT are NULL (previously returned empty string `""`)
- **New helper**: added `compareByCollationNoTieBreak()` in `expr_eval.go` — same as `compareByCollation()` but without secondary tie-break on raw string value for CI collations

## Affected test

- `other/func_gconcat`: first-diff-line improved from **44 → 114** (lines 44–113 now match expected output)
- `other/subselect_innodb`: **fail → pass** (indirect benefit from DISTINCT dedup fix)
- No regressions (Pass +1, Fail -1, Error -1 vs baseline)

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./... -count=1` passes (including new `TestGroupConcatOrderByAscCI`, `TestGroupConcatOrderByDescCI`, `TestGroupConcatDistinctCI`, `TestGroupConcatNullValues`)
- [x] Full mtrrun suite: Pass 1677 (+1), Fail 302 (-1), Error 118 (-1), no regressions
- [x] `other/func_gconcat` first-diff-line: 44 → 114

Refs #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)