### PR TITLE
feat: SUBQUERY group ordering in EXPLAIN for semijoin=off (Refs #81)

### DIFF
--- a/executor/explain.go
+++ b/executor/explain.go
@@ -3157,6 +3157,32 @@ func (e *Executor) explainSubqueries(sel *sqlparser.Select, idCounter *int64, re
 		outerST = outerSelectType[0]
 	}
 	for _, node := range nodes {
+		// When semijoin is disabled but materialization is on, IN subqueries appear as
+		// SUBQUERY (not DEPENDENT SUBQUERY) in EXPLAIN. MySQL outputs multiple outer-level
+		// SUBQUERY groups in reverse order of their definition. Apply group-aware reversal:
+		// process each direct subquery separately and output groups in reverse order.
+		// This matches MySQL's optimizer processing order (last-defined subquery first).
+		if whereNode, ok := node.(*sqlparser.Where); ok && !outerCanSemijoin &&
+			!e.isSemijoinEnabled() && e.isOptimizerSwitchEnabled("materialization") && whereNode != nil {
+			directExprs := collectDirectSubqueryExprs(whereNode.Expr)
+			if len(directExprs) > 1 {
+				var groups [][]explainSelectType
+				for _, expr := range directExprs {
+					gStart := len(*result)
+					e.walkForSubqueries(expr, idCounter, result, outerTables, outerCanSemijoin, outerHasOnlyDerived, sel, outerST)
+					group := make([]explainSelectType, len(*result)-gStart)
+					copy(group, (*result)[gStart:])
+					*result = (*result)[:gStart]
+					groups = append(groups, group)
+				}
+				// Output groups in reverse order (last-defined subquery group first)
+				for i := len(groups) - 1; i >= 0; i-- {
+					*result = append(*result, groups[i]...)
+				}
+				continue
+			}
+		}
+
 		startIdx := len(*result)
 		e.walkForSubqueries(node, idCounter, result, outerTables, outerCanSemijoin, outerHasOnlyDerived, sel, outerST)
 		// MySQL displays DEPENDENT SUBQUERY rows from the WHERE clause in reverse order
@@ -3178,6 +3204,39 @@ func (e *Executor) explainSubqueries(sel *sqlparser.Select, idCounter *int64, re
 			}
 		}
 	}
+}
+
+// collectDirectSubqueryExprs collects the direct IN/EXISTS/scalar subquery expressions
+// from the given expression tree without descending into sub-selects.
+// Each returned node is a ComparisonExpr (with InOp/NotInOp), ExistsExpr, or Subquery
+// that is directly referenced in the given expression (not nested inside another subquery).
+// This is used to identify outer-level subquery groups for EXPLAIN ordering.
+func collectDirectSubqueryExprs(expr sqlparser.Expr) []sqlparser.SQLNode {
+	var exprs []sqlparser.SQLNode
+	_ = sqlparser.Walk(func(n sqlparser.SQLNode) (bool, error) {
+		switch v := n.(type) {
+		case *sqlparser.ComparisonExpr:
+			if _, ok := v.Right.(*sqlparser.Subquery); ok {
+				// Only collect IN/NOT IN/= ANY/!= ANY etc. with a subquery on the right
+				switch v.Operator {
+				case sqlparser.InOp, sqlparser.NotInOp:
+					exprs = append(exprs, n)
+					return false, nil // don't descend into this subquery
+				default:
+					// Scalar subquery comparison (e.g. col = (SELECT ...))
+					if v.Modifier == sqlparser.Any || v.Modifier == sqlparser.All {
+						exprs = append(exprs, n)
+						return false, nil
+					}
+				}
+			}
+		case *sqlparser.ExistsExpr:
+			exprs = append(exprs, n)
+			return false, nil
+		}
+		return true, nil
+	}, expr)
+	return exprs
 }
 
 // collectJoinOnConditions recursively collects ON condition expressions from JOIN table expressions.

