### PR TITLE
feat: column-level CHARACTER SET/COLLATE preservation (Refs #78)

### DIFF
--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -40,6 +40,7 @@ type ColumnDef struct {
 	OnUpdateCurrentTimestamp bool   // true for TIMESTAMP/DATETIME with ON UPDATE CURRENT_TIMESTAMP
 	Charset                 string // column-level charset override (e.g. "latin1"); empty means inherit table default
 	Collation               string // column-level collation override; empty means inherit table default
+	CharsetExplicit         bool   // true when charset was explicitly specified by user (not inferred from collation or table default)
 	SRIDConstraint          *uint32 // SRID constraint for spatial columns; nil means no constraint
 }
 

--- a/executor/ddl.go
+++ b/executor/ddl.go
@@ -1235,6 +1235,7 @@ func (e *Executor) execCreateTable(stmt *sqlparser.CreateTable) (*Result, error)
 			if csLower != "binary" {
 				colDef.Charset = csLower
 				colDef.Collation = catalog.DefaultCollationForCharset(colDef.Charset)
+				colDef.CharsetExplicit = true // user explicitly wrote CHARACTER SET
 			}
 		} else if col.Type.Charset.Binary {
 			// BINARY modifier without explicit CHARACTER SET means binary collation of the current charset.
@@ -1252,6 +1253,8 @@ func (e *Executor) execCreateTable(stmt *sqlparser.CreateTable) (*Result, error)
 				}
 				colDef.Charset = cs
 				colDef.Collation = catalog.BinaryCollationForCharset(cs)
+				// Do NOT set CharsetExplicit: BINARY modifier inherits charset from the table.
+				// SHOW CREATE TABLE should display only COLLATE (not CHARACTER SET) for these columns.
 			}
 		} else if strings.EqualFold(tableCharset, "binary") {
 			// Table-level CHARACTER SET binary propagates to columns without explicit charset.
@@ -2789,6 +2792,7 @@ func columnDefFromAST(col *sqlparser.ColumnDefinition) catalog.ColumnDef {
 		if csLower != "binary" {
 			colDef.Charset = csLower
 			colDef.Collation = catalog.DefaultCollationForCharset(colDef.Charset)
+			colDef.CharsetExplicit = true // user explicitly wrote CHARACTER SET
 		}
 	}
 	// Override/set collation from explicit COLLATE clause.
@@ -4163,6 +4167,50 @@ func (e *Executor) execAlterTable(stmt *sqlparser.AlterTable) (*Result, error) {
 					tableDef, _ := db.GetTable(tableName)
 					if tableDef != nil {
 						tableDef.InsertMethod = strings.ToUpper(tableOptionString(to))
+					}
+				case "CHARSET", "CHARACTER SET":
+					// ALTER TABLE ... DEFAULT CHARSET=newcs
+					// Pin existing columns that were inheriting the old table charset
+					// to the old charset explicitly, so SHOW CREATE TABLE can display
+					// "CHARACTER SET old" when they differ from the new table default.
+					newCharset := strings.ToLower(tableOptionString(to))
+					tableDef, _ := db.GetTable(tableName)
+					if tableDef != nil {
+						oldCharset := tableDef.Charset
+						if oldCharset == "" {
+							oldCharset = "utf8mb4"
+						}
+						if !strings.EqualFold(oldCharset, newCharset) {
+							// Pin implicit-charset columns to the old charset, so that
+							// SHOW CREATE TABLE can display "CHARACTER SET old_cs" when
+							// they differ from the new table default. Do NOT pin collation
+							// (leave it empty) so that SHOW CREATE TABLE only shows
+							// "CHARACTER SET old_cs" without a COLLATE clause.
+							for i, col := range tableDef.Columns {
+								if col.Charset == "" && columnTypeSupportsCharset(col.Type) {
+									tableDef.Columns[i].Charset = oldCharset
+									// Collation stays empty: inherited columns had no explicit
+									// collation, and pinning should not introduce one.
+									tableDef.Columns[i].CharsetExplicit = true
+								}
+							}
+						}
+						tableDef.Charset = newCharset
+						// Reset collation to default for the new charset (may be overridden by COLLATE option).
+						tableDef.Collation = catalog.DefaultCollationForCharset(newCharset)
+					}
+				case "COLLATE":
+					// ALTER TABLE ... COLLATE=newcoll
+					newCollation := strings.ToLower(tableOptionString(to))
+					tableDef, _ := db.GetTable(tableName)
+					if tableDef != nil {
+						tableDef.Collation = newCollation
+						// Infer charset from collation if not already set.
+						if tableDef.Charset == "" {
+							if cs, ok := catalog.CharsetForCollation(newCollation); ok {
+								tableDef.Charset = cs
+							}
+						}
 					}
 				}
 			}

