### PR TITLE
fix: ADDTIME/SUBTIME DATE column datetime arithmetic + SELECT * view join expansion

### DIFF
--- a/executor/func_datetime.go
+++ b/executor/func_datetime.go
@@ -705,7 +705,6 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr, row *stor
 			return nil, true, nil
 		}
 		// If base is a full DATETIME (has YYYY-MM-DD HH:MM:SS), use datetime arithmetic.
-		// Plain DATE strings (YYYY-MM-DD only) are treated as TIME strings by MySQL.
 		if isDatetimeWithTimeComponent(baseStr) {
 			t, dtErr := parseDateTimeValue(base)
 			if dtErr == nil {
@@ -717,8 +716,24 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr, row *stor
 				return formatDateTimeWithOptionalMicros(result), true, nil
 			}
 		}
+		// If base is a pure DATE value coming from a DATE-typed column (YYYY-MM-DD exactly),
+		// MySQL treats it as midnight (YYYY-MM-DD 00:00:00) and returns a DATETIME result.
+		// NOTE: when the argument is a string literal like '2006-07-16', MySQL treats it
+		// as an invalid TIME string (with warning), NOT as a DATE for datetime arithmetic.
+		// We distinguish the two cases by checking the expression type.
+		if isPureDateString(baseStr) && !e.isNonDateTypeExpr(v.Exprs[0]) {
+			t, dtErr := parseDateTimeValue(baseStr + " 00:00:00")
+			if dtErr == nil {
+				dur, err := parseMySQLTimeInterval(intervalStr)
+				if err != nil {
+					return baseStr, true, nil
+				}
+				result := t.Add(dur)
+				return formatDateTimeWithOptionalMicros(result), true, nil
+			}
+		}
 		// Base is a TIME string (possibly with garbage at end) - use time arithmetic.
-		// If base looks like a date string (YYYY-MM-DD), MySQL emits a warning.
+		// If base looks like a datetime/date string, MySQL emits a warning.
 		if isDatetimeLikeString(baseStr) {
 			e.addWarning("Warning", 1292, fmt.Sprintf("Truncated incorrect time value: '%s'", baseStr))
 		}
@@ -748,7 +763,6 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr, row *stor
 			return nil, true, nil
 		}
 		// If base is a full DATETIME (has YYYY-MM-DD HH:MM:SS), use datetime arithmetic.
-		// Plain DATE strings (YYYY-MM-DD only) are treated as TIME strings by MySQL.
 		if isDatetimeWithTimeComponent(baseStr) {
 			t, dtErr := parseDateTimeValue(base)
 			if dtErr == nil {
@@ -760,8 +774,23 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr, row *stor
 				return formatDateTimeWithOptionalMicros(result), true, nil
 			}
 		}
+		// If base is a pure DATE value coming from a DATE-typed column (YYYY-MM-DD exactly),
+		// MySQL treats it as midnight (YYYY-MM-DD 00:00:00) and returns a DATETIME result.
+		// NOTE: when the argument is a string literal, MySQL treats it as an invalid TIME
+		// string (with warning), NOT as a DATE for datetime arithmetic.
+		if isPureDateString(baseStr) && !e.isNonDateTypeExpr(v.Exprs[0]) {
+			t, dtErr := parseDateTimeValue(baseStr + " 00:00:00")
+			if dtErr == nil {
+				dur, err := parseMySQLTimeInterval(intervalStr)
+				if err != nil {
+					return baseStr, true, nil
+				}
+				result := t.Add(-dur)
+				return formatDateTimeWithOptionalMicros(result), true, nil
+			}
+		}
 		// Base is a TIME string - use time arithmetic.
-		// If base looks like a date string (YYYY-MM-DD), MySQL emits a warning.
+		// If base looks like a datetime/date string, MySQL emits a warning.
 		if isDatetimeLikeString(baseStr) {
 			e.addWarning("Warning", 1292, fmt.Sprintf("Truncated incorrect time value: '%s'", baseStr))
 		}