--- a/executor/test_subquery_explain_test.go
+++ b/executor/test_subquery_explain_test.go
@@ -1,0 +1,142 @@
+package executor
+
+import (
+    "testing"
+    "fmt"
+    
+    "github.com/myuon/mylite/catalog"
+    "github.com/myuon/mylite/storage"
+)
+
+func TestSubqueryComplexExplain(t *testing.T) {
+    cat := catalog.New()
+    store := storage.NewEngine()
+    e := New(cat, store)
+    
+    if _, err := e.Execute("CREATE DATABASE IF NOT EXISTS test"); err != nil {
+        t.Fatalf("create db: %v", err)
+    }
+    e.CurrentDB = "test"
+    
+    // Set semijoin=off, materialization=on
+    if _, err := e.Execute("SET optimizer_switch='semijoin=off'"); err != nil {
+        t.Fatalf("set optimizer_switch: %v", err)
+    }
+    
+    for _, stmt := range []string{
+        "CREATE TABLE t1 (a1 varchar(10), a2 varchar(10))",
+        "CREATE TABLE t2 (b1 varchar(10), b2 varchar(10))",
+        "CREATE TABLE t3 (c1 varchar(10), c2 varchar(10))",
+        "CREATE TABLE t2i (b1 varchar(10), b2 varchar(10))",
+    } {
+        if _, err := e.Execute(stmt); err != nil {
+            t.Fatalf("create table: %v", err)
+        }
+    }
+    
+    res, err := e.Execute(`EXPLAIN select * from t1
+        where (a1, a2) in (select b1, b2 from t2
+        where b2 in (select c2 from t3 where c2 LIKE '%02') or
+        b2 in (select c2 from t3 where c2 LIKE '%03')) and
+        (a1, a2) in (select c1, c2 from t3
+        where (c1, c2) in (select b1, b2 from t2i where b2 > '0'))`)
+    
+    if err != nil {
+        t.Fatalf("EXPLAIN failed: %v", err)
+    }
+    
+    fmt.Printf("Got %d rows:\n", len(res.Rows))
+    for _, row := range res.Rows {
+        fmt.Printf("%v\t%v\t%v\n", row[0], row[1], row[2])
+    }
+    
+    // Expected: [1 PRIMARY t1, 5 SUBQUERY t3, 6 SUBQUERY t2i, 2 SUBQUERY t2, 4 SUBQUERY t3, 3 SUBQUERY t3]
+    expected := []struct{ id, st, tbl string }{
+        {"1", "PRIMARY", "t1"},
+        {"5", "SUBQUERY", "t3"},
+        {"6", "SUBQUERY", "t2i"},
+        {"2", "SUBQUERY", "t2"},
+        {"4", "SUBQUERY", "t3"},
+        {"3", "SUBQUERY", "t3"},
+    }
+    
+    if len(res.Rows) != len(expected) {
+        t.Errorf("expected %d rows, got %d", len(expected), len(res.Rows))
+        return
+    }
+    
+    for i, exp := range expected {
+        row := res.Rows[i]
+        idStr := fmt.Sprintf("%v", row[0])
+        stStr := fmt.Sprintf("%v", row[1])
+        tblStr := fmt.Sprintf("%v", row[2])
+        if idStr != exp.id || stStr != exp.st || tblStr != exp.tbl {
+            t.Errorf("row %d: expected {id=%s, st=%s, tbl=%s}, got {id=%v, st=%v, tbl=%v}",
+                i, exp.id, exp.st, exp.tbl, row[0], row[1], row[2])
+        }
+    }
+}
+
+func TestSubquerySimpleExplain(t *testing.T) {
+    cat := catalog.New()
+    store := storage.NewEngine()
+    e := New(cat, store)
+    
+    if _, err := e.Execute("CREATE DATABASE IF NOT EXISTS test"); err != nil {
+        t.Fatalf("create db: %v", err)
+    }
+    e.CurrentDB = "test"
+    
+    if _, err := e.Execute("SET optimizer_switch='semijoin=off'"); err != nil {
+        t.Fatalf("set optimizer_switch: %v", err)
+    }
+    
+    for _, stmt := range []string{
+        "CREATE TABLE t1 (a1 varchar(10), a2 varchar(10))",
+        "CREATE TABLE t2 (b1 varchar(10), b2 varchar(10))",
+        "CREATE TABLE t3 (c1 varchar(10), c2 varchar(10))",
+        "CREATE TABLE t2i (b1 varchar(10), b2 varchar(10))",
+    } {
+        if _, err := e.Execute(stmt); err != nil {
+            t.Fatalf("create table: %v", err)
+        }
+    }
+    
+    res, err := e.Execute(`EXPLAIN select * from t1
+        where (a1, a2) in (select b1, b2 from t2 where b1 > '0') and
+        (a1, a2) in (select c1, c2 from t3
+        where (c1, c2) in (select b1, b2 from t2i where b2 > '0'))`)
+    
+    if err != nil {
+        t.Fatalf("EXPLAIN failed: %v", err)
+    }
+    
+    fmt.Printf("Simple got %d rows:\n", len(res.Rows))
+    for _, row := range res.Rows {
+        fmt.Printf("%v\t%v\t%v\n", row[0], row[1], row[2])
+    }
+    
+    // Expected: [1 PRIMARY t1, 3 SUBQUERY t3, 4 SUBQUERY t2i, 2 SUBQUERY t2]
+    expected := []struct{ id, st, tbl string }{
+        {"1", "PRIMARY", "t1"},
+        {"3", "SUBQUERY", "t3"},
+        {"4", "SUBQUERY", "t2i"},
+        {"2", "SUBQUERY", "t2"},
+    }
+    
+    if len(res.Rows) != len(expected) {
+        t.Errorf("expected %d rows, got %d", len(expected), len(res.Rows))
+        return
+    }
+    
+    for i, exp := range expected {
+        row := res.Rows[i]
+        idStr := fmt.Sprintf("%v", row[0])
+        stStr := fmt.Sprintf("%v", row[1])
+        tblStr := fmt.Sprintf("%v", row[2])
+        if idStr != exp.id || stStr != exp.st || tblStr != exp.tbl {
+            t.Errorf("row %d: expected {id=%s, st=%s, tbl=%s}, got {id=%v, st=%v, tbl=%v}",
+                i, exp.id, exp.st, exp.tbl, row[0], row[1], row[2])
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- When `semijoin=off` and `materialization=on`, MySQL outputs outer-level SUBQUERY groups in **reverse definition order** in EXPLAIN output
- Added group-aware reversal in `explainSubqueries` for this case, applying separately to each direct IN/EXISTS subquery expression in the WHERE clause
- Added `collectDirectSubqueryExprs` helper to collect top-level subquery expressions without descending into nested sub-selects

## KPI

- `other/subquery_mat` first-diff-line: **220 → 290** (+70 lines)
- No regressions: all 1681 previously passing tests still pass (baseline maintained)

## Scope

Partial implementation of #81. This fix addresses EXPLAIN ordering for `semijoin=off,materialization=on`. Remaining work includes: full semijoin strategy selection (FirstMatch, DuplicateWeedout, LooseScan), MaterializeScan/Lookup distinction, and EXPLAIN type/key/rows improvements.

Refs #81 (partial)

🤖 Generated with [Claude Code](https://claude.com/claude-code)