### PR TITLE
feat: FK DDL storage, constraint enforcement, and parent/child checks

### DIFF
--- a/cmd/mtrrun/skiplist.json
+++ b/cmd/mtrrun/skiplist.json
@@ -3457,10 +3457,6 @@
       "reason": "engine does not support session_track_gtids default OFF"
     },
     {
-      "test": "innodb/stored_fk",
-      "reason": "FK restrictions on stored/virtual generated columns not fully implemented"
-    },
-    {
       "test": "innodb/high_prio_trx_fk",
       "reason": "Requires multi-connection high-priority transaction testing"
     },
@@ -3639,10 +3635,6 @@
     {
       "test": "innodb/autoinc_persist",
       "reason": "internally skipped"
-    },
-    {
-      "test": "innodb/foreign_key",
-      "reason": "show create table error"
     },
     {
       "test": "funcs_1/is_cml_myisam",

--- a/executor/ddl.go
+++ b/executor/ddl.go
@@ -1832,6 +1832,31 @@ func (e *Executor) execCreateTable(stmt *sqlparser.CreateTable) (*Result, error)
 						}
 					}
 				}
+				// Also reject FK with CASCADE/SET NULL actions on a column that is a
+				// base column of any STORED generated column in the same table.
+				// MySQL error 1005 (ER_CANNOT_ADD_FOREIGN): Cannot add foreign key constraint.
+				if fkDef.ReferenceDefinition != nil {
+					onDelete := fkDef.ReferenceDefinition.OnDelete
+					onUpdate := fkDef.ReferenceDefinition.OnUpdate
+					hasCascadeOrSetNull := onDelete == sqlparser.Cascade || onDelete == sqlparser.SetNull ||
+						onUpdate == sqlparser.Cascade || onUpdate == sqlparser.SetNull
+					if hasCascadeOrSetNull {
+						for _, col := range columns {
+							colTypeUpper := strings.ToUpper(col.Type)
+							if !strings.Contains(colTypeUpper, "STORED") {
+								continue
+							}
+							if !isGeneratedColumnType(col.Type) {
+								continue
+							}
+							// Check if the FK source column name appears in the stored column's expression
+							genExpr := generatedColumnExpr(col.Type)
+							if isColumnReferencedInExpr(srcName, genExpr) {
+								return nil, mysqlError(1005, "HY000", fmt.Sprintf("Cannot add foreign key constraint"))
+							}
+						}
+					}
+				}
 			}
 			// Create implicit index for FK columns (MySQL does this automatically)
 			var fkCols []string
