### PR TITLE
fix: resolve other/rename timeout in chain rename detection (#106)

### DIFF
--- a/executor/ddl.go
+++ b/executor/ddl.go
@@ -156,7 +156,16 @@ func (e *Executor) execRenameTable(stmt *sqlparser.RenameTable) (*Result, error)
 			return false
 		}
 		_, err = catDB.GetTable(name)
-		return err == nil
+		if err == nil {
+			return true
+		}
+		// Also check if it's a view in viewStore.
+		if e.viewStore != nil {
+			if _, isView := e.viewStore.Lookup(db, name); isView {
+				return true
+			}
+		}
+		return false
 	}
 
 	type renamePair struct {
@@ -219,7 +228,17 @@ func (e *Executor) execRenameTable(stmt *sqlparser.RenameTable) (*Result, error)
 
 		def, err := srcCatDB.GetTable(p.oldName)
 		if err != nil {
-			continue // shouldn't happen after validation
+			// May be a view rather than a table — try renaming it in viewStore.
+			if e.viewStore != nil && p.srcDB == p.targetDB {
+				e.viewStore.Rename(p.srcDB, p.oldName, p.newName)
+			}
+			// Transfer lock regardless.
+			if e.tableLockManager != nil {
+				oldKey := p.srcDB + "." + p.oldName
+				newKey := p.targetDB + "." + p.newName
+				e.tableLockManager.RenameTableLock(e.connectionID, oldKey, newKey)
+			}
+			continue
 		}
 		// Rename in catalog
 		def.Name = p.newName
@@ -238,6 +257,14 @@ func (e *Executor) execRenameTable(stmt *sqlparser.RenameTable) (*Result, error)
 		}
 		e.removeInnoDBStatsRows(p.srcDB, p.oldName)
 		e.upsertInnoDBStatsRows(p.targetDB, p.newName, e.tableRowCount(p.targetDB, p.newName))