@@ -1106,6 +1135,14 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr, row *stor
 		mtHi := toInt64(mtH)
 		mtMi := toInt64(mtM)
 		mtSi := toInt64(mtSec)
+		// Capture original hour string for potential warning message (before any modification).
+		var origHourStr string
+		if u, ok := mtH.(uint64); ok && mtHi < 0 {
+			// Large unsigned value that overflowed int64 - use original uint64 string.
+			origHourStr = strconv.FormatUint(u, 10)
+		} else {
+			origHourStr = toString(mtH)
+		}
 		// If the hour was a uint64 value that overflows int64 (e.g., CAST(-1 AS UNSIGNED)
 		// = 18446744073709551615), treat it as a very large positive value (clamp to max).
 		if mtHi < 0 {
@@ -1155,6 +1192,14 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr, row *stor
 			clampedM = 59
 			clampedS = 59
 			mtFrac = ""
+			// MySQL emits warning 1292 when the hour value overflows the TIME range.
+			// Build the original time string using the raw input values.
+			origSecStr := fmt.Sprintf("%02d", mtSi)
+			if dot := strings.IndexByte(mtSecStr, '.'); dot >= 0 {
+				origSecStr = mtSecStr // use full original seconds string
+			}
+			origTimeStr := fmt.Sprintf("%s%s:%02d:%s", mtNeg, origHourStr, mtMi, origSecStr)
+			e.addWarning("Warning", 1292, fmt.Sprintf("Truncated incorrect time value: '%s'", origTimeStr))
 		}
 		timeStr := fmt.Sprintf("%s%02d:%02d:%02d%s", mtNeg, clampedH, clampedM, clampedS, mtFrac)
 		return timeStr, true, nil
@@ -4119,6 +4164,15 @@ func normalizeDateTimeForCompare(a, b string) (string, string) {
 
 func isDateString(s string) bool {
 	return len(s) >= 10 && s[4] == '-' && s[7] == '-' && (len(s) == 10 || s[10] == ' ')
+}
+
+// isPureDateString returns true if s is exactly a DATE string (YYYY-MM-DD, 10 chars,
+// no time component). This is used to distinguish DATE from DATETIME in ADDTIME/SUBTIME.
+func isPureDateString(s string) bool {
+	if len(s) != 10 {
+		return false
+	}
+	return s[4] == '-' && s[7] == '-'
 }
 
 func isTimeString(s string) bool {

--- a/executor/select.go
+++ b/executor/select.go
@@ -67,6 +67,14 @@ func (e *Executor) collectTableDefsWithAliases(expr sqlparser.TableExpr) ([]*cat
 					return []*catalog.TableDef{td}, []string{alias}
 				}
 			}
+			// Check if this is a view: look up the view SQL and synthesize a TableDef
+			// from the view's underlying table columns. This ensures SELECT * from a JOIN
+			// with a view produces the correct number of columns.
+			if viewSQL, _, isView := e.lookupView(tblName); isView {
+				if td := e.syntheticTableDefFromViewSQL(tblName, viewSQL); td != nil {
+					return []*catalog.TableDef{td}, []string{alias}
+				}
+			}
 		}
 	case *sqlparser.JoinTableExpr:
 		leftDefs, leftAliases := e.collectTableDefsWithAliases(te.LeftExpr)
@@ -83,6 +91,73 @@ func (e *Executor) collectTableDefsWithAliases(expr sqlparser.TableExpr) ([]*cat
 		return defs, aliases
 	}
 	return nil, nil
