### PR TITLE
feat: storage-layer PK collation-aware sort via Vitess weight strings (Closes #163)

### DIFF
--- a/storage/storage.go
+++ b/storage/storage.go
@@ -105,20 +105,17 @@ func compareRowValueWithCollation(a, b interface{}, collationName string) int {
 	if (aIsStr || bIsStr) && collationName != "" && isSafeForVitessCollationStorage(collationName) {
 		aStr := fmt.Sprintf("%v", a)
 		bStr := fmt.Sprintf("%v", b)
-		if strings.Contains(strings.ToLower(collationName), "_0900_") ||
-			strings.HasSuffix(strings.ToLower(collationName), "_0900_bin") ||
-			isSafeForVitessCollationStorage(collationName) {
-			if vc := lookupStorageCollation(collationName); vc != nil {
-				wa := storageWeightString(aStr, vc)
-				wb := storageWeightString(bStr, vc)
-				if string(wa) < string(wb) {
-					return -1
-				}
-				if string(wa) > string(wb) {
-					return 1
-				}
-				return 0
+		// Use Vitess weight strings for accurate MySQL-compatible collation ordering.
+		if vc := lookupStorageCollation(collationName); vc != nil {
+			wa := storageWeightString(aStr, vc)
+			wb := storageWeightString(bStr, vc)
+			if string(wa) < string(wb) {
+				return -1
 			}
+			if string(wa) > string(wb) {
+				return 1
+			}
+			return 0
 		}
 		// Fallback: case-insensitive for _ci collations
 		coll := strings.ToLower(collationName)


### PR DESCRIPTION
## Summary

- The core functionality for issue #163 was already landed in PR #116 (`fix/collation-aware-sort-safer-charset`): `isSafeForVitessCollationStorage()`, `lookupStorageCollation()`, `storageWeightString()`, `effectivePKCollation()`, and `compareRowValueWithCollation()` in `storage/storage.go`; `Scan()` uses per-column effective collation for PK ordering with `hasNonSortableCharset` guard preventing jp-suite regressions
- This PR removes a redundant inner condition in `compareRowValueWithCollation()` that re-checked `isSafeForVitessCollationStorage` and `_0900_`-specific predicates inside a block already guarded by the same predicate

## Changes

- `storage/storage.go`: Simplified `compareRowValueWithCollation()` — removed tautological inner `_0900_` / `isSafeForVitessCollationStorage` guard; Vitess weight strings are used directly for all safe-charset collations

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./... -count=1` passes
- [x] jp suite: 107/107 maintained (hasNonSortableCharset guard still in place)
- [x] Full suite: Passed 1692 (baseline maintained, 0 regressions)

Closes #163

🤖 Generated with [Claude Code](https://claude.com/claude-code)