+		// Transfer table lock to new name when LOCK TABLES is active.
+		// MySQL behavior: after RENAME TABLE under LOCK TABLES, the renamed table
+		// is accessible under the new name with the original lock mode.
+		if e.tableLockManager != nil {
+			oldKey := p.srcDB + "." + p.oldName
+			newKey := p.targetDB + "." + p.newName
+			e.tableLockManager.RenameTableLock(e.connectionID, oldKey, newKey)
+		}
 		// Handle temporary table tracking: if the renamed table was a temp table,
 		// update the tempTables map and restore any saved permanent table.
 		if e.tempTables != nil && e.tempTables[p.oldName] {
@@ -2704,6 +2731,18 @@ func (e *Executor) execAlterTable(stmt *sqlparser.AlterTable) (*Result, error) {
 	// Ensure the storage table exists.
 	tbl, err := e.Storage.GetTable(dbName, tableName)
 	if err != nil {
+		// If a view exists with this name, return ER_WRONG_OBJECT (1347) for
+		// ALTER TABLE ... RENAME operations. For other ALTER operations, still
+		// return "doesn't exist" as the view is not a base table.
+		if e.viewStore != nil {
+			if _, isView := e.viewStore.Lookup(dbName, tableName); isView {
+				for _, opt := range stmt.AlterOptions {
+					if _, ok := opt.(*sqlparser.RenameTableName); ok {
+						return nil, mysqlError(1347, "HY000", fmt.Sprintf("'%s.%s' is not BASE TABLE", dbName, tableName))
+					}
+				}
+			}
+		}
 		return nil, mysqlError(1146, "42S02", fmt.Sprintf("Table '%s.%s' doesn't exist", dbName, tableName))
 	}
 
@@ -3888,6 +3927,12 @@ func (e *Executor) execAlterTable(stmt *sqlparser.AlterTable) (*Result, error) {
 			// Get the current table def
 			def, getErr := db.GetTable(tableName)
 			if getErr != nil {
+				// If a view exists with this name, return ER_WRONG_OBJECT instead of "doesn't exist".
+				if e.viewStore != nil {
+					if _, isView := e.viewStore.Lookup(dbName, tableName); isView {
+						return nil, mysqlError(1347, "HY000", fmt.Sprintf("'%s.%s' is not BASE TABLE", dbName, tableName))
+					}
+				}
 				return nil, mysqlError(1146, "42S02", fmt.Sprintf("Table '%s.%s' doesn't exist", dbName, tableName))
 			}
 			// Determine if the table being renamed is a temporary table

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -1759,6 +1759,13 @@ func (e *Executor) Execute(query string) (res *Result, retErr error) {
 		}
 	}
 
+	// MySQL supports "RENAME TABLES" as a synonym for "RENAME TABLE".
+	// The Vitess parser only recognizes "RENAME TABLE", so rewrite the query.
+	if strings.HasPrefix(upper, "RENAME TABLES ") || strings.EqualFold(strings.TrimSpace(query), "RENAME TABLES") {
+		query = query[:len("RENAME TABLE")] + query[len("RENAME TABLES"):]
+		upper = strings.ToUpper(strings.TrimSpace(query))
+	}
+
 	stmt, err := e.parser().Parse(query)
 	if err != nil {
 		// Accept statements that Vitess parser doesn't support
@@ -3473,6 +3480,61 @@ func (e *Executor) checkTableLockRestrictions(stmt sqlparser.Statement) error {
 					}
 				}
 			}
+		}
+	case *sqlparser.RenameTable:
+		// RENAME TABLE under LOCK TABLES: each source table must be locked for WRITE
+		// unless it is an intermediate name produced by an earlier step in the same
+		// multi-rename statement (MySQL allows chains like t3→t4,t4→t5 when only
+		// t3 is explicitly locked — t4 is implicitly available as it was just created).
+		// Additionally, if a rename would provide a parent for an orphan FK (i.e., a
+		// child table has a FK referencing the new target name), that child table must
+		// be write-locked as well (MySQL behavior for FK invariant safety).
+		introducedByChain := map[string]bool{}
+		for _, pair := range s.TablePairs {
+			srcName := pair.FromTable.Name.String()
+			srcDB := e.CurrentDB
+			if !pair.FromTable.Qualifier.IsEmpty() {
+				srcDB = pair.FromTable.Qualifier.String()
+			}
+			targetName := pair.ToTable.Name.String()
+			targetDB := e.CurrentDB
+			if !pair.ToTable.Qualifier.IsEmpty() {
+				targetDB = pair.ToTable.Qualifier.String()
+			}
+			srcKey := srcDB + "." + srcName
+			// Skip lock check if this source was introduced as a target by a prior
+			// step in the same RENAME statement (intermediate chain table).
+			if !introducedByChain[srcKey] {
+				locked, mode := e.tableLockManager.IsLocked(e.connectionID, srcKey)
+				if !locked {
+					return mysqlError(1100, "HY000", fmt.Sprintf("Table '%s' was not locked with LOCK TABLES", srcName))
+				}
+				if mode == "READ" {
+					return mysqlError(1099, "HY000", fmt.Sprintf("Table '%s' was locked with a READ lock and can't be updated", srcName))
+				}
+			}
+			// Check FK child tables: if any table in the catalog has a FK that
+			// references targetName (the new name), that child table must be write-locked.
+			// This enforces MySQL's FK invariant safety under LOCK TABLES.
+			if catDB, err := e.Catalog.GetDatabase(targetDB); err == nil {
+				for childTableName, childDef := range catDB.Tables {
+					for _, fk := range childDef.ForeignKeys {
+						if strings.EqualFold(fk.ReferencedTable, targetName) {
+							childKey := targetDB + "." + childTableName
+							childLocked, childMode := e.tableLockManager.IsLocked(e.connectionID, childKey)
+							if !childLocked {
+								return mysqlError(1100, "HY000", fmt.Sprintf("Table '%s' was not locked with LOCK TABLES", childTableName))
+							}
+							if childMode == "READ" {
+								return mysqlError(1099, "HY000", fmt.Sprintf("Table '%s' was locked with a READ lock and can't be updated", childTableName))
+							}
+						}
+					}
+				}
+			}
+			// Track target as introduced by this chain step.
+			targetKey := targetDB + "." + targetName
+			introducedByChain[targetKey] = true
 		}
 	case *sqlparser.CreateTable:
 		// CREATE TABLE when LOCK TABLES is active: the new table must be locked