--- a/executor/show.go
+++ b/executor/show.go
@@ -2028,18 +2028,41 @@ func (e *Executor) showCreateTable(tableName string) (*Result, error) {
 			// This handles cases like VARCHAR BINARY which gets latin1_bin vs latin1's default latin1_swedish_ci.
 			defaultCollForColCharset := catalog.DefaultCollationForCharset(col.Charset)
 			collationDiffers := col.Collation != "" && !strings.EqualFold(col.Collation, defaultCollForColCharset)
-			if charsetDiffers {
+			// showCharset: true when we need to emit the CHARACTER SET clause.
+			// We show charset when:
+			//  - col.CharsetExplicit (user wrote CHARACTER SET explicitly or charset was pinned
+			//    during ALTER TABLE DEFAULT CHARSET change)
+			//  - or the charset differs from the table default.
+			showCharset := charsetDiffers || col.CharsetExplicit
+			if showCharset {
 				collation := col.Collation
 				if collation == "" {
-					// No explicit collation: show only CHARACTER SET (MySQL behavior for
-					// columns whose collation was not explicitly set, e.g. from SELECT result)
+					// No explicit collation: show only CHARACTER SET.
 					parts = append(parts, fmt.Sprintf("CHARACTER SET %s", col.Charset))
 				} else {
+					// Show CHARACTER SET + COLLATE (MySQL includes collation whenever it's stored).
 					parts = append(parts, fmt.Sprintf("CHARACTER SET %s COLLATE %s", col.Charset, collation))
 				}
 			} else if collationDiffers {
-				// Same charset as table but different collation: show only COLLATE
-				parts = append(parts, fmt.Sprintf("COLLATE %s", col.Collation))
+				// Charset matches table but column collation differs from the charset default.
+				// If the column collation also differs from the TABLE collation, the charset was
+				// inferred from an explicit COLLATE clause — MySQL shows CHARACTER SET + COLLATE.
+				// If the column collation MATCHES the table collation, the column is inheriting
+				// the table's non-default collation (e.g. via BINARY modifier) — show only COLLATE.
+				tableCollation := def.Collation
+				if tableCollation == "" {
+					tableCollation = catalog.DefaultCollationForCharset(def.Charset)
+					if def.Charset == "" {
+						tableCollation = catalog.DefaultCollationForCharset("utf8mb4")
+					}
+				}
+				if !strings.EqualFold(col.Collation, tableCollation) {
+					// Column's collation differs from the table collation: charset was inferred.
+					parts = append(parts, fmt.Sprintf("CHARACTER SET %s COLLATE %s", col.Charset, col.Collation))
+				} else {
+					// Column's collation matches the table collation: show only COLLATE.
+					parts = append(parts, fmt.Sprintf("COLLATE %s", col.Collation))
+				}
 			}
 		} else if columnTypeSupportsCharset(col.Type) {
 			// Column has no explicit charset (inherits from table). However, if the table


### PR DESCRIPTION
## Summary

- Add `CharsetExplicit` flag to `ColumnDef` to distinguish user-specified charset from inherited/inferred charset
- Fix `ALTER TABLE DEFAULT CHARSET=X` to update table's charset and "pin" implicit-charset columns to the old charset so SHOW CREATE TABLE displays correct output
- Fix SHOW CREATE TABLE charset/collate display logic: show `CHARACTER SET` when explicitly specified, show `CHARACTER SET + COLLATE` when collation was inferred from explicit COLLATE clause

## Details

### ALTER TABLE DEFAULT CHARSET support
Previously, `ALTER TABLE t1 DEFAULT CHARSET=latin2` was silently ignored (the table's charset was not updated). Now it:
1. Updates `tableDef.Charset` to the new charset
2. Pins columns that were using the old implicit charset to the old charset explicitly (so SHOW CREATE TABLE can display `CHARACTER SET old_cs`)

### SHOW CREATE TABLE fixes
The charset/collate display logic now handles three cases correctly:
- `CharsetExplicit=true`: always show `CHARACTER SET X [COLLATE Y]`
- `charsetDiffers && !CharsetExplicit`: show `CHARACTER SET X [COLLATE Y]` (existing behavior)
- `!charsetDiffers && collationDiffers && col.Collation != tableCollation`: show `CHARACTER SET X COLLATE Y` (new: for columns where charset was inferred from explicit COLLATE clause)

### Test results
- `ctype_many` first-diff-line improved from 36 to 98 (+62 lines)
- `ctype_latin2_ch_myisam` line 47 charset display fixed
- **Zero regressions** (Pass: 1689, baseline: 1689)

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./... -count=1` passes (all unit tests)
- [x] Full mtrrun suite: 1689 passed (same as baseline)
- [x] No regressions vs baseline

Refs #78 partial

🤖 Generated with [Claude Code](https://claude.com/claude-code)