### PR TITLE
fix: BIGINT overflow detection (Error 1264) in multi-table UPDATE (Refs #79)

### DIFF
--- a/executor/dml_update.go
+++ b/executor/dml_update.go
@@ -1200,6 +1200,26 @@ nextRow:
 								break
 							}
 						}
+						// In strict mode (without IGNORE), check integer column range before coercion.
+						if e.isStrictMode() && !bool(stmt.Ignore) && val != nil {
+							if err := checkIntegerStrict(col.Type, col.Name, val); err != nil {
+								// Report row 1 (multi-table UPDATE doesn't track absolute row numbers here).
+								unlockAndReturn = mysqlError(1264, "22003", fmt.Sprintf("Out of range value for column '%s' at row 1", col.Name))
+								break
+							}
+						}
+						// In IGNORE or non-strict mode, emit warning 1264 for out-of-range integer values.
+						if val != nil {
+							if e.isStrictMode() && bool(stmt.Ignore) {
+								if err := checkIntegerStrict(col.Type, col.Name, val); err != nil {
+									e.addWarning("Warning", 1264, fmt.Sprintf("Out of range value for column '%s' at row %d", col.Name, i+1))
+								}
+							} else if !e.isStrictMode() {
+								if err := checkIntegerStrict(col.Type, col.Name, val); err != nil {
+									e.addWarning("Warning", 1264, fmt.Sprintf("Out of range value for column '%s' at row %d", col.Name, i+1))
+								}
+							}
+						}
 						val = e.coerceColumnValueForWrite(col.Type, val)
 						break
 					}


### PR DESCRIPTION
## Summary

- Multi-table `UPDATE t1, t2 SET ...` was silently clamping out-of-range integer values instead of raising Error 1264 in strict mode
- Add `checkIntegerStrict` calls to `execMultiTableUpdate` to match behavior already present in single-table UPDATE and INSERT handlers
- In `IGNORE` mode or non-strict mode, emits Warning 1264 and clamps the value (same as single-table UPDATE behavior)

## Changes

- `executor/dml_update.go`: Added integer range validation in `execMultiTableUpdate` before `coerceColumnValueForWrite`

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./... -count=1` passes
- [ ] Full mtrrun suite confirms no regression from baseline (Pass 1689)

Refs #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)