--- a/executor/lock_manager.go
+++ b/executor/lock_manager.go
@@ -534,6 +534,25 @@ func (tlm *TableLockManager) GetLocks(connID int64) map[string]string {
 	return result
 }
 
+// RenameTableLock transfers the lock for oldKey to newKey for the given connection.
+// This implements MySQL's behavior where RENAME TABLE under LOCK TABLES transfers
+// the table lock to the new name.
+func (tlm *TableLockManager) RenameTableLock(connID int64, oldDBTable, newDBTable string) {
+	tlm.mu.Lock()
+	defer tlm.mu.Unlock()
+	m, ok := tlm.locks[connID]
+	if !ok {
+		return
+	}
+	oldKey := strings.ToLower(oldDBTable)
+	mode, exists := m[oldKey]
+	if !exists {
+		return
+	}
+	delete(m, oldKey)
+	m[strings.ToLower(newDBTable)] = mode
+}
+
 // IsLockedByOther checks if a table is locked by any connection OTHER than connID.
 // Returns (true, mode) if locked by another connection, where mode is the strongest
 // lock mode held (WRITE > READ). Returns (false, "") if not locked by others.

--- a/executor/view_store.go
+++ b/executor/view_store.go
@@ -123,6 +123,38 @@ func (vs *ViewStore) LookupCreateSQL(db, name string) (string, bool) {
 	return v, ok
 }
 
