### PR TITLE
fix: SET NAMES rejects ucs2/utf16/utf32 and CREATE DATABASE uses charset-default collation (Refs #78)

### DIFF
--- a/executor/ddl.go
+++ b/executor/ddl.go
@@ -302,6 +302,7 @@ func (e *Executor) execCreateDatabase(stmt *sqlparser.CreateDatabase) (*Result, 
 	// Extract charset and collation from CREATE DATABASE options
 	charset := ""
 	collation := ""
+	explicitCharset := false
 	for _, opt := range stmt.CreateOptions {
 		switch opt.Type {
 		case sqlparser.CharacterSetType:
@@ -310,6 +311,7 @@ func (e *Executor) execCreateDatabase(stmt *sqlparser.CreateDatabase) (*Result, 
 				return nil, mysqlError(1302, "HY000", fmt.Sprintf("Conflicting declarations: 'CHARACTER SET %s' and 'CHARACTER SET %s'", charset, newCS))
 			}
 			charset = newCS
+			explicitCharset = true
 		case sqlparser.CollateType:
 			collation = strings.ToLower(strings.Trim(opt.Value, "'\""))
 		}
@@ -321,10 +323,18 @@ func (e *Executor) execCreateDatabase(stmt *sqlparser.CreateDatabase) (*Result, 
 		}
 		// Fall through to catalog default (utf8mb4) if session value not set
 	}
-	// If no explicit collation, use the session-level collation_server.
+	// If no explicit collation:
+	// - When charset was explicitly set: use that charset's default collation (to avoid
+	//   mismatching collation_server with a different charset, e.g. gb18030 + utf8mb4_0900_ai_ci).
+	// - When charset came from character_set_server: use collation_server (preserving server defaults).
 	if collation == "" {
-		if collVal, ok := e.getSysVarSession("collation_server"); ok && collVal != "" {
-			collation = strings.ToLower(collVal)
+		if explicitCharset && charset != "" {
+			collation = catalog.DefaultCollationForCharset(charset)
+		}
+		if collation == "" {
+			if collVal, ok := e.getSysVarSession("collation_server"); ok && collVal != "" {
+				collation = strings.ToLower(collVal)
+			}
 		}
 	}
 	// Validate charset name

--- a/executor/variables.go
+++ b/executor/variables.go
@@ -198,6 +198,9 @@ func (e *Executor) execSet(stmt *sqlparser.Set) (*Result, error) {
 				delete(e.sessionScopeVars, "collation_connection")
 			} else if charset != "binary" && !isKnownCharset(charset) {
 				return nil, mysqlError(1115, "42000", fmt.Sprintf("Unknown character set: '%s'", charset))
+			} else if isNonClientCharset(charset) {
+				// ucs2/utf16/utf16le/utf32 cannot be used as client charset
+				return nil, mysqlError(1231, "42000", fmt.Sprintf("Variable 'character_set_client' can't be set to the value of '%s'", charset))
 			} else {
 				e.sessionScopeVars["character_set_client"] = charset
 				e.sessionScopeVars["character_set_connection"] = charset
@@ -1600,6 +1603,9 @@ func (e *Executor) handleRawSet(raw string) error {
 				delete(e.sessionScopeVars, "character_set_connection")
 				delete(e.sessionScopeVars, "character_set_results")
 				delete(e.sessionScopeVars, "collation_connection")
+			} else if isNonClientCharset(charset) {
+				// ucs2/utf16/utf16le/utf32 cannot be used as client charset
+				return mysqlError(1231, "42000", fmt.Sprintf("Variable 'character_set_client' can't be set to the value of '%s'", charset))
 			} else {
 				e.sessionScopeVars["character_set_client"] = charset
 				e.sessionScopeVars["character_set_connection"] = charset


### PR DESCRIPTION
## Summary

Partial fix for Issue #78 (Charset/Collation: 正しいcharset伝播とcollation比較).

- **SET NAMES with non-client charsets (ucs2/utf16/utf16le/utf32)** now returns `ER_WRONG_VALUE_FOR_VAR` (1231) with message `Variable 'character_set_client' can't be set to the value of '<charset>'`. MySQL prohibits these charsets as client charsets since they cannot represent ASCII in a single byte. Fix applies to both the vitess parser path and the raw SQL path.

- **CREATE DATABASE with explicit CHARACTER SET but no COLLATE** now uses the charset's default collation instead of `collation_server`. This prevents a false `ER_COLLATION_CHARSET_MISMATCH` (1253) when `collation_server` is from a different charset (e.g. `CREATE DATABASE d1 CHARSET=gb18030` was failing because `collation_server=utf8mb4_0900_ai_ci` is not valid for gb18030).

## Test results

- `sys_vars` suite: 496/496 pass (same as baseline, no regression)
- `ctype_gb18030`: changed from `error` (execution error due to 1253) to `fail` (test runs, first-diff-line 99)
- `ctype_ucs`: `SET NAMES ucs2` now correctly returns error 1231 (test still fails at line 116 due to unrelated ucs2 HEX encoding)
- `ctype_utf16_myisam`, `ctype_utf32_myisam`: remain passing

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./... -count=1` passes (executor + harness)
- [x] `sys_vars` suite: 496 pass, 0 fail (no regression)
- [x] `ctype_create` still passes
- [x] `ctype_gb18030` no longer errors

Refs #78

🤖 Generated with [Claude Code](https://claude.com/claude-code)