### PR TITLE
feat: BEFORE/AFTER INSERT triggers (Refs #91)

### DIFF
--- a/executor/coerce.go
+++ b/executor/coerce.go
@@ -2504,9 +2504,32 @@ func coerceIntegerValue(colType string, v interface{}) interface{} {
 	return intVal
 }
 
+// defaultZerofillWidth returns the default display width for a ZEROFILL integer type.
+// In MySQL, ZEROFILL columns without explicit width use the default display width
+// for the integer type (e.g., INT ZEROFILL defaults to 10 digits).
+func defaultZerofillWidth(upperColType string) int {
+	// Get base type (strip UNSIGNED, ZEROFILL, whitespace)
+	base := upperColType
+	base = strings.ReplaceAll(base, "UNSIGNED", "")
+	base = strings.ReplaceAll(base, "ZEROFILL", "")
+	base = strings.TrimSpace(base)
+	switch {
+	case strings.HasPrefix(base, "TINYINT"):
+		return 3
+	case strings.HasPrefix(base, "SMALLINT"):
+		return 5
+	case strings.HasPrefix(base, "MEDIUMINT"):
+		return 8
+	case strings.HasPrefix(base, "BIGINT"):
+		return 20
+	default: // INT, INTEGER
+		return 10
+	}
+}
+
 // applyIntZerofill applies ZEROFILL zero-padding to an integer value for display.
 // The display width is extracted from the column type (e.g., "INT(2) ZEROFILL" -> width 2).
-// Returns a zero-padded string if a display width is specified, otherwise returns val unchanged.
+// If no explicit width is given, the MySQL default display width for the type is used.
 func applyIntZerofill(val interface{}, upperColType string) interface{} {
 	// Extract display width from INT(N), TINYINT(N), etc.
 	var width int
@@ -2514,6 +2537,10 @@ func applyIntZerofill(val interface{}, upperColType string) interface{} {
 		if n, err := fmt.Sscanf(upperColType[idx:], "(%d)", &width); err != nil || n == 0 {
 			width = 0
 		}
+	}
+	if width <= 0 {
+		// No explicit width: use MySQL default display width for the type
+		width = defaultZerofillWidth(upperColType)
 	}
 	if width <= 0 {
 		return val

--- a/executor/dml_delete.go
+++ b/executor/dml_delete.go
@@ -512,6 +512,14 @@ func (e *Executor) execDelete(stmt *sqlparser.Delete) (*Result, error) {
 
 	newRows := make([]storage.Row, 0)
 	var affected uint64
+	// afterDeleteRows collects rows that need AFTER DELETE trigger firing.
+	// We fire AFTER DELETE triggers after the row has been physically removed from tbl.Rows,
+	// so that trigger queries (e.g. SELECT COUNT(*)) see the post-deletion state.
+	type afterDeleteEntry struct {
+		row storage.Row
+	}
+	var afterDeleteRows []afterDeleteEntry
+
 	for _, row := range tbl.Rows {
 		match := true
 		if stmt.Where != nil {
@@ -554,14 +562,8 @@ func (e *Executor) execDelete(stmt *sqlparser.Delete) (*Result, error) {
 			tbl.Lock()
 
 			affected++
-
-			// Fire AFTER DELETE triggers
-			tbl.Unlock()
-			if err := e.fireTriggers(tableName, "AFTER", "DELETE", nil, row); err != nil {
-				tbl.Lock()
-				return nil, err
-			}
-			tbl.Lock()
+			// Collect row for AFTER DELETE trigger (fired after tbl.Rows is updated)
+			afterDeleteRows = append(afterDeleteRows, afterDeleteEntry{row: row})
 		} else {
 			newRows = append(newRows, row)
 		}
@@ -572,6 +574,17 @@ func (e *Executor) execDelete(stmt *sqlparser.Delete) (*Result, error) {
 		tbl.HeapInsertFront = true
 	}
 	tbl.InvalidateIndexes()
+
+	// Fire AFTER DELETE triggers now that tbl.Rows reflects the post-deletion state.
+	// This ensures trigger queries (e.g. SELECT COUNT(*)) see the correct row counts.
+	for _, entry := range afterDeleteRows {
+		tbl.Unlock()
+		if err := e.fireTriggers(tableName, "AFTER", "DELETE", nil, entry.row); err != nil {
+			tbl.Lock()
+			return nil, err
+		}
+		tbl.Lock()
+	}
 
 	return &Result{AffectedRows: affected}, nil
 }

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -3029,6 +3029,39 @@ func stripWithClausePrefix(query string) string {
 	return strings.TrimSpace(q[i:])
 }
 
+// extractExplicitStringAlias checks if a raw SELECT expression has an explicit
+// AS '...' or AS "..." alias. Returns (alias, true) if found, ("", false) otherwise.
+// This is needed because vitess treats AS "" as no alias (IsEmpty() returns true),
+// but MySQL uses the empty string as the column name.
+func extractExplicitStringAlias(raw string) (string, bool) {
+	// Look for " AS " (case-insensitive) followed by a quoted string at the end.
+	// Returns (alias, true) if found, ("", false) otherwise.
+	// This is needed because Vitess treats AS "" as no alias (IsEmpty() returns true),
+	// but MySQL uses the empty string as the explicit column name.
+	rLower := strings.ToLower(strings.TrimSpace(raw))
+	i := len(rLower) - 1
+	for i >= 3 {
+		if rLower[i] == '\'' || rLower[i] == '"' {
+			// Found a closing quote; find the matching opening quote.
+			quote := rLower[i]
+			j := i - 1
+			for j >= 0 && rLower[j] != quote {
+				j--
+			}
+			if j >= 0 {
+				// Check if preceded by " as" (space or tab before "as").
+				before := strings.TrimRight(rLower[:j], " \t")
+				if strings.HasSuffix(before, " as") || strings.HasSuffix(before, "\tas") {
+					// Extract the alias content (between the quotes), using original case.
+					return raw[j+1 : i], true
+				}
+			}
+		}
+		i--
+	}
+	return "", false
+}
+
 func extractRawSelectExprs(query string) []string {
 	q := strings.TrimSpace(query)
 	lq := strings.ToLower(q)

--- a/executor/procedures.go
+++ b/executor/procedures.go
@@ -27,14 +27,70 @@ func (e *Executor) execCreateTrigger(query string) (*Result, error) {
 	// Remove "CREATE TRIGGER " prefix
 	rest := strings.TrimSpace(query[len("CREATE TRIGGER "):])
 
+	// Helper to return a MySQL-style syntax error.
+	// lineNum: pass 0 to auto-detect from query newlines.
+	syntaxError := func(near string, lineNum int) error {
+		if near == "" {
+			near = rest
+		}
+		// Truncate at newline to avoid multi-line near text
+		if nl := strings.IndexAny(near, "\n\r"); nl >= 0 {
+			near = near[:nl]
+		}
+		near = strings.TrimSpace(near)
+		// Truncate to a reasonable length
+		if len(near) > 80 {
+			near = near[:80]
+		}
+		if lineNum <= 0 {
+			lineNum = 1 + strings.Count(query, "\n")
+		}
+		return mysqlError(1064, "42000", fmt.Sprintf(
+			"You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '%s' at line %d",
+			near, lineNum))
+	}
+
 	// Extract trigger name
 	parts := strings.Fields(rest)
 	if len(parts) < 6 {
-		return nil, fmt.Errorf("invalid CREATE TRIGGER syntax")
+		return nil, syntaxError(rest, 1)
 	}
-	triggerName := parts[0]
+	rawName := parts[0]
+	// If name is backtick-quoted, strip the backticks
+	isQuoted := len(rawName) >= 2 && rawName[0] == '`' && rawName[len(rawName)-1] == '`'
+	triggerName := strings.Trim(rawName, "`")
+
+	// Validate trigger name: must be a valid MySQL identifier (unquoted names).
+	// If not backtick-quoted, must match [a-zA-Z_$][a-zA-Z0-9_$]* pattern.
+	if !isQuoted {
+		validNameRe := regexp.MustCompile(`^[a-zA-Z_$][a-zA-Z0-9_$]*$`)
+		if !validNameRe.MatchString(triggerName) {
+			return nil, syntaxError(triggerName+" "+strings.Join(parts[1:], " "), 1)
+		}
+		// Reserved words cannot be trigger names (without quoting)
+		reservedForTrigger := map[string]bool{
+			"trigger": true, "select": true, "insert": true, "update": true, "delete": true,
+			"create": true, "drop": true, "table": true, "view": true, "index": true,
+			"procedure": true, "function": true, "database": true, "schema": true,
+		}
+		if reservedForTrigger[strings.ToLower(triggerName)] {
+			return nil, syntaxError(triggerName+" "+strings.Join(parts[1:], " "), 1)
+		}
+	}
+
+	// Validate trigger name length (MySQL identifier max = 64 chars)
+	if len(triggerName) > 64 {
+		return nil, mysqlError(1059, "42000", fmt.Sprintf("Identifier name '%s' is too long", triggerName))
+	}
 	timing := strings.ToUpper(parts[1]) // BEFORE or AFTER
 	event := strings.ToUpper(parts[2])  // INSERT, UPDATE, or DELETE
+
+	// Validate timing and event
+	validTiming := timing == "BEFORE" || timing == "AFTER"
+	validEvent := event == "INSERT" || event == "UPDATE" || event == "DELETE"
+	if !validTiming || !validEvent {
+		return nil, syntaxError(parts[1], 1)
+	}
 
 	// Find "ON" keyword
 	onIdx := -1
@@ -45,29 +101,53 @@ func (e *Executor) execCreateTrigger(query string) (*Result, error) {
 		}
 	}
 	if onIdx < 0 {
-		return nil, fmt.Errorf("invalid CREATE TRIGGER syntax: missing ON")
+		return nil, syntaxError(rest, 1)
 	}
-	tableName := parts[onIdx+1]
-	tableName = strings.Trim(tableName, "`")
+	rawTableName := strings.Trim(parts[onIdx+1], "`")
+	trigDB := e.CurrentDB
 
-	// Check if table references performance_schema — deny CREATE TRIGGER on PS tables
-	if strings.Contains(tableName, ".") {
-		dbTbl := strings.SplitN(tableName, ".", 2)
-		trigDB := strings.Trim(dbTbl[0], "`")
-		if strings.EqualFold(trigDB, "performance_schema") {
+	// Handle qualified table names (e.g. test.t1)
+	if strings.Contains(rawTableName, ".") {
+		dbTbl := strings.SplitN(rawTableName, ".", 2)
+		qualDB := strings.Trim(dbTbl[0], "`")
+		qualTbl := strings.Trim(dbTbl[1], "`")
+		// Check if table references performance_schema — deny CREATE TRIGGER on PS tables
+		if strings.EqualFold(qualDB, "performance_schema") {
 			return nil, mysqlError(1044, "42000", fmt.Sprintf("Access denied for user 'root'@'localhost' to database 'performance_schema'"))
 		}
+		// Trigger must be created in the same database as the table
+		if !strings.EqualFold(qualDB, e.CurrentDB) {
+			return nil, mysqlError(1435, "HY000", fmt.Sprintf("Trigger in wrong schema"))
+		}
+		trigDB = qualDB
+		rawTableName = qualTbl
 	}
+	tableName := rawTableName
+	_ = trigDB // used for the db to store the trigger
 
-	// Extract body: everything after "FOR EACH ROW"
+	// Extract body: everything after "FOR EACH ROW".
+	// "FOR EACH ROW" must appear AFTER the "ON table_name" position.
 	// Use a regex to handle variable whitespace (e.g. "FOR  EACH ROW" with two spaces).
 	_ = upper // already have it
 	forEachRe := regexp.MustCompile(`(?i)FOR\s+EACH\s+ROW`)
-	forEachLoc := forEachRe.FindStringIndex(query)
-	if forEachLoc == nil {
-		return nil, fmt.Errorf("invalid CREATE TRIGGER syntax: missing FOR EACH ROW")
+
+	// Find the position of "ON tableName" in the original query
+	onTableRe := regexp.MustCompile(`(?i)\bON\s+\S+`)
+	onTableLoc := onTableRe.FindStringIndex(query)
+	onTableEnd := 0
+	if onTableLoc != nil {
+		onTableEnd = onTableLoc[1]
 	}
-	body := strings.TrimSpace(query[forEachLoc[1]:])
+
+	// Find "FOR EACH ROW" that appears AFTER "ON tableName"
+	queryAfterOn := query[onTableEnd:]
+	forEachLoc := forEachRe.FindStringIndex(queryAfterOn)
+	if forEachLoc == nil {
+		return nil, syntaxError(rest, 0)
+	}
+	// Adjust to absolute position in original query
+	forEachAbsEnd := onTableEnd + forEachLoc[1]
+	body := strings.TrimSpace(query[forEachAbsEnd:])
 
 	// Strip optional FOLLOWS <trigger_name> or PRECEDES <trigger_name> clause.
 	// These are ordering hints; we ignore the ordering and just store the body.
@@ -100,6 +180,18 @@ func (e *Executor) execCreateTrigger(query string) (*Result, error) {
 		// Single statement trigger
 		body = strings.TrimRight(body, ";")
 		bodyStatements = []string{strings.TrimSpace(body)}
+	}
+
+	// Validate: trigger body must not be empty
+	hasBody := false
+	for _, stmt := range bodyStatements {
+		if strings.TrimSpace(stmt) != "" {
+			hasBody = true
+			break
+		}
+	}
+	if !hasBody {
+		return nil, syntaxError(rest, 1)
 	}
 
 	// Validate: AFTER triggers cannot modify NEW row
@@ -395,9 +487,17 @@ func (e *Executor) fireTriggers(tableName, timing, event string, newRow, oldRow 
 		e.functionOrTriggerDepth++
 		for _, stmtStr := range tr.Body {
 			stmtUpper := strings.ToUpper(strings.TrimSpace(stmtStr))
-			// Handle SET NEW.col = value in BEFORE triggers
-			if strings.HasPrefix(stmtUpper, "SET NEW.") && timing == "BEFORE" && newRow != nil {
-				e.handleSetNew(stmtStr, newRow, oldRow)
+			// Handle SET statements in BEFORE triggers that contain NEW.col assignments.
+			// This includes both simple "SET NEW.col = val" and compound statements like
+			// "SET @var = val, NEW.col = @var". We handle these specially to avoid
+			// resolveNewOldRefs substituting NEW.col values in assignment targets.
+			if strings.HasPrefix(stmtUpper, "SET ") && timing == "BEFORE" && newRow != nil &&
+				containsNewColAssignment(stmtUpper) {
+				if err := e.handleSetWithNew(stmtStr, newRow, oldRow); err != nil {
+					e.routineDepth--
+					e.functionOrTriggerDepth--
+					return err
+				}
 				continue
 			}
 			// Substitute NEW.col and OLD.col references
@@ -463,6 +563,72 @@ func (e *Executor) fireTriggerWithRoutineInterpreter(tr *catalog.TriggerDef, tim
 		}
 	}
 
+	return nil
+}
+
+// containsNewColAssignment checks if a SET statement (already uppercased) contains
+// a NEW.col assignment like "SET NEW.col = val" or "SET @v = x, NEW.col = y".
+func containsNewColAssignment(stmtUpper string) bool {
+	// Look for "NEW." followed by an identifier, occurring as an assignment target.
+	// It must be at the start (after SET) or after a comma.
+	rest := strings.TrimSpace(stmtUpper[4:]) // strip "SET "
+	// Scan comma-delimited assignments
+	parts := splitSetAssignments(rest)
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if strings.HasPrefix(part, "NEW.") {
+			return true
+		}
+	}
+	return false
+}
+
+// handleSetWithNew processes a SET statement in a BEFORE trigger that contains
+// one or more NEW.col assignments (possibly mixed with @var assignments).
+// Non-NEW assignments are executed immediately (so @var values are up-to-date
+// when later NEW.col = @var assignments are evaluated).
+func (e *Executor) handleSetWithNew(stmtStr string, newRow, oldRow storage.Row) error {
+	rest := strings.TrimSpace(stmtStr)
+	// Strip "SET " prefix (case-insensitive)
+	if len(rest) < 4 || !strings.EqualFold(rest[:4], "set ") {
+		return nil
+	}
+	rest = strings.TrimSpace(rest[4:])
+	rest = strings.TrimRight(rest, ";")
+
+	parts := splitSetAssignments(rest)
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		partUpper := strings.ToUpper(part)
+		if strings.HasPrefix(partUpper, "NEW.") {
+			// Parse: NEW.col = expr
+			eqIdx := strings.Index(part, "=")
+			if eqIdx < 0 {
+				continue
+			}
+			colRef := strings.TrimSpace(part[:eqIdx])
+			valExpr := strings.TrimSpace(part[eqIdx+1:])
+			// colRef is "NEW.colname"
+			colName := colRef[4:] // strip "NEW."
+			// Resolve OLD/NEW references in the value expression
+			resolved := e.resolveNewOldRefs(valExpr, newRow, oldRow)
+			// Evaluate the value expression (can reference @vars set in earlier assignments)
+			val, err := e.evaluateSimpleExpr(resolved)
+			if err != nil {
+				return err
+			}
+			newRow[colName] = val
+		} else {
+			// Regular assignment (e.g. @var = expr): execute as SQL
+			_, err := e.Execute("SET " + part)
+			if err != nil {
+				return err
+			}
+		}
+	}
 	return nil
 }
 

--- a/executor/select.go
+++ b/executor/select.go
@@ -3969,8 +3969,21 @@ func (e *Executor) execSelectGroupBy(stmt *sqlparser.Select, allRows []storage.R
 	for _, expr := range stmt.SelectExprs.Exprs {
 		switch se := expr.(type) {
 		case *sqlparser.AliasedExpr:
+			// Vitess treats AS "" as no alias (IsEmpty()=true), but MySQL uses ""
+			// as the explicit column name. Check raw text for explicit string alias first.
+			rawForAlias := ""
+			if rawExprIdx < len(rawExprs) {
+				rawForAlias = strings.TrimSpace(rawExprs[rawExprIdx])
+			}
 			if !se.As.IsEmpty() {
 				colNames = append(colNames, se.As.String())
+				rawExprIdx++
+				continue
+			} else if alias, ok := extractExplicitStringAlias(rawForAlias); ok {
+				// Explicit string alias (e.g. AS "" or AS 'name') detected in raw text
+				colNames = append(colNames, alias)
+				rawExprIdx++
+				continue
 			} else if isAggregateExpr(se.Expr) {
 				// Use raw expression text for aggregates, then normalize
 				// MySQL displays function args without space after comma: JSON_OBJECTAGG(k,b)
@@ -5680,6 +5693,16 @@ func (e *Executor) resolveSelectExprs(exprs []sqlparser.SelectExpr, rows []stora
 			rawExprIdx++
 		case *sqlparser.AliasedExpr:
 			name := ""
+			// Check for explicit string alias (e.g. AS "" or AS 'name') in raw text FIRST,
+			// because Vitess treats AS "" as no alias (IsEmpty() returns true), but MySQL uses "" as column name.
+			if rawExprIdx < len(rawExprs) {
+				if alias, ok := extractExplicitStringAlias(strings.TrimSpace(rawExprs[rawExprIdx])); ok {
+					cols = append(cols, alias)
+					colExprs = append(colExprs, se.Expr)
+					rawExprIdx++
+					continue
+				}
+			}
 			if !se.As.IsEmpty() {
 				name = se.As.String()
 			} else if lit, ok := se.Expr.(*sqlparser.Literal); ok && lit.Type == sqlparser.StrVal {
@@ -6855,6 +6878,38 @@ func (e *Executor) execSelectNoFrom(stmt *sqlparser.Select) (*Result, error) {
 		switch se := expr.(type) {
 		case *sqlparser.AliasedExpr:
 			name := ""
+			// Check for explicit string alias (e.g. AS "" or AS 'name') in raw text FIRST,
+			// because Vitess treats AS "" as no alias (IsEmpty() returns true), but MySQL uses "" as column name.
+			if rawExprIdx < len(rawExprs) {
+				if alias, ok := extractExplicitStringAlias(strings.TrimSpace(rawExprs[rawExprIdx])); ok {
+					name = alias
+					colNames = append(colNames, name)
+					rawExprIdx++
+					// Evaluate the value for this expression and continue
+					if containsWindowFunc(se.Expr) {
+						syntheticRow := storage.Row{}
+						syntheticAllRows := []storage.Row{syntheticRow}
+						syntheticResultRows := [][]interface{}{{nil}}
+						wfInfo := findWindowFuncs([]sqlparser.Expr{se.Expr})
+						if len(wfInfo) > 0 {
+							wfInfo = resolveNamedWindows(wfInfo, stmt.Windows)
+							for _, wf := range wfInfo {
+								if err := e.computeWindowFunc(wf, syntheticAllRows, syntheticResultRows); err != nil {
+									return nil, err
+								}
+							}
+							values = append(values, syntheticResultRows[0][0])
+							continue
+						}
+					}
+					v, err := e.evalExpr(se.Expr)
+					if err != nil {
+						return nil, err
+					}
+					values = append(values, v)
+					continue
+				}
+			}
 			if !se.As.IsEmpty() {
 				name = se.As.String()
 			} else if lit, ok := se.Expr.(*sqlparser.Literal); ok && lit.Type == sqlparser.StrVal {

--- a/executor/test_empty_alias_test.go
+++ b/executor/test_empty_alias_test.go
@@ -1,0 +1,44 @@
+package executor
+
+import (
+	"testing"
+	"github.com/myuon/mylite/catalog"
+	"github.com/myuon/mylite/storage"
+)
+
+func TestEmptyStringAlias(t *testing.T) {
+	cat := catalog.New()
+	store := storage.NewEngine()
+	e := New(cat, store)
+	if _, err := e.Execute("CREATE DATABASE IF NOT EXISTS test"); err != nil {
+		t.Fatalf("create db: %v", err)
+	}
+	e.CurrentDB = "test"
+	
+	// Test SELECT @var AS ""
+	e.Execute("SET @utf8_message = 'Testcase: 3.5.1.1:'")
+	res, err := e.Execute(`SELECT @utf8_message AS ""`)
+	if err != nil {
+		t.Fatalf("select: %v", err)
+	}
+	t.Logf("Columns for AS \"\": %v", res.Columns)
+	if len(res.Columns) == 0 {
+		t.Fatal("no columns")
+	}
+	// The column header should be empty string, not the expression text
+	if res.Columns[0] != "" {
+		t.Errorf("expected empty column name for AS \"\", got %q", res.Columns[0])
+	}
+	// Test SELECT @var AS ''
+	res2, err2 := e.Execute(`SELECT @utf8_message AS ''`)
+	if err2 != nil {
+		t.Fatalf("select2: %v", err2)
+	}
+	t.Logf("Columns for AS '': %v", res2.Columns)
+	if len(res2.Columns) == 0 {
+		t.Fatal("no columns2")
+	}
+	if res2.Columns[0] != "" {
+		t.Errorf("expected empty column name for AS '', got %q", res2.Columns[0])
+	}
+}


### PR DESCRIPTION
## Summary

- Fix compound SET in BEFORE triggers: `SET @var=val, NEW.col=expr` now updates both session vars and NEW row (previously only the session var was updated, NEW.col was not modified)
- Fix AFTER DELETE trigger timing: triggers now fire after row removal from storage so queries inside triggers see the correct post-deletion state
- Fix ZEROFILL display for integer columns without explicit width (MySQL defaults: INT=10, BIGINT=20, SMALLINT=5, MEDIUMINT=8, TINYINT=3)
- Fix CREATE TRIGGER parser: validates timing/event order, rejects invalid names (reserved words, special chars, numerics), emits MySQL-format syntax errors with correct line numbers, rejects empty trigger bodies
- Fix `SELECT expr AS ""` column name: vitess treats `AS ""` as no alias but MySQL uses the empty string; added `extractExplicitStringAlias` to detect quoted string aliases in raw SQL text

Refs #91

## Test plan

- [x] `go build ./... && go test ./... -count=1` passes (zero unit test failures)
- [x] `funcs_1/innodb_trig_0102` first-diff-line improved from line 1 to line 201 (vs line 86 before this PR)
- [x] Full `mtrrun` suite: +125 passing, -62 failing, -74 errors vs CLAUDE.md baseline — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)