+// Rename renames a view from oldName to newName within the given database.
+// Returns true if the view was found and renamed.
+func (vs *ViewStore) Rename(db, oldName, newName string) bool {
+	oldKey := viewKey(db, oldName)
+	newKey := viewKey(db, newName)
+	vs.mu.Lock()
+	defer vs.mu.Unlock()
+	sql, ok := vs.selectSQL[oldKey]
+	if !ok {
+		return false
+	}
+	vs.selectSQL[newKey] = sql
+	delete(vs.selectSQL, oldKey)
+	if v, ok2 := vs.displaySQL[oldKey]; ok2 {
+		vs.displaySQL[newKey] = v
+		delete(vs.displaySQL, oldKey)
+	}
+	if v, ok2 := vs.checkOptions[oldKey]; ok2 {
+		vs.checkOptions[newKey] = v
+		delete(vs.checkOptions, oldKey)
+	}
+	if v, ok2 := vs.createSQL[oldKey]; ok2 {
+		vs.createSQL[newKey] = v
+		delete(vs.createSQL, oldKey)
+	}
+	if v, ok2 := vs.security[oldKey]; ok2 {
+		vs.security[newKey] = v
+		delete(vs.security, oldKey)
+	}
+	return true
+}
+
 // AllViews returns a snapshot of all view entries as (db, name, selectSQL) tuples.
 func (vs *ViewStore) AllViews() []viewEntry {
 	vs.mu.RLock()

--- a/mtrrunner/runner.go
+++ b/mtrrunner/runner.go
@@ -442,9 +442,11 @@ type tableSnapshot struct {
 
 // sendResult holds the result of an asynchronously sent query.
 type sendResult struct {
-	output string
-	err    error
-	query  string // original query (for retry on lock wait timeout)
+	output  string
+	err     error
+	query   string // original query (for retry on lock wait timeout)
+	errno   string // $mysql_errno after the query completes
+	errname string // $mysql_errname after the query completes
 }
 
 // pendingSend tracks a query that was dispatched via the "send" directive.
@@ -1713,6 +1715,13 @@ func (ctx *execContext) handleDirective(directive string) (handled bool, skip bo
 		ctx.replaceRegex = nil // consumed by send
 		sendInfoEnabled := ctx.infoEnabled
 
+		// Copy variables map for goroutine to avoid concurrent map writes.
+		// The goroutine needs a snapshot of current variables (for substitution),
+		// but must not share the map reference with the main goroutine.
+		sendVarsCopy := make(map[string]string, len(ctx.variables))
+		for k, v := range ctx.variables {
+			sendVarsCopy[k] = v
+		}
 		go func() {
 			// Create a temporary execContext for the goroutine to format output.
 			// abortOnError=true ensures that unexpected query errors are returned
@@ -1732,7 +1741,7 @@ func (ctx *execContext) handleDirective(directive string) (handled bool, skip bo
 				resultLogEnabled: sendResultLogEnabled,
 				sortResult:       sendSortResult,
 				tmpDir:           ctx.tmpDir,
-				variables:        ctx.variables,
+				variables:        sendVarsCopy,
 				verticalResult:   sendVerticalResult,
 				verticalResults:  sendVerticalResults,
 				replaceColumns:   sendReplaceColumns,
@@ -1744,7 +1753,14 @@ func (ctx *execContext) handleDirective(directive string) (handled bool, skip bo
 				metadataEnabled:  ctx.metadataEnabled,
 			}
 			err := tmpCtx.executeSQLInner(query)
-			ch <- sendResult{output: tmpCtx.output.String(), err: err, query: query}
+			// Capture errno/errname so reap can propagate them to the parent context.
+			errno := ""
+			errname := ""
+			if tmpCtx.variables != nil {
+				errno = tmpCtx.variables["$mysql_errno"]
+				errname = tmpCtx.variables["$mysql_errname"]
+			}
+			ch <- sendResult{output: tmpCtx.output.String(), err: err, query: query, errno: errno, errname: errname}
 		}()
 		return true, false, nil
 
@@ -1761,6 +1777,14 @@ func (ctx *execContext) handleDirective(directive string) (handled bool, skip bo
 		}
 		result := <-pending.resultCh
 		delete(ctx.pendingSendByConn, connKey)
+		// Propagate $mysql_errno/$mysql_errname from the goroutine to ctx.
+		if result.errno != "" || result.errname != "" {
+			if ctx.variables == nil {
+				ctx.variables = make(map[string]string)
+			}
+			ctx.variables["$mysql_errno"] = result.errno
+			ctx.variables["$mysql_errname"] = result.errname
+		}
 		if result.output != "" {
 			ctx.output.WriteString(result.output)
 		}
@@ -2723,24 +2747,36 @@ func (ctx *execContext) executeQuery(stmt string) error {
 		}
 		if !ctx.abortOnError {
 			// --disable_abort_on_error: output the error as a line and continue.
+			// Always update $mysql_errno/$mysql_errname regardless of resultLogEnabled
+			// so that include files like wait_for_query_to_succeed.inc can detect failure.
+			errCode := extractMySQLErrorCode(err)
+			if ctx.variables == nil {
+				ctx.variables = make(map[string]string)
+			}
+			ctx.variables["$mysql_errno"] = strconv.Itoa(errCode)
+			if name, ok := mysqlErrorCodeToName[errCode]; ok {
+				ctx.variables["$mysql_errname"] = name
+			} else {
+				ctx.variables["$mysql_errname"] = strconv.Itoa(errCode)
+			}
 			if ctx.resultLogEnabled {
 				ctx.output.WriteString(formatMySQLError(err) + "\n")
-				errCode := extractMySQLErrorCode(err)
-				if ctx.variables == nil {
-					ctx.variables = make(map[string]string)
-				}
-				ctx.variables["$mysql_errno"] = strconv.Itoa(errCode)
-				if name, ok := mysqlErrorCodeToName[errCode]; ok {
-					ctx.variables["$mysql_errname"] = name
-				} else {
-					ctx.variables["$mysql_errname"] = strconv.Itoa(errCode)
-				}
 			}
 			return nil
 		}
 		return fmt.Errorf("query failed: %s: %v", stmt, err)
 	}
 	defer rows.Close()
+
+	// Reset $mysql_errno to 0 on success (matches MySQL mysqltest behavior).
+	// This must happen regardless of resultLogEnabled so that include files that
+	// use "while ($mysql_errno)" (e.g. wait_for_query_to_succeed.inc) correctly
+	// detect query success even when result logging is disabled.
+	if ctx.variables == nil {
+		ctx.variables = make(map[string]string)
+	}
+	ctx.variables["$mysql_errno"] = "0"
+	ctx.variables["$mysql_errname"] = ""
 
 	if ctx.expectedError != "" {
 		ctx.expectedError = ""
@@ -3284,24 +3320,35 @@ func (ctx *execContext) executeExec(stmt string) error {
 		}
 		if !ctx.abortOnError {
 			// --disable_abort_on_error: output the error as a line and continue.
+			// Always update $mysql_errno/$mysql_errname regardless of resultLogEnabled
+			// so that include files like wait_for_query_to_succeed.inc can detect failure.
+			errCode := extractMySQLErrorCode(err)
+			if ctx.variables == nil {
+				ctx.variables = make(map[string]string)
+			}
+			ctx.variables["$mysql_errno"] = strconv.Itoa(errCode)
+			if name, ok := mysqlErrorCodeToName[errCode]; ok {
+				ctx.variables["$mysql_errname"] = name
+			} else {
+				ctx.variables["$mysql_errname"] = strconv.Itoa(errCode)
+			}
 			if ctx.resultLogEnabled {
 				ctx.output.WriteString(formatMySQLError(err) + "\n")
-				// Update $mysql_errno/$mysql_errname for scripts that check them.
-				errCode := extractMySQLErrorCode(err)
-				if ctx.variables == nil {
-					ctx.variables = make(map[string]string)
-				}
-				ctx.variables["$mysql_errno"] = strconv.Itoa(errCode)
-				if name, ok := mysqlErrorCodeToName[errCode]; ok {
-					ctx.variables["$mysql_errname"] = name
-				} else {
-					ctx.variables["$mysql_errname"] = strconv.Itoa(errCode)
-				}
 			}
 			return nil
 		}
 		return fmt.Errorf("exec failed: %s: %v", stmt, err)
 	}
+	// Reset $mysql_errno to 0 on success (matches MySQL mysqltest behavior).
+	// This must happen regardless of resultLogEnabled so that include files that
+	// use "while ($mysql_errno)" (e.g. wait_for_query_to_succeed.inc) correctly
+	// detect statement success even when result logging is disabled.
+	if ctx.variables == nil {
+		ctx.variables = make(map[string]string)
+	}
+	ctx.variables["$mysql_errno"] = "0"
+	ctx.variables["$mysql_errname"] = ""
+
 	// Warning output after exec is handled by the caller or by SHOW WARNINGS queries in the test.
 	if ctx.infoEnabled && result != nil {
 		affected, _ := result.RowsAffected()


### PR DESCRIPTION
## Summary

- Fixed `other/rename` test timing out (20s) due to `$mysql_errno` never being reset to `"0"` after successful statements; `wait_for_query_to_succeed.inc`'s `while ($mysql_errno)` loop spun forever
- Fixed a concurrent map write panic (`fatal error: concurrent map writes`) when using `send`/`reap` directives — the `send` goroutine now receives its own copy of `ctx.variables` and propagates errno/errname back to the parent after `reap`
- Added `RENAME TABLE` support to `checkTableLockRestrictions` (including FK child-table write-lock enforcement)
- Added `RENAME TABLES` (with S) → `RENAME TABLE` rewrite since the Vitess parser only handles the singular form
- Fixed `execRenameTable.tableExists` to check `viewStore` so views can be renamed via RENAME TABLE
- Added `ViewStore.Rename` and `TableLockManager.RenameTableLock` methods
- Returns `ER_WRONG_OBJECT` for `ALTER TABLE ... RENAME` on view names
- Removed `other/rename` from skiplist

## Test plan

- [x] `go build ./... && go test ./... -count=1` — clean build, all unit tests pass
- [x] `go run ./cmd/mtrrun` — full suite: Passed=1679, Timeouts=0 (matches baseline, no regression)
- [x] `other/rename` no longer times out — runs to completion (status: fail at line 106, a pre-existing lock-wait-semantics gap unrelated to the timeout)
- [x] Full `other` suite (900 tests) completes without crash (previously hit `fatal error: concurrent map writes` midway)

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)