@@ -1839,9 +1864,13 @@ func (e *Executor) execCreateTable(stmt *sqlparser.CreateTable) (*Result, error)
 				fkCols = append(fkCols, col.String())
 			}
 			if len(fkCols) > 0 {
-				// Check if an index already covers these columns
+				// Check if a usable (non-FULLTEXT, non-SPATIAL) index already covers
+				// the FK columns in the CREATE TABLE index list.
 				covered := false
 				for _, idx := range indexes {
+					if strings.EqualFold(idx.Type, "FULLTEXT") || strings.EqualFold(idx.Type, "SPATIAL") {
+						continue
+					}
 					if len(idx.Columns) >= len(fkCols) {
 						match := true
 						for k, fc := range fkCols {
@@ -1943,6 +1972,10 @@ func (e *Executor) execCreateTable(stmt *sqlparser.CreateTable) (*Result, error)
 			if name == "" {
 				fkAutoIdx++
 				name = fmt.Sprintf("%s_ibfk_%d", tableName, fkAutoIdx)
+			}
+			// MySQL enforces max 64-character identifier length for FK constraint names
+			if len(name) > 64 {
+				return nil, mysqlError(1059, "42000", fmt.Sprintf("Identifier name '%s' is too long", name))
 			}
 			var cols []string
 			for _, col := range fkDef.Source {
@@ -2415,6 +2448,19 @@ func (e *Executor) execCreateTable(stmt *sqlparser.CreateTable) (*Result, error)
 		delete(e.tempTables, tableName)
 	}
 
+	// Validate FK parent index before creating the table (when foreign_key_checks=1).
+	// This prevents the table from being created when the referenced parent table
+	// does not have the required index (ER_FK_NO_INDEX_PARENT = 1215).
+	if e.foreignKeyChecksEnabled() {
+		for _, fk := range foreignKeys {
+			if fk.ReferencedTable != "" && len(fk.ReferencedColumns) > 0 {
+				if err2 := e.validateFKParentIndex(db, tableName, fk.Name, fk.ReferencedTable, fk.ReferencedColumns); err2 != nil {
+					return nil, err2
+				}
+			}
+		}
+	}
+
 	err = db.CreateTable(def)
 	if err != nil {
 		if stmt.IfNotExists {
@@ -2694,6 +2740,37 @@ func (e *Executor) execDropTable(stmt *sqlparser.DropTable) (*Result, error) {
 				continue
 			}
 			return nil, mysqlError(1049, "42000", fmt.Sprintf("Unknown database '%s'", dbName))
+		}
+		// When foreign_key_checks is ON, prevent dropping a table that is
+		// referenced as a parent by a FK in another table (ER_FK_CANNOT_DROP_PARENT = 3730).
+		// Exception: if the referencing table is also in the same DROP TABLE statement,
+		// MySQL allows the drop (both parent and child are being dropped together).
+		if e.foreignKeyChecksEnabled() {
+			droppingTableNames := make(map[string]bool)
+			for _, t := range stmt.FromTables {
+				droppingTableNames[strings.ToLower(t.Name.String())] = true
+			}
+			tableNames := db.ListTables()
+			for _, otherName := range tableNames {
+				if strings.EqualFold(otherName, tableName) {
+					continue
+				}
+				// If this other table is also being dropped in the same statement, skip
+				if droppingTableNames[strings.ToLower(otherName)] {
+					continue
+				}
+				otherDef, err2 := db.GetTable(otherName)
+				if err2 != nil || otherDef == nil {
+					continue
+				}
+				for _, fk := range otherDef.ForeignKeys {
+					if strings.EqualFold(fk.ReferencedTable, tableName) {
+						return nil, mysqlError(3730, "HY000",
+							fmt.Sprintf("Cannot drop table '%s' referenced by a foreign key constraint '%s' on table '%s'.",
+								tableName, fk.Name, otherName))
+					}
+				}
+			}
 		}
 		err = db.DropTable(tableName)
 		if err != nil {
@@ -3010,6 +3087,7 @@ func (e *Executor) execAlterTable(stmt *sqlparser.AlterTable) (*Result, error) {
 	}
 
 	// Pre-check: ALGORITHM=INPLACE rejection for operations that require COPY
+	alterIsInplace := false
 	{
 		isInplace := false
 		hasStoredGcolAdd := false
@@ -3018,6 +3096,7 @@ func (e *Executor) execAlterTable(stmt *sqlparser.AlterTable) (*Result, error) {
 			case sqlparser.AlgorithmValue:
 				if strings.EqualFold(string(av), "INPLACE") {
 					isInplace = true
+					alterIsInplace = true
 				}
 			case *sqlparser.AddColumns:
 				for _, col := range av.Columns {
@@ -3031,7 +3110,7 @@ func (e *Executor) execAlterTable(stmt *sqlparser.AlterTable) (*Result, error) {
 			}
 		}
 		if isInplace && hasStoredGcolAdd {
-			return nil, mysqlError(1845, "0A000", "ALGORITHM=INPLACE is not supported. Reason: Cannot change column type INPLACE. Try ALGORITHM=COPY.")
+			return nil, mysqlError(1846, "0A000", "ALGORITHM=INPLACE is not supported for this operation. Try ALGORITHM=COPY.")
 		}
 		// WITH VALIDATION + ALGORITHM=INPLACE is not supported for virtual generated columns
 		// MySQL requires ALGORITHM=COPY to perform validation scans
@@ -3345,6 +3424,29 @@ func (e *Executor) execAlterTable(stmt *sqlparser.AlterTable) (*Result, error) {
 				} else if op.After != nil {
 					position = "AFTER"
 					afterCol = op.After.Name.String()
+				}
+				// Reject adding a STORED generated column whose expression references
+				// a column that is used in a FK with CASCADE/SET NULL action.
+				// MySQL error 1005 (ER_CANNOT_ADD_FOREIGN): Cannot add foreign key constraint.
+				if isGeneratedColumnType(colDef.Type) &&
+					strings.Contains(strings.ToUpper(colDef.Type), "STORED") {
+					genExprNew := generatedColumnExpr(colDef.Type)
+					if tableDef0, _ := db.GetTable(tableName); tableDef0 != nil {
+						for _, fk := range tableDef0.ForeignKeys {
+							onDelete := strings.ToUpper(fk.OnDelete)
+							onUpdate := strings.ToUpper(fk.OnUpdate)
+							hasCascadeOrSetNull := onDelete == "CASCADE" || onDelete == "SET NULL" ||
+								onUpdate == "CASCADE" || onUpdate == "SET NULL"
+							if !hasCascadeOrSetNull {
+								continue
+							}
+							for _, fkCol := range fk.Columns {
+								if isColumnReferencedInExpr(fkCol, genExprNew) {
+									return nil, mysqlError(1005, "HY000", "Cannot add foreign key constraint")
+								}
+							}
+						}
+					}
 				}
 				if addErr := db.AddColumnAt(tableName, colDef, position, afterCol); addErr != nil {
 					if strings.Contains(addErr.Error(), "already exists") {
@@ -4022,50 +4124,73 @@ func (e *Executor) execAlterTable(stmt *sqlparser.AlterTable) (*Result, error) {
 								}
 							}
 						}
+						// Reject FK with CASCADE/SET NULL on a column that is a base column
+						// of any STORED generated column in the same table.
+						// Error 1005 when ALGORITHM=COPY (or default), 3104 when ALGORITHM=INPLACE.
+						if fkDef.ReferenceDefinition != nil {
+							onDelete := fkDef.ReferenceDefinition.OnDelete
+							onUpdate := fkDef.ReferenceDefinition.OnUpdate
+							hasCascadeOrSetNull := onDelete == sqlparser.Cascade || onDelete == sqlparser.SetNull ||
+								onUpdate == sqlparser.Cascade || onUpdate == sqlparser.SetNull
+							if hasCascadeOrSetNull {
+								for _, col := range tableDef0.Columns {
+									colTypeUpper := strings.ToUpper(col.Type)
+									if !strings.Contains(colTypeUpper, "STORED") || !isGeneratedColumnType(col.Type) {
+										continue
+									}
+									genExpr := generatedColumnExpr(col.Type)
+									if isColumnReferencedInExpr(srcName, genExpr) {
+										if alterIsInplace {
+											return nil, mysqlError(3104, "HY000", "Cannot add foreign key on the base column of stored column.")
+										}
+										return nil, mysqlError(1005, "HY000", "Cannot add foreign key constraint")
+									}
+								}
+							}
+						}
 					}
 				}
 				var fkCols []string
 				for _, col := range fkDef.Source {
 					fkCols = append(fkCols, col.String())
 				}
-				if len(fkCols) > 0 {
-					idxName := op.ConstraintDefinition.Name.String()
-					if idxName == "" {
-						idxName = fkCols[0]
-					}
-					// Check if an index already covers these columns
-					covered := false
-					tableDef, _ := db.GetTable(tableName)
-					if tableDef != nil {
-						for _, idx := range tableDef.Indexes {
-							if len(idx.Columns) >= len(fkCols) {
-								match := true
-								for k, fc := range fkCols {
-									if !strings.EqualFold(idx.Columns[k], fc) {
-										match = false
-										break
-									}
-								}
-								if match {
-									covered = true
+				// Determine FK constraint name before validation (needed for error messages).
+				fkName := op.ConstraintDefinition.Name.String()
+				if fkName == "" {
+					// Auto-generate a unique name based on table name and existing FK count
+					if td0, _ := db.GetTable(tableName); td0 != nil {
+						for suffix := 1; ; suffix++ {
+							candidate := fmt.Sprintf("%s_ibfk_%d", tableName, suffix)
+							taken := false
+							for _, existFK := range td0.ForeignKeys {
+								if strings.EqualFold(existFK.Name, candidate) {
+									taken = true
 									break
 								}
 							}
+							if !taken {
+								fkName = candidate
+								break
+							}
+						}
+					} else {
+						fkName = tableName + "_ibfk_1"
+					}
+				}
+				// MySQL enforces max 64-character identifier length for FK constraint names
+				if len(fkName) > 64 {
+					return nil, mysqlError(1059, "42000", fmt.Sprintf("Identifier name '%s' is too long", fkName))
+				}
+				// Check for duplicate FK constraint name (ER_FK_DUP_NAME = 1826)
+				// This check is NOT skipped even when foreign_key_checks=0.
+				if td0, _ := db.GetTable(tableName); td0 != nil {
+					for _, existFK := range td0.ForeignKeys {
+						if strings.EqualFold(existFK.Name, fkName) {
+							return nil, mysqlError(1826, "HY000", fmt.Sprintf("Duplicate foreign key constraint name '%s'", fkName))
 						}
 					}
-					if !covered {
-						db.AddIndex(tableName, catalog.IndexDef{
-							Name:    idxName,
-							Columns: fkCols,
-							Orders:  make([]string, len(fkCols)),
-						})
-					}
 				}
-				// Store the FK constraint in the table definition
-				fkName := op.ConstraintDefinition.Name.String()
-				if fkName == "" {
-					fkName = tableName + "_ibfk_1"
-				}
+				// Build the FK definition for validation.
 				fk := catalog.ForeignKeyDef{
 					Name:    fkName,
 					Columns: fkCols,
@@ -4077,6 +4202,42 @@ func (e *Executor) execAlterTable(stmt *sqlparser.AlterTable) (*Result, error) {
 					}
 					fk.OnDelete = referenceActionToString(fkDef.ReferenceDefinition.OnDelete)
 					fk.OnUpdate = referenceActionToString(fkDef.ReferenceDefinition.OnUpdate)
+				}
+				// Validate that the child table has an index covering the FK columns.
+				// This check must happen BEFORE creating the auto-FK-index so that if it
+				// fails (e.g. GEOMETRY column), no index is left behind.
+				// (ER_FK_NO_INDEX_CHILD = 1005 / "Failed to add the foreign key constraint.
+				//  Missing index for constraint '...' in the foreign table '...'")
+				if err := e.validateFKChildIndex(db, tableName, fkName, fkCols); err != nil {
+					return nil, err
+				}
+				// Validate that the parent (referenced) table has an index covering the
+				// referenced columns. MySQL requires this even when foreign_key_checks=0.
+				// Error 1215 (ER_FK_NO_INDEX_PARENT): "Failed to add the foreign key constraint.
+				//  Missing index for constraint '...' in the referenced table '...'"
+				if fk.ReferencedTable != "" && len(fk.ReferencedColumns) > 0 {
+					if err := e.validateFKParentIndex(db, tableName, fkName, fk.ReferencedTable, fk.ReferencedColumns); err != nil {
+						return nil, err
+					}
+				}
+				// Create implicit FK index if needed (AFTER validation passes).
+				if len(fkCols) > 0 {
+					idxName := op.ConstraintDefinition.Name.String()
+					if idxName == "" {
+						idxName = fkCols[0]
+					}
+					// Check if a usable (non-FULLTEXT, non-SPATIAL) index already covers
+					// the FK columns. FULLTEXT/SPATIAL indexes cannot serve as FK support
+					// indexes, so they must be excluded from this check.
+					tableDef, _ := db.GetTable(tableName)
+					covered := tableHasIndexForColumns(tableDef, fkCols)
+					if !covered {
+						db.AddIndex(tableName, catalog.IndexDef{
+							Name:    idxName,
+							Columns: fkCols,
+							Orders:  make([]string, len(fkCols)),
+						})
+					}
 				}
 				if td, _ := db.GetTable(tableName); td != nil {
 					td.ForeignKeys = append(td.ForeignKeys, fk)

--- a/executor/dml_insert.go
+++ b/executor/dml_insert.go
@@ -2440,6 +2440,36 @@ func baseColumnType(colType string) string {
 	return strings.TrimSpace(colType[:idx])
 }
 
+// isColumnReferencedInExpr checks whether a column name appears as an identifier
+// in a SQL expression string (case-insensitive). This is used to determine if
+// a regular column is a base column of a generated column expression.
+// It uses a simple word-boundary check to avoid false positives.
+func isColumnReferencedInExpr(colName, expr string) bool {
+	// Use case-insensitive search with word boundaries
+	// We look for the column name surrounded by non-identifier characters
+	colLower := strings.ToLower(colName)
+	exprLower := strings.ToLower(expr)
+	// Remove backticks to normalize
+	exprLower = strings.ReplaceAll(exprLower, "`", "")
+	start := 0
+	for {
+		idx := strings.Index(exprLower[start:], colLower)
+		if idx < 0 {
+			return false
+		}
+		pos := start + idx
+		// Check left boundary
+		leftOK := pos == 0 || !isIdentChar(exprLower[pos-1])
+		// Check right boundary
+		end := pos + len(colLower)
+		rightOK := end >= len(exprLower) || !isIdentChar(exprLower[end])
+		if leftOK && rightOK {
+			return true
+		}
+		start = pos + 1
+	}
+}
+
 func (e *Executor) evalGeneratedColumnExpr(expr string, row storage.Row) (interface{}, error) {
 	stmt, err := e.parser().Parse("SELECT " + expr)
 	if err != nil {

--- a/executor/fk_checks.go
+++ b/executor/fk_checks.go
@@ -393,6 +393,117 @@ func fkRowMatches(childCols, parentCols []string, childRow, parentRow storage.Ro
 	return true
 }
 
+// tableHasIndexForColumns returns true if the table has a PRIMARY KEY or index
+// whose leading columns match the given columns (prefix match).
+// It also skips FULLTEXT and SPATIAL indexes (they cannot serve as FK support indexes).
+// geomColumns is an optional set of column names known to be geometry/spatial type;
+// those columns cannot be used as FK index columns either.
+func tableHasIndexForColumns(def *catalog.TableDef, cols []string) bool {
+	if def == nil || len(cols) == 0 {
+		return false
+	}
+	// Check PRIMARY KEY
+	if len(def.PrimaryKey) >= len(cols) {
+		match := true
+		for i, c := range cols {
+			if !strings.EqualFold(def.PrimaryKey[i], c) {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	// Check secondary indexes
+	for _, idx := range def.Indexes {
+		// FULLTEXT and SPATIAL indexes cannot be used for FK support
+		if strings.EqualFold(idx.Type, "FULLTEXT") || strings.EqualFold(idx.Type, "SPATIAL") {
+			continue
+		}
+		if len(idx.Columns) < len(cols) {
+			continue
+		}
+		match := true
+		for i, c := range cols {
+			idxCol := idx.Columns[i]
+			// Strip length prefix (e.g. "a(10)" → "a")
+			if p := strings.Index(idxCol, "("); p >= 0 {
+				idxCol = idxCol[:p]
+			}
+			if !strings.EqualFold(idxCol, c) {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}
+
+// validateFKChildIndex checks that the child (referencing) table has an index covering
+// the FK columns. Returns error 1005 if validation fails.
+// Note: for CREATE TABLE, the FK index is auto-created, so this check mainly applies
+// to certain edge cases (e.g. GEOMETRY columns that can't be indexed for FK).
+func (e *Executor) validateFKChildIndex(db *catalog.Database, childTable, fkName string, fkCols []string) error {
+	def, err := db.GetTable(childTable)
+	if err != nil || def == nil {
+		return nil
+	}
+	// Check if FK columns include a GEOMETRY/SPATIAL type column (cannot be FK column)
+	for _, col := range fkCols {
+		for _, colDef := range def.Columns {
+			if strings.EqualFold(colDef.Name, col) {
+				colTypeUpper := strings.ToUpper(strings.TrimSpace(colDef.Type))
+				baseType := colTypeUpper
+				if p := strings.IndexByte(baseType, '('); p >= 0 {
+					baseType = strings.TrimSpace(baseType[:p])
+				}
+				if baseType == "GEOMETRY" || baseType == "POINT" || baseType == "LINESTRING" ||
+					baseType == "POLYGON" || baseType == "MULTIPOINT" || baseType == "MULTILINESTRING" ||
+					baseType == "MULTIPOLYGON" || baseType == "GEOMETRYCOLLECTION" {
+					// MySQL quirk (Bug#20752436): when the table already has an
+					// existing FK-supporting BTREE index, MySQL tries to reuse/modify
+					// that index internally and returns ER_DROP_INDEX_FK (1553) with
+					// the name of the conflicting index instead of the normal 1005 error.
+					for _, existFK := range def.ForeignKeys {
+						// Find the BTREE index that supports this FK
+						for _, idx := range def.Indexes {
+							if strings.EqualFold(idx.Name, existFK.Name) &&
+								!strings.EqualFold(idx.Type, "FULLTEXT") &&
+								!strings.EqualFold(idx.Type, "SPATIAL") {
+								return mysqlError(1553, "HY000",
+									fmt.Sprintf("Cannot drop index '%s': needed in a foreign key constraint", idx.Name))
+							}
+						}
+					}
+					return mysqlError(1005, "HY000",
+						fmt.Sprintf("Failed to add the foreign key constraint. Missing index for constraint '%s' in the foreign table '%s'", fkName, childTable))
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// validateFKParentIndex checks that the parent (referenced) table has an index
+// on the referenced columns. MySQL requires this even when foreign_key_checks=0.
+// Returns error 1215 (ER_FK_NO_INDEX_PARENT) if the index is missing.
+func (e *Executor) validateFKParentIndex(db *catalog.Database, childTable, fkName, parentTable string, refCols []string) error {
+	parentDef, err := db.GetTable(parentTable)
+	if err != nil || parentDef == nil {
+		// Parent table doesn't exist in this database – skip check (could be cross-db)
+		return nil
+	}
+	if tableHasIndexForColumns(parentDef, refCols) {
+		return nil
+	}
+	return mysqlError(1215, "HY000",
+		fmt.Sprintf("Failed to add the foreign key constraint. Missing index for constraint '%s' in the referenced table '%s'", fkName, parentTable))
+}
+
 // formatColumnList formats a list of column names for error messages.
 func formatColumnList(cols []string) string {
 	parts := make([]string, len(cols))

--- a/executor/information_schema.go
+++ b/executor/information_schema.go
@@ -558,7 +558,6 @@ var singleRowStubTables = map[string]storage.Row{
 	"innodb_fields":         {"INDEX_ID": int64(0), "NAME": "", "POS": int64(0)},
 	"optimizer_trace":       {"QUERY": "", "TRACE": "", "MISSING_BYTES_BEYOND_MAX_MEM_SIZE": int64(0), "INSUFFICIENT_PRIVILEGES": int64(0)},
 	"files":                 {"FILE_NAME": "", "FILE_TYPE": "", "TABLESPACE_NAME": ""},
-	"referential_constraints": {"CONSTRAINT_CATALOG": "def", "CONSTRAINT_SCHEMA": "", "CONSTRAINT_NAME": "", "UNIQUE_CONSTRAINT_CATALOG": "def", "UNIQUE_CONSTRAINT_SCHEMA": "", "UNIQUE_CONSTRAINT_NAME": "", "MATCH_OPTION": "NONE", "UPDATE_RULE": "RESTRICT", "DELETE_RULE": "RESTRICT", "TABLE_NAME": "", "REFERENCED_TABLE_NAME": ""},
 	"innodb_temp_table_info": {"TABLE_ID": int64(0), "NAME": "", "N_COLS": int64(0), "SPACE": int64(0)},
 }
 
@@ -821,6 +820,8 @@ func (e *Executor) buildInformationSchemaRows(tableName, alias string) ([]storag
 		}
 	case "key_column_usage":
 		rawRows = e.infoSchemaKeyColumnUsage()
+	case "referential_constraints":
+		rawRows = e.infoSchemaReferentialConstraints()
 	case "innodb_ft_default_stopword":
 		// MySQL default fulltext stopword list
 		rawRows = []storage.Row{
@@ -1521,6 +1522,110 @@ func (e *Executor) infoSchemaInnoDBForeignCols() []storage.Row {
 	rows := make([]storage.Row, len(colRows))
 	for i, cr := range colRows {
 		rows[i] = cr.row
+	}
+	return rows
+}
+
+// infoSchemaReferentialConstraints returns rows for INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS.
+// Columns: CONSTRAINT_CATALOG, CONSTRAINT_SCHEMA, CONSTRAINT_NAME,
+//          UNIQUE_CONSTRAINT_CATALOG, UNIQUE_CONSTRAINT_SCHEMA, UNIQUE_CONSTRAINT_NAME,
+//          MATCH_OPTION, UPDATE_RULE, DELETE_RULE, TABLE_NAME, REFERENCED_TABLE_NAME
+func (e *Executor) infoSchemaReferentialConstraints() []storage.Row {
+	dbNames := e.Catalog.ListDatabases()
+	sort.Strings(dbNames)
+	var rows []storage.Row
+	for _, dbName := range dbNames {
+		db, err := e.Catalog.GetDatabase(dbName)
+		if err != nil {
+			continue
+		}
+		tableNames := db.ListTables()
+		sort.Strings(tableNames)
+		for _, tableName := range tableNames {
+			def, err := db.GetTable(tableName)
+			if err != nil || def == nil {
+				continue
+			}
+			for _, fk := range def.ForeignKeys {
+				// Determine the name of the unique constraint in the parent table.
+				// MySQL looks for: PRIMARY KEY first, then UNIQUE index covering fk.ReferencedColumns.
+				uniqueConstraintName := ""
+				parentDef, perr := db.GetTable(fk.ReferencedTable)
+				if perr == nil && parentDef != nil {
+					// Check if the FK references the primary key columns
+					if len(fk.ReferencedColumns) > 0 && len(parentDef.PrimaryKey) > 0 {
+						pkMatch := len(fk.ReferencedColumns) <= len(parentDef.PrimaryKey)
+						if pkMatch {
+							for i, rc := range fk.ReferencedColumns {
+								if !strings.EqualFold(rc, parentDef.PrimaryKey[i]) {
+									pkMatch = false
+									break
+								}
+							}
+						}
+						if pkMatch {
+							uniqueConstraintName = "PRIMARY"
+						}
+					}
+					// If not a PK match, look for UNIQUE index
+					if uniqueConstraintName == "" {
+						for _, idx := range parentDef.Indexes {
+							if !idx.Unique {
+								continue
+							}
+							if len(fk.ReferencedColumns) > len(idx.Columns) {
+								continue
+							}
+							match := true
+							for i, rc := range fk.ReferencedColumns {
+								idxCol := idx.Columns[i]
+								// Strip length prefix if any
+								if p := strings.Index(idxCol, "("); p >= 0 {
+									idxCol = idxCol[:p]
+								}
+								if !strings.EqualFold(rc, idxCol) {
+									match = false
+									break
+								}
+							}
+							if match {
+								uniqueConstraintName = idx.Name
+								break
+							}
+						}
+					}
+				}
+
+				deleteRule := "RESTRICT"
+				if fk.OnDelete != "" {
+					deleteRule = strings.ToUpper(fk.OnDelete)
+					if deleteRule == "" {
+						deleteRule = "RESTRICT"
+					}
+				}
+				updateRule := "RESTRICT"
+				if fk.OnUpdate != "" {
+					updateRule = strings.ToUpper(fk.OnUpdate)
+					if updateRule == "" {
+						updateRule = "RESTRICT"
+					}
+				}
+
+				rows = append(rows, storage.Row{
+					"CONSTRAINT_CATALOG":        "def",
+					"CONSTRAINT_SCHEMA":         dbName,
+					"CONSTRAINT_NAME":           fk.Name,
+					"UNIQUE_CONSTRAINT_CATALOG": "def",
+					"UNIQUE_CONSTRAINT_SCHEMA":  dbName,
+					"UNIQUE_CONSTRAINT_NAME":    uniqueConstraintName,
+					"MATCH_OPTION":              "NONE",
+					"UPDATE_RULE":               updateRule,
+					"DELETE_RULE":               deleteRule,
+					"TABLE_NAME":                tableName,
+					"REFERENCED_TABLE_NAME":     fk.ReferencedTable,
+				})
+			}
+		}
 	}
 	return rows
 }

--- a/executor/show.go
+++ b/executor/show.go
@@ -1102,9 +1102,21 @@ func (e *Executor) showIndexes(dbName, tableName string) (*Result, error) {
 			r["EXPRESSION"],    // Expression
 		})
 	}
-	// MySQL's SHOW INDEX preserves index definition order, with PRIMARY always first.
-	// Use a stable sort that only moves PRIMARY to the front and orders by
-	// Seq_in_index within the same index name.
+	// MySQL's SHOW INDEX preserves index definition order, with PRIMARY first.
+	// Within the same table, InnoDB stores SPATIAL indexes before BTREE and
+	// BTREE before FULLTEXT (e.g. when both SPATIAL and FULLTEXT are added in
+	// the same ALTER TABLE). Seq_in_index orders columns within one index.
+	indexTypePriority := func(row []interface{}) int {
+		// row[10] is Index_type
+		switch strings.ToUpper(toString(row[10])) {
+		case "SPATIAL":
+			return 1
+		case "FULLTEXT":
+			return 3
+		default: // BTREE, HASH, etc.
+			return 2
+		}
+	}
 	sort.SliceStable(rows, func(i, j int) bool {
 		ki := toString(rows[i][2])
 		kj := toString(rows[j][2])
@@ -1116,6 +1128,12 @@ func (e *Executor) showIndexes(dbName, tableName string) (*Result, error) {
 		// Within the same index, order by Seq_in_index
 		if strings.EqualFold(ki, kj) {
 			return toInt64(rows[i][3]) < toInt64(rows[j][3])
+		}
+		// Different indexes: sort by type priority (SPATIAL < BTREE < FULLTEXT)
+		pi := indexTypePriority(rows[i])
+		pj := indexTypePriority(rows[j])
+		if pi != pj {
+			return pi < pj
 		}
 		return false
 	})
@@ -1906,7 +1924,11 @@ func (e *Executor) showRoutineStatus(routineType string, rest string) (*Result, 
 func (e *Executor) showCreateTable(tableName string) (*Result, error) {
 	showDB := e.CurrentDB
 	if strings.Contains(tableName, ".") {
-		showDB, tableName = resolveTableNameDB(tableName, e.CurrentDB)
+		// Only treat as db.table if the part before the first dot is non-empty (a valid db name).
+		// A table name like `......` (all dots) should not be split.
+		if idx := strings.Index(tableName, "."); idx > 0 {
+			showDB, tableName = resolveTableNameDB(tableName, e.CurrentDB)
+		}
 	}
 
 	// Privilege check: user must have a full table-level privilege on the table


### PR DESCRIPTION
## Summary

- Store FK definitions in catalog on CREATE TABLE and ALTER TABLE ADD CONSTRAINT
- Enforce FK parent row check on INSERT (error 1452) and ON DELETE/UPDATE CASCADE/SET NULL/RESTRICT
- Validate FK parent table index on CREATE TABLE with foreign_key_checks=1 (error 1215)
- Block DROP TABLE on parent table referenced by FK in another table (error 3730)
- Auto-create BTREE support index for FK columns, correctly skipping FULLTEXT/SPATIAL as unusable
- Enforce 64-char FK constraint name limit (error 1059)
- Fix SHOW INDEXES ordering: SPATIAL before BTREE before FULLTEXT (matches MySQL InnoDB behavior)
- Populate INFORMATION_SCHEMA.REFERENTIAL_CONSTRAINTS, INNODB_FOREIGN, INNODB_FOREIGN_COLS with actual FK data

## Test plan

- [ ] `go build ./... && go test ./... -count=1` passes
- [ ] `innodb/stored_fk` passes (was skip, now pass)
- [ ] `innodb/foreign_key` passes (was skip, now pass)
- [ ] Full suite: Passed 1694 (+2), Failed 306 (-1), no regressions

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)