+}
+
+// syntheticTableDefFromViewSQL creates a synthetic TableDef for a view by parsing
+// its SELECT SQL and resolving column names from the underlying tables.
+// Returns nil if the view SQL cannot be resolved to a known set of columns.
+func (e *Executor) syntheticTableDefFromViewSQL(viewName, viewSQL string) *catalog.TableDef {
+	stmt, err := e.parser().Parse(viewSQL)
+	if err != nil {
+		return nil
+	}
+	sel, ok := stmt.(*sqlparser.Select)
+	if !ok {
+		return nil
+	}
+	// If SELECT * FROM single_table, use that table's columns.
+	if len(sel.From) == 1 {
+		if ate, ok := sel.From[0].(*sqlparser.AliasedTableExpr); ok {
+			if tn, ok := ate.Expr.(sqlparser.TableName); ok {
+				underlyingTable := tn.Name.String()
+				// Check if it's SELECT * or SELECT col1, col2, ...
+				if len(sel.SelectExprs.Exprs) == 1 {
+					if _, isStar := sel.SelectExprs.Exprs[0].(*sqlparser.StarExpr); isStar {
+						// SELECT * FROM table: use the underlying table's columns
+						defs, _ := e.collectTableDefsWithAliases(sel.From[0])
+						if len(defs) == 1 && defs[0] != nil {
+							// Return a copy of the underlying table def, renamed to the view
+							td := &catalog.TableDef{
+								Name:    viewName,
+								Columns: defs[0].Columns,
+							}
+							return td
+						}
+						// Try catalog lookup directly
+						if e.Catalog != nil {
+							if db, err := e.Catalog.GetDatabase(e.CurrentDB); err == nil {
+								if td, err := db.GetTable(underlyingTable); err == nil {
+									return &catalog.TableDef{Name: viewName, Columns: td.Columns}
+								}
+							}
+						}
+					}
+				}
+				// For named column lists, synthesize from SELECT expressions
+				var synCols []catalog.ColumnDef
+				for _, se := range sel.SelectExprs.Exprs {
+					switch s := se.(type) {
+					case *sqlparser.StarExpr:
+						return nil // can't handle qualified star here
+					case *sqlparser.AliasedExpr:
+						name := ""
+						if !s.As.IsEmpty() {
+							name = s.As.String()
+						} else if col, ok := s.Expr.(*sqlparser.ColName); ok {
+							name = col.Name.String()
+						}
+						if name != "" {
+							synCols = append(synCols, catalog.ColumnDef{Name: name})
+						}
+					}
+				}
+				if len(synCols) > 0 {
+					return &catalog.TableDef{Name: viewName, Columns: synCols}
+				}
+			}
+		}
+	}
+	return nil
 }
 
 // extractJoinUsingCols extracts column names from JOIN ... USING(...) clauses.


### PR DESCRIPTION
## Summary

Partial fix for #80 (additional datetime function correctness).

- **ADDTIME/SUBTIME with DATE column**: When the first argument is a `DATE`-typed column, MySQL treats the date value as midnight (`YYYY-MM-DD 00:00:00`) and returns a `DATETIME` result. Previously, all pure-date strings were treated as invalid TIME strings. The fix distinguishes DATE columns from string literals using `isNonDateTypeExpr`, matching MySQL's actual behaviour.
  - String literals like `'2006-07-16'` still go through TIME arithmetic (with Warning 1292 "Truncated incorrect time value"), as MySQL does.
  - Fixes `SELECT * FROM t1 t11 JOIN t1 t12 ON addtime(t11.the_date, t11.the_time) = addtime(t12.the_date, t12.the_time)` producing correct DATETIME comparisons.

- **MAKETIME overflow warning**: Emit Warning 1292 when clamping overflowed hours to `838:59:59`.

- **SELECT \* expansion through VIEW JOIN**: `collectTableDefsWithAliases` now looks up view SQL and synthesises a `TableDef` via `syntheticTableDefFromViewSQL`, so `SELECT * FROM t1 JOIN v1 ON ...` correctly expands all columns from both tables instead of only the base table's columns.

## Regression check

- `sp-bugs`: passes (SUBTIME with string literal correctly returns TIME, not DATETIME)
- `date_formats`, `func_sapdb`: still pass
- `other/type_date`: first diff line moves past the VIEW JOIN section (lines 256–268 now match); only remaining failure is the `0000-00-00 BETWEEN '0000-00-01' AND '0000-00-02'` row (type-aware date comparison, out of scope for this PR)

Refs #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)