### PR TITLE
fix: hex literal as integer in mixed-mode bitwise ops (Refs #80)

### DIFF
--- a/executor/display.go
+++ b/executor/display.go
@@ -137,16 +137,29 @@ func stripCharsetIntroducerForColName(s string) string {
 	if len(s) >= 3 && (s[0] == 'n' || s[0] == 'N') && s[1] == '\'' && s[len(s)-1] == '\'' {
 		return s[1:]
 	}
-	// Handle _charset'...' pattern
+	// Handle _charset'...' pattern (e.g. _utf8'abc', _latin1'hello')
+	// A charset introducer has no spaces or operators between _ and the quote.
+	// Expressions like "_bit | x'cafebabe'" start with _ but are not charset introducers.
 	if len(s) >= 3 && s[0] == '_' {
-		// Find the quote
+		// Find the quote, but only if all chars between _ and ' are identifier chars
+		isCharsetIntroducer := false
+		quotePos := -1
 		for i := 1; i < len(s); i++ {
-			if s[i] == '\'' {
-				if i < len(s)-1 && s[len(s)-1] == '\'' {
-					return s[i:]
-				}
+			ch := s[i]
+			if ch == '\'' {
+				quotePos = i
 				break
 			}
+			// Charset names are letters, digits, underscore only (e.g. utf8mb4, latin1)
+			if !((ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch >= '0' && ch <= '9') || ch == '_') {
+				break // space, operator, etc. → not a charset introducer
+			}
+		}
+		if quotePos > 0 && s[len(s)-1] == '\'' {
+			isCharsetIntroducer = true
+		}
+		if isCharsetIntroducer {
+			return s[quotePos:]
 		}
 	}
 	return s

--- a/executor/expr_eval.go
+++ b/executor/expr_eval.go
@@ -5527,6 +5527,39 @@ func (e *Executor) evalRowExpr(expr sqlparser.Expr, row storage.Row) (interface{
 				}
 			}
 		}
+		// When a hex literal (x'...' or 0x...) is used in a bit operation alongside a
+		// non-binary operand, MySQL treats the hex literal as an integer (big-endian), not
+		// as raw binary bytes. For example: integer_col | x'cafebabe' treats x'cafebabe'
+		// as the integer 0xcafebabe. This conversion only applies when the OTHER operand is
+		// NOT binary; if the other side is a BINARY/VARBINARY column, byte-wise ops apply.
+		if isBitOpRow && leftIsHexLit {
+			if hb, ok := left.(HexBytes); ok {
+				_, rightIsBin := toBinaryBytesForBitOp(right)
+				if !rightIsBin {
+					if decoded, err2 := hex.DecodeString(string(hb)); err2 == nil {
+						var val uint64
+						for _, b := range decoded {
+							val = val<<8 | uint64(b)
+						}
+						left = val
+					}
+				}
+			}
+		}
+		if isBitOpRow && rightIsHexLit {
+			if hb, ok := right.(HexBytes); ok {
+				_, leftIsBin := toBinaryBytesForBitOp(left)
+				if !leftIsBin {
+					if decoded, err2 := hex.DecodeString(string(hb)); err2 == nil {
+						var val uint64
+						for _, b := range decoded {
+							val = val<<8 | uint64(b)
+						}
+						right = val
+					}
+				}
+			}
+		}
 		// In TRADITIONAL/ERROR_FOR_DIVISION_BY_ZERO + strict mode during DML:
 		// division by zero raises error 1365. NULL divisor returns NULL (not an error).
 		if (v.Operator == sqlparser.DivOp || v.Operator == sqlparser.IntDivOp || v.Operator == sqlparser.ModOp) && e.insideDML && right != nil {

--- a/executor/typeutil.go
+++ b/executor/typeutil.go
@@ -57,7 +57,7 @@ func isIntValLiteral(expr sqlparser.Expr) bool {
 // isHexNumLiteral returns true if the expression is a HexNum literal (0x...).
 func isHexNumLiteral(expr sqlparser.Expr) bool {
 	if lit, ok := expr.(*sqlparser.Literal); ok {
-		return lit.Type == sqlparser.HexNum
+		return lit.Type == sqlparser.HexNum || lit.Type == sqlparser.HexVal
 	}
 	return false
 }


### PR DESCRIPTION
## Summary

- Fix `x'...'` hex literals being treated as raw byte strings instead of integers when used in bitwise operations with a non-binary operand (e.g., `integer_col | x'cafebabe'` now correctly returns the expected integer result instead of 64)
- Fix `stripCharsetIntroducerForColName` incorrectly stripping the leading identifier from expressions like `_bit | x'cafebabe'` (column header was showing `cafebabe` instead of `_bit | x'cafebabe'`)

**Root causes:**
1. `isHexNumLiteral` only recognized `0x...` (HexNum) literals but not `x'...'` (HexVal) literals, so the mixed-mode conversion path was never triggered for `x'...'` notation
2. `stripCharsetIntroducerForColName` searched for the first `'` in any string starting with `_`, without checking that only identifier characters appear between `_` and `'`

**Behavior preserved:** When both operands are binary types (BINARY/VARBINARY columns with hex literals of matching length), byte-wise ops continue to work correctly (including error for size mismatch).

## Test plan

- [x] `go build ./... && go test ./... -count=1` passes
- [x] `go run ./cmd/mtrrun -test other/func_bitwise_ops` run to verify improvements
- [x] Full suite run: `Passed: 1688` (baseline), `Failed: 305` - no regressions
- [x] func_bitwise_ops: `_bit | x'cafebabe'` col header now shows `_bit | x'cafebabe'` (not `cafebabe`), value now `3405691646` (not `64`)

Refs #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)