### PR TITLE
feat: INFORMATION_SCHEMA.COLUMN_PRIVILEGES dynamic enumeration (Refs #93)

### DIFF
--- a/executor/grants.go
+++ b/executor/grants.go
@@ -1242,26 +1242,53 @@ func objectToGrantType(object string) GrantType {
 	return GrantTypeTable
 }
 
+// splitPrivs splits a privilege list string on commas that are outside parentheses.
+// This handles column-level grants like "SELECT(a,b), INSERT" correctly, producing
+// ["SELECT(a,b)", "INSERT"] rather than ["SELECT(a", "b)", "INSERT"].
+func splitPrivs(privs string) []string {
+	var parts []string
+	depth := 0
+	start := 0
+	for i, ch := range privs {
+		switch ch {
+		case '(':
+			depth++
+		case ')':
+			if depth > 0 {
+				depth--
+			}
+		case ',':
+			if depth == 0 {
+				parts = append(parts, privs[start:i])
+				start = i + 1
+			}
+		}
+	}
+	parts = append(parts, privs[start:])
+	return parts
+}
+
 // normalizePrivList converts a comma-separated privilege string into a sorted uppercase list.
-// For column-level grants like "SELECT(c1)", the priv name is uppercased but column names
-// are kept lowercase (MySQL stores them lowercase).
+// For column-level grants like "SELECT(c1,c2)", the priv name is uppercased but column names
+// are kept lowercase (MySQL stores them lowercase). Commas inside parentheses (column lists)
+// are not treated as privilege separators.
 func normalizePrivList(privs string) []string {
 	// Expand ALL / ALL PRIVILEGES
 	upper := strings.ToUpper(strings.TrimSpace(privs))
 	if upper == "ALL" || upper == "ALL PRIVILEGES" {
 		return []string{"ALL PRIVILEGES"}
 	}
-	parts := strings.Split(privs, ",")
+	parts := splitPrivs(privs)
 	var result []string
 	for _, p := range parts {
 		p = strings.TrimSpace(p)
 		if p == "" {
 			continue
 		}
-		// Handle column-level grants: "SELECT(c1)" -> "SELECT(c1)" with uppercase priv name
+		// Handle column-level grants: "SELECT(c1,c2)" -> "SELECT(c1,c2)" with uppercase priv name
 		if parenIdx := strings.Index(p, "("); parenIdx > 0 {
 			basePriv := strings.ToUpper(strings.TrimSpace(p[:parenIdx]))
-			colPart := p[parenIdx:] // "(c1)" - preserve as-is but lowercase col names
+			colPart := p[parenIdx:] // "(c1,c2)" - preserve as-is but lowercase col names
 			// Lowercase the column names inside parens
 			colPart = "(" + strings.ToLower(strings.Trim(strings.TrimSpace(colPart), "()")) + ")"
 			result = append(result, basePriv+colPart)

--- a/executor/grants_test.go
+++ b/executor/grants_test.go
@@ -196,6 +196,45 @@ func TestSelectPrivilegeEnforcement(t *testing.T) {
 	}
 }
 
+func TestInfoSchemaColumnPrivileges(t *testing.T) {
+	e := newTestExecutor(t)
+
+	// Set up: create table, user, and column-level grant.
+	if _, err := e.Execute("CREATE TABLE t_col (id INT, name VARCHAR(10), secret INT)"); err != nil {
+		t.Fatalf("CREATE TABLE: %v", err)
+	}
+	if _, err := e.Execute("CREATE USER u_col@localhost"); err != nil {
+		t.Fatalf("CREATE USER: %v", err)
+	}
+	// GRANT SELECT(id,name) on test.t_col TO u_col@localhost
+	if _, err := e.Execute("GRANT SELECT(id,name) ON test.t_col TO u_col@localhost"); err != nil {
+		t.Fatalf("GRANT SELECT(id,name): %v", err)
+	}
+	// Also grant a full table-level privilege (should NOT appear in COLUMN_PRIVILEGES).
+	if _, err := e.Execute("GRANT INSERT ON test.t_col TO u_col@localhost"); err != nil {
+		t.Fatalf("GRANT INSERT: %v", err)
+	}
+
+	res, err := e.Execute("SELECT GRANTEE, TABLE_SCHEMA, TABLE_NAME, COLUMN_NAME, PRIVILEGE_TYPE FROM INFORMATION_SCHEMA.COLUMN_PRIVILEGES ORDER BY COLUMN_NAME")
+	if err != nil {
+		t.Fatalf("SELECT COLUMN_PRIVILEGES: %v", err)
+	}
+
+	// Should return exactly two rows: id and name (not secret, not INSERT).
+	if len(res.Rows) != 2 {
+		t.Fatalf("expected 2 COLUMN_PRIVILEGES rows, got %d: %v", len(res.Rows), res.Rows)
+	}
+	for _, row := range res.Rows {
+		if row[4] != "SELECT" {
+			t.Errorf("PRIVILEGE_TYPE should be SELECT, got %v", row[4])
+		}
+		colName, _ := row[3].(string)
+		if colName != "id" && colName != "name" {
+			t.Errorf("unexpected column_name %q in COLUMN_PRIVILEGES", colName)
+		}
+	}
+}
+
 func TestExecutorGrantFlow(t *testing.T) {
 	// Test the full executor grant flow
 	e := newTestExecutor(t)

--- a/executor/information_schema.go
+++ b/executor/information_schema.go
@@ -503,7 +503,7 @@ var emptyStubTables = map[string]bool{
 	"innodb_ft_config":       true,
 	"innodb_ft_being_deleted": true,
 	"innodb_ft_deleted":      true,
-	"column_privileges":      true,
+	// "column_privileges" is handled dynamically via infoSchemaColumnPrivileges.
 	"persisted_variables":    true,
 	// "variables_by_thread" is handled dynamically
 	// "status_by_thread" is handled dynamically
@@ -1001,6 +1001,8 @@ func (e *Executor) buildInformationSchemaRows(tableName, alias string) ([]storag
 		rawRows = e.infoSchemaSchemaPrivileges()
 	case "table_privileges":
 		rawRows = e.infoSchemaTablePrivileges()
+	case "column_privileges":
+		rawRows = e.infoSchemaColumnPrivileges()
 	case "routines":
 		rawRows = e.infoSchemaRoutines()
 	case "views":
@@ -4771,6 +4773,57 @@ func (e *Executor) infoSchemaTablePrivileges() []storage.Row {
 					"PRIVILEGE_TYPE": p,
 					"IS_GRANTABLE":   isGrantable,
 				})
+			}
+		}
+	}
+	return rows
+}
+
+// infoSchemaColumnPrivileges returns rows for INFORMATION_SCHEMA.COLUMN_PRIVILEGES.
+// Only table-level (db.table) grants that have column-level specifiers (e.g. SELECT(col))
+// are emitted here — one row per (grantee, db, table, column, privilege) combination.
+func (e *Executor) infoSchemaColumnPrivileges() []storage.Row {
+	if e.grantStore == nil {
+		return []storage.Row{}
+	}
+	var rows []storage.Row
+	for _, uh := range e.grantStore.ListAllUserHosts() {
+		grantee := fmt.Sprintf("'%s'@'%s'", uh.User, uh.Host)
+		tableGrants := e.grantStore.GetGrantsByType(uh.User, uh.Host, GrantTypeTable)
+		for _, entry := range tableGrants {
+			parts := strings.SplitN(entry.Object, ".", 2)
+			if len(parts) != 2 {
+				continue
+			}
+			dbName, tableName := parts[0], parts[1]
+			isGrantable := "NO"
+			if entry.GrantOption {
+				isGrantable = "YES"
+			}
+			for _, p := range entry.Privs {
+				parenIdx := strings.Index(p, "(")
+				if parenIdx < 0 {
+					// Not a column-level grant; skip.
+					continue
+				}
+				basePriv := strings.TrimSpace(p[:parenIdx])
+				// Column list is inside parens, comma-separated, already lowercased.
+				colList := strings.Trim(p[parenIdx:], "()")
+				for _, col := range strings.Split(colList, ",") {
+					col = strings.TrimSpace(col)
+					if col == "" {
+						continue
+					}
+					rows = append(rows, storage.Row{
+						"GRANTEE":        grantee,
+						"TABLE_CATALOG":  "def",
+						"TABLE_SCHEMA":   dbName,
+						"TABLE_NAME":     tableName,
+						"COLUMN_NAME":    col,
+						"PRIVILEGE_TYPE": basePriv,
+						"IS_GRANTABLE":   isGrantable,
+					})
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

- **splitPrivs() fix**: `normalizePrivList` previously split on all commas, breaking multi-column grants like `GRANT SELECT(id,name) ON t TO u` into malformed entries. Added `splitPrivs()` that only splits on commas outside parentheses.
- **infoSchemaColumnPrivileges()**: New function that scans `GrantStore` table-level entries, finds privileges with column-list specifiers (`SELECT(col)`, `INSERT(col)` etc.), and emits one `COLUMN_PRIVILEGES` row per `(grantee, db, table, column, privilege)`.
- **Dispatch wired**: Added `case "column_privileges":` in `buildInformationSchemaRows`, removed `"column_privileges": true` from `emptyStubTables`.

## Test plan

- [ ] `go build ./... && go test ./... -count=1` passes (zero regressions)
- [ ] New `TestInfoSchemaColumnPrivileges` covers: multi-column grant `SELECT(id,name)`, full-table grant `INSERT` excluded from COLUMN_PRIVILEGES, correct column enumeration

🤖 Generated with [Claude Code](https://claude.com/claude-code)