### PR TITLE
feat: BEFORE/AFTER UPDATE and DELETE triggers (Refs #91)

### DIFF
--- a/executor/procedures.go
+++ b/executor/procedures.go
@@ -194,21 +194,34 @@ func (e *Executor) execCreateTrigger(query string) (*Result, error) {
 		return nil, syntaxError(rest, 1)
 	}
 
+	// Validate: BEFORE/AFTER DELETE triggers cannot reference NEW (including SET NEW.)
+	// This check must come before the general "AFTER trigger cannot SET NEW" check,
+	// because DELETE triggers give error 1363 (no NEW row) even for SET NEW.col.
+	if event == "DELETE" {
+		for _, stmt := range bodyStatements {
+			stmtUpper := strings.ToUpper(stmt)
+			if strings.Contains(stmtUpper, "NEW.") {
+				return nil, mysqlError(1363, "HY000", "There is no NEW row in on DELETE trigger")
+			}
+		}
+	}
+	// Validate: OLD columns are read-only in all triggers.
+	// SET OLD.col = val is an error in any trigger (error 1362).
+	// This check must come before the "no OLD row in INSERT" check so that
+	// AFTER INSERT triggers with "SET OLD.col = val" get 1362 (ER_TRG_CANT_CHANGE_ROW)
+	// rather than 1363 (ER_TRG_NO_SUCH_ROW_IN_TRG).
+	for _, stmt := range bodyStatements {
+		stmtUpper := strings.ToUpper(strings.TrimSpace(stmt))
+		if containsOldColAssignment(stmtUpper) {
+			return nil, mysqlError(1362, "HY000", "Updating of OLD row is not allowed in trigger")
+		}
+	}
 	// Validate: AFTER triggers cannot modify NEW row
 	if timing == "AFTER" {
 		for _, stmt := range bodyStatements {
 			stmtUpper := strings.ToUpper(stmt)
 			if strings.Contains(stmtUpper, "SET NEW.") {
 				return nil, mysqlError(1362, "HY000", "Updating of NEW row is not allowed in after trigger")
-			}
-		}
-	}
-	// Validate: BEFORE/AFTER DELETE triggers cannot reference NEW
-	if event == "DELETE" {
-		for _, stmt := range bodyStatements {
-			stmtUpper := strings.ToUpper(stmt)
-			if strings.Contains(stmtUpper, "NEW.") {
-				return nil, mysqlError(1363, "HY000", "There is no NEW row in on DELETE trigger")
 			}
 		}
 	}
@@ -577,6 +590,24 @@ func containsNewColAssignment(stmtUpper string) bool {
 	for _, part := range parts {
 		part = strings.TrimSpace(part)
 		if strings.HasPrefix(part, "NEW.") {
+			return true
+		}
+	}
+	return false
+}
+
+// containsOldColAssignment checks if a SET statement (already uppercased) contains
+// an OLD.col assignment like "SET OLD.col = val" or "SET @v = x, OLD.col = y".
+// OLD columns are read-only in all triggers; assigning to them is error 1362.
+func containsOldColAssignment(stmtUpper string) bool {
+	if !strings.HasPrefix(stmtUpper, "SET ") {
+		return false
+	}
+	rest := strings.TrimSpace(stmtUpper[4:]) // strip "SET "
+	parts := splitSetAssignments(rest)
+	for _, part := range parts {
+		part = strings.TrimSpace(part)
+		if strings.HasPrefix(part, "OLD.") {
 			return true
 		}
 	}

--- a/executor/trigger_controlflow_test.go
+++ b/executor/trigger_controlflow_test.go
@@ -1,6 +1,7 @@
 package executor
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/myuon/mylite/catalog"
@@ -187,5 +188,160 @@ func TestTriggerWithIfThenStringValues(t *testing.T) {
 	}
 	if len(res.Rows) == 0 || res.Rows[0][0] != "Bob" {
 		t.Errorf("expected user_name='Bob', got %v", res.Rows)
+	}
+}
+
+func TestBeforeAfterUpdateTriggerNewOld(t *testing.T) {
+	e := newTriggerTestExecutor(t)
+
+	if _, err := e.Execute("CREATE TABLE products (id INT PRIMARY KEY, price INT, old_price INT)"); err != nil {
+		t.Fatalf("create products: %v", err)
+	}
+	if _, err := e.Execute("CREATE TABLE audit (id INT PRIMARY KEY AUTO_INCREMENT, product_id INT, before_price INT, after_price INT)"); err != nil {
+		t.Fatalf("create audit: %v", err)
+	}
+
+	// BEFORE UPDATE trigger: reads OLD, modifies NEW
+	if _, err := e.Execute(`CREATE TRIGGER tr_before_update BEFORE UPDATE ON products FOR EACH ROW SET NEW.old_price = OLD.price`); err != nil {
+		t.Fatalf("create before update trigger: %v", err)
+	}
+	// AFTER UPDATE trigger: inserts audit row with OLD and NEW values
+	if _, err := e.Execute(`CREATE TRIGGER tr_after_update AFTER UPDATE ON products FOR EACH ROW INSERT INTO audit (product_id, before_price, after_price) VALUES (NEW.id, OLD.price, NEW.price)`); err != nil {
+		t.Fatalf("create after update trigger: %v", err)
+	}
+
+	// Insert initial data
+	if _, err := e.Execute("INSERT INTO products (id, price, old_price) VALUES (1, 100, 0)"); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	// Update price
+	if _, err := e.Execute("UPDATE products SET price = 200 WHERE id = 1"); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+
+	// Check old_price was set by BEFORE trigger
+	res, err := e.Execute("SELECT price, old_price FROM products WHERE id = 1")
+	if err != nil {
+		t.Fatalf("select products: %v", err)
+	}
+	if len(res.Rows) == 0 {
+		t.Fatal("expected 1 row in products")
+	}
+	if res.Rows[0][0] != int64(200) {
+		t.Errorf("expected price=200, got %v", res.Rows[0][0])
+	}
+	if res.Rows[0][1] != int64(100) {
+		t.Errorf("expected old_price=100 (set by BEFORE trigger from OLD.price), got %v", res.Rows[0][1])
+	}
+
+	// Check audit row was created by AFTER trigger
+	res, err = e.Execute("SELECT before_price, after_price FROM audit WHERE product_id = 1")
+	if err != nil {
+		t.Fatalf("select audit: %v", err)
+	}
+	if len(res.Rows) == 0 {
+		t.Fatal("expected 1 audit row")
+	}
+	if res.Rows[0][0] != int64(100) {
+		t.Errorf("expected before_price=100 (OLD.price), got %v", res.Rows[0][0])
+	}
+	if res.Rows[0][1] != int64(200) {
+		t.Errorf("expected after_price=200 (NEW.price), got %v", res.Rows[0][1])
+	}
+}
+
+func TestBeforeAfterDeleteTriggerOld(t *testing.T) {
+	e := newTriggerTestExecutor(t)
+
+	if _, err := e.Execute("CREATE TABLE items (id INT PRIMARY KEY, name VARCHAR(50))"); err != nil {
+		t.Fatalf("create items: %v", err)
+	}
+	if _, err := e.Execute("CREATE TABLE deleted_items (id INT, name VARCHAR(50), deleted_at VARCHAR(50))"); err != nil {
+		t.Fatalf("create deleted_items: %v", err)
+	}
+
+	// BEFORE DELETE trigger: logs the deletion
+	if _, err := e.Execute(`CREATE TRIGGER tr_before_delete BEFORE DELETE ON items FOR EACH ROW SET @last_deleted = OLD.name`); err != nil {
+		t.Fatalf("create before delete trigger: %v", err)
+	}
+	// AFTER DELETE trigger: archives deleted rows
+	if _, err := e.Execute(`CREATE TRIGGER tr_after_delete AFTER DELETE ON items FOR EACH ROW INSERT INTO deleted_items (id, name) VALUES (OLD.id, OLD.name)`); err != nil {
+		t.Fatalf("create after delete trigger: %v", err)
+	}
+
+	// Insert test data
+	if _, err := e.Execute("INSERT INTO items (id, name) VALUES (1, 'Widget'), (2, 'Gadget')"); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	// Delete one row
+	if _, err := e.Execute("DELETE FROM items WHERE id = 1"); err != nil {
+		t.Fatalf("delete: %v", err)
+	}
+
+	// Check @last_deleted was set by BEFORE DELETE trigger
+	res, err := e.Execute("SELECT @last_deleted")
+	if err != nil {
+		t.Fatalf("select @last_deleted: %v", err)
+	}
+	if len(res.Rows) == 0 || res.Rows[0][0] != "Widget" {
+		t.Errorf("expected @last_deleted='Widget', got %v", res.Rows)
+	}
+
+	// Check deleted_items was populated by AFTER DELETE trigger
+	res, err = e.Execute("SELECT id, name FROM deleted_items")
+	if err != nil {
+		t.Fatalf("select deleted_items: %v", err)
+	}
+	if len(res.Rows) == 0 {
+		t.Fatal("expected 1 deleted_items row")
+	}
+	if res.Rows[0][0] != int64(1) || res.Rows[0][1] != "Widget" {
+		t.Errorf("expected deleted row (1, Widget), got %v", res.Rows[0])
+	}
+
+	// Check items still has Gadget
+	res, err = e.Execute("SELECT COUNT(*) FROM items")
+	if err != nil {
+		t.Fatalf("select count: %v", err)
+	}
+	if len(res.Rows) == 0 || res.Rows[0][0] != int64(1) {
+		t.Errorf("expected 1 remaining item, got %v", res.Rows)
+	}
+}
+
+func TestTriggerSetOldColError(t *testing.T) {
+	e := newTriggerTestExecutor(t)
+
+	if _, err := e.Execute("CREATE TABLE t1 (id INT, val INT)"); err != nil {
+		t.Fatalf("create t1: %v", err)
+	}
+
+	// SET OLD.col in any trigger should give error 1362 (ER_TRG_CANT_CHANGE_ROW)
+	_, err := e.Execute("CREATE TRIGGER tr_bad BEFORE UPDATE ON t1 FOR EACH ROW SET OLD.val = 100")
+	if err == nil {
+		t.Fatal("expected error for SET OLD.col in trigger")
+	}
+	if !strings.Contains(err.Error(), "1362") {
+		t.Errorf("expected error 1362 (Updating of OLD row), got: %v", err)
+	}
+
+	// SET OLD.col in AFTER INSERT should also give 1362
+	_, err = e.Execute("CREATE TRIGGER tr_bad2 AFTER INSERT ON t1 FOR EACH ROW SET OLD.val = 100")
+	if err == nil {
+		t.Fatal("expected error for SET OLD.col in AFTER INSERT trigger")
+	}
+	if !strings.Contains(err.Error(), "1362") {
+		t.Errorf("expected error 1362 (Updating of OLD row), got: %v", err)
+	}
+
+	// Reading OLD.col in INSERT trigger should give 1363 (ER_TRG_NO_SUCH_ROW_IN_TRG)
+	_, err = e.Execute("CREATE TRIGGER tr_bad3 BEFORE INSERT ON t1 FOR EACH ROW SET @x = OLD.val")
+	if err == nil {
+		t.Fatal("expected error for reading OLD.col in INSERT trigger")
+	}
+	if !strings.Contains(err.Error(), "1363") {
+		t.Errorf("expected error 1363 (no OLD row in INSERT), got: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

- Fix trigger body validation so `SET OLD.col = val` in any trigger correctly returns error 1362 (`ER_TRG_CANT_CHANGE_ROW`) rather than 1363 (`ER_TRG_NO_SUCH_ROW_IN_TRG`)
- Reorder validation checks: DELETE trigger `NEW.` check now runs before AFTER trigger `SET NEW.` check, so AFTER DELETE with `SET NEW.col` correctly returns 1363 ("no NEW row in DELETE trigger")
- Add `containsOldColAssignment()` helper (mirrors existing `containsNewColAssignment()`) to detect `SET OLD.col = expr` patterns in trigger bodies
- Add unit tests for: BEFORE/AFTER UPDATE triggers with OLD/NEW references, BEFORE/AFTER DELETE triggers with OLD references, and error code validation for SET OLD.col
- Remove `funcs_1/innodb_trig_frkey` from skiplist — test now passes

The BEFORE/AFTER UPDATE and DELETE trigger execution itself was already implemented in `dml_update.go` and `dml_delete.go` (PR #111). This PR fixes the CREATE TRIGGER validation logic to correctly distinguish:
1. `SET OLD.col = val` (any trigger) → error 1362 `ER_TRG_CANT_CHANGE_ROW`
2. `OLD.col` read in INSERT trigger → error 1363 `ER_TRG_NO_SUCH_ROW_IN_TRG`
3. `NEW.col` ref in DELETE trigger → error 1363 `ER_TRG_NO_SUCH_ROW_IN_TRG`
4. `SET NEW.col` in AFTER (non-DELETE) trigger → error 1362 `ER_TRG_CANT_CHANGE_ROW`

Refs #91 (partial)

## Test plan

- [x] `go build ./... && go test ./... -count=1` — clean build, all unit tests pass
- [x] New unit tests: `TestBeforeAfterUpdateTriggerNewOld`, `TestBeforeAfterDeleteTriggerOld`, `TestTriggerSetOldColError` — all pass
- [x] `funcs_1/innodb_trig_frkey` removed from skiplist and verified to pass
- [x] 10 key suites (sys_vars, innodb, collations, funcs_1, gcol, auth_sec, perfschema, x, binlog_nogtid, encryption): 973 passes — matches baseline, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)