### PR TITLE
feat: triggers per-row DELETE firing order and SHOW TRIGGERS (Closes #156)

### DIFF
--- a/executor/dml_delete.go
+++ b/executor/dml_delete.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"reflect"
 	"regexp"
 	"sort"
 	"strconv"
@@ -527,27 +528,25 @@ func (e *Executor) execDelete(stmt *sqlparser.Delete) (*Result, error) {
 		}
 	}
 
-	newRows := make([]storage.Row, 0)
 	var affected uint64
-	// afterDeleteRows collects rows that need AFTER DELETE trigger firing.
-	// We fire AFTER DELETE triggers after the row has been physically removed from tbl.Rows,
-	// so that trigger queries (e.g. SELECT COUNT(*)) see the post-deletion state.
-	type afterDeleteEntry struct {
-		row storage.Row
-	}
-	var afterDeleteRows []afterDeleteEntry
 
-	for _, row := range tbl.Rows {
+	// Process rows one at a time, matching MySQL's per-row trigger semantics:
+	//   BEFORE DELETE → delete row → AFTER DELETE
+	// We take a snapshot of the original rows to iterate over (so WHERE evaluation
+	// sees the full original table), then process each matching row: fire BEFORE DELETE,
+	// remove the row from tbl.Rows, and fire AFTER DELETE immediately.
+	originalRows := make([]storage.Row, len(tbl.Rows))
+	copy(originalRows, tbl.Rows)
+
+	for _, row := range originalRows {
 		match := true
 		// Apply PARTITION filter: skip rows not belonging to the specified partitions.
 		if len(stmt.Partitions) > 0 && tbl.Def != nil {
 			inPart, partErr := e.rowBelongsToPartitions(stmt.Partitions, tbl.Def, row)
 			if partErr != nil {
-				newRows = append(newRows, row)
 				continue
 			}
 			if !inPart {
-				newRows = append(newRows, row)
 				continue
 			}
 		}
@@ -565,57 +564,78 @@ func (e *Executor) execDelete(stmt *sqlparser.Delete) (*Result, error) {
 				match = m
 			}
 		}
-		if match {
-			// Fire BEFORE DELETE triggers
-			tbl.Unlock()
-			if err := e.fireTriggers(tableName, "BEFORE", "DELETE", nil, row); err != nil {
-				tbl.Lock()
-				return nil, err
-			}
-			tbl.Lock()
-
-			// Enforce FOREIGN KEY constraints: check child rows referencing this parent row
-			tbl.Unlock()
-			if err := e.checkForeignKeyOnDelete(deleteDB, tableName, row); err != nil {
-				tbl.Lock()
-				if bool(stmt.Ignore) {
-					// DELETE IGNORE: add warning, skip this row (don't delete it)
-					errCode := 1451
-					msg := strings.TrimPrefix(err.Error(), "ERROR 1451 (23000): ")
-					e.addWarning("Warning", errCode, msg)
-					newRows = append(newRows, row)
-					continue
-				}
-				return nil, err
-			}
-			tbl.Lock()
-
-			affected++
-			// Collect row for AFTER DELETE trigger (fired after tbl.Rows is updated)
-			afterDeleteRows = append(afterDeleteRows, afterDeleteEntry{row: row})
-		} else {
-			newRows = append(newRows, row)
+		if !match {
+			continue
 		}
-	}
-	tbl.Rows = newRows
-	// For HEAP/MEMORY tables: if the table is now completely empty, set HeapInsertFront.
-	if tbl.IsHeap() && len(tbl.Rows) == 0 {
-		tbl.HeapInsertFront = true
-	}
-	tbl.InvalidateIndexes()
 
-	// Fire AFTER DELETE triggers now that tbl.Rows reflects the post-deletion state.
-	// This ensures trigger queries (e.g. SELECT COUNT(*)) see the correct row counts.
-	for _, entry := range afterDeleteRows {
+		// Fire BEFORE DELETE triggers
 		tbl.Unlock()
-		if err := e.fireTriggers(tableName, "AFTER", "DELETE", nil, entry.row); err != nil {
+		if err := e.fireTriggers(tableName, "BEFORE", "DELETE", nil, row); err != nil {
+			tbl.Lock()
+			return nil, err
+		}
+		tbl.Lock()
+
+		// Enforce FOREIGN KEY constraints: check child rows referencing this parent row
+		tbl.Unlock()
+		if err := e.checkForeignKeyOnDelete(deleteDB, tableName, row); err != nil {
+			tbl.Lock()
+			if bool(stmt.Ignore) {
+				// DELETE IGNORE: add warning, skip this row (don't delete it)
+				errCode := 1451
+				msg := strings.TrimPrefix(err.Error(), "ERROR 1451 (23000): ")
+				e.addWarning("Warning", errCode, msg)
+				continue
+			}
+			return nil, err
+		}
+		tbl.Lock()
+
+		// Remove this row from tbl.Rows (find and remove the first matching entry).
+		// Use pointer identity: storage.Row is a map, so we compare the map header.
+		newRows := make([]storage.Row, 0, len(tbl.Rows))
+		rowRemoved := false
+		for _, r := range tbl.Rows {
+			if !rowRemoved && rowPtrEqual(r, row) {
+				rowRemoved = true
+				continue
+			}
+			newRows = append(newRows, r)
+		}
+		tbl.Rows = newRows
+		tbl.InvalidateIndexes()
+		affected++
+
+		// Fire AFTER DELETE trigger immediately after removing this row.
+		// This matches MySQL semantics: AFTER DELETE sees the row already gone.
+		tbl.Unlock()
+		if err := e.fireTriggers(tableName, "AFTER", "DELETE", nil, row); err != nil {
 			tbl.Lock()
 			return nil, err
 		}
 		tbl.Lock()
 	}
 
+	// For HEAP/MEMORY tables: if the table is now completely empty, set HeapInsertFront.
+	if tbl.IsHeap() && len(tbl.Rows) == 0 {
+		tbl.HeapInsertFront = true
+	}
+
 	return &Result{AffectedRows: affected}, nil
+}
+
+// rowPtrEqual returns true if two storage.Row map values refer to the same
+// underlying map (pointer identity). Used to uniquely identify a specific row
+// from an originalRows snapshot within the current tbl.Rows slice.
+func rowPtrEqual(a, b storage.Row) bool {
+	va, vb := reflect.ValueOf(a), reflect.ValueOf(b)
+	if !va.IsValid() || !vb.IsValid() {
+		return !va.IsValid() && !vb.IsValid()
+	}
+	if va.IsNil() || vb.IsNil() {
+		return va.IsNil() && vb.IsNil()
+	}
+	return va.Pointer() == vb.Pointer()
 }
 
 func numericOrderColumnSet(def *catalog.TableDef, colNames []string) map[int]bool {

--- a/executor/show.go
+++ b/executor/show.go
@@ -856,6 +856,19 @@ func (e *Executor) execShow(stmt *sqlparser.Show, query string) (*Result, error)
 		return e.showRoutineStatus("PROCEDURE", query[len("SHOW PROCEDURE STATUS"):])
 	}
 
+	// SHOW TRIGGERS [FROM/IN <db>] [LIKE 'pattern' | WHERE expr]
+	if strings.HasPrefix(upper, "SHOW TRIGGERS") {
+		return e.showTriggers(query)
+	}
+
+	// SHOW CREATE TRIGGER <name>
+	if strings.HasPrefix(upper, "SHOW CREATE TRIGGER") {
+		rest := strings.TrimSpace(query[len("SHOW CREATE TRIGGER"):])
+		rest = strings.TrimRight(rest, ";")
+		rest = strings.Trim(rest, "`")
+		return e.showCreateTrigger(rest)
+	}
+
 	// SHOW INDEX/INDEXES/KEYS FROM <table>
 	if strings.HasPrefix(upper, "SHOW INDEX ") || strings.HasPrefix(upper, "SHOW INDEXES ") || strings.HasPrefix(upper, "SHOW KEYS ") {
 		showDB, showTable, ok := parseShowIndexTarget(query, e.CurrentDB)
@@ -2960,6 +2973,136 @@ func (e *Executor) execShowGrants(query string) (*Result, error) {
 	return &Result{
 		Columns:     []string{fmt.Sprintf("Grants for %s@%s", grantUser, grantHost)},
 		Rows:        grantRows,
+		IsResultSet: true,
+	}, nil
+}
+
+// showTriggers handles SHOW TRIGGERS [FROM/IN <db>] [LIKE 'pattern' | WHERE expr].
+// Returns columns: Trigger, Event, Table, Statement, Timing, Created, sql_mode,
+// Definer, character_set_client, collation_connection, Database Collation.
+func (e *Executor) showTriggers(query string) (*Result, error) {
+	upper := strings.ToUpper(strings.TrimSpace(query))
+
+	// Determine target database
+	targetDB := e.CurrentDB
+	rest := strings.TrimSpace(query[len("SHOW TRIGGERS"):])
+	restU := strings.ToUpper(rest)
+
+	if strings.HasPrefix(restU, "FROM ") || strings.HasPrefix(restU, "IN ") {
+		skip := 5
+		if strings.HasPrefix(restU, "IN ") {
+			skip = 3
+		}
+		parts := strings.Fields(rest[skip:])
+		if len(parts) > 0 {
+			targetDB = strings.Trim(parts[0], "`;")
+		}
+		rest = strings.TrimSpace(rest[skip+len(strings.Fields(rest[skip:])[0]):])
+		restU = strings.ToUpper(rest)
+	}
+
+	// Parse optional LIKE or WHERE clause
+	likePattern := ""
+	if strings.HasPrefix(restU, "LIKE ") {
+		likePattern = strings.Trim(strings.TrimRight(strings.TrimSpace(rest[5:]), ";"), "'\"")
+	}
+	_ = upper
+
+	db, err := e.Catalog.GetDatabase(targetDB)
+	if err != nil {
+		return nil, mysqlError(1049, "42000", fmt.Sprintf("Unknown database '%s'", targetDB))
+	}
+
+	cols := []string{
+		"Trigger", "Event", "Table", "Statement", "Timing",
+		"Created", "sql_mode", "Definer",
+		"character_set_client", "collation_connection", "Database Collation",
+	}
+
+	trigNames := make([]string, 0, len(db.Triggers))
+	for n := range db.Triggers {
+		trigNames = append(trigNames, n)
+	}
+	sort.Strings(trigNames)
+
+	sqlMode := "ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION"
+	dbColl := db.CollationName
+	if dbColl == "" {
+		dbColl = "utf8mb4_0900_ai_ci"
+	}
+
+	var rows [][]interface{}
+	for _, trigName := range trigNames {
+		if likePattern != "" && !matchLike(trigName, likePattern) {
+			continue
+		}
+		tr := db.Triggers[trigName]
+		stmt := strings.Join(tr.Body, ";\n")
+		rows = append(rows, []interface{}{
+			tr.Name,
+			tr.Event,
+			tr.Table,
+			stmt,
+			tr.Timing,
+			nil, // Created
+			sqlMode,
+			"root@localhost",
+			"utf8mb4",
+			"utf8mb4_0900_ai_ci",
+			dbColl,
+		})
+	}
+
+	return &Result{
+		Columns:     cols,
+		Rows:        rows,
+		IsResultSet: true,
+	}, nil
+}
+
+// showCreateTrigger handles SHOW CREATE TRIGGER <name>.
+// Returns columns: Trigger, sql_mode, SQL Original Statement,
+// character_set_client, collation_connection, Database Collation, Created.
+func (e *Executor) showCreateTrigger(triggerName string) (*Result, error) {
+	db, err := e.Catalog.GetDatabase(e.CurrentDB)
+	if err != nil {
+		return nil, mysqlError(1049, "42000", fmt.Sprintf("Unknown database '%s'", e.CurrentDB))
+	}
+
+	tr, ok := db.Triggers[triggerName]
+	if !ok {
+		// Try case-insensitive lookup
+		for n, trig := range db.Triggers {
+			if strings.EqualFold(n, triggerName) {
+				tr = trig
+				ok = true
+				break
+			}
+		}
+	}
+	if !ok {
+		return nil, mysqlError(1360, "HY000", fmt.Sprintf("Trigger '%s' does not exist", triggerName))
+	}
+
+	body := strings.Join(tr.Body, ";\n")
+	var createSQL string
+	if len(tr.Body) == 1 {
+		createSQL = fmt.Sprintf("CREATE DEFINER=`root`@`localhost` TRIGGER `%s` %s %s ON `%s` FOR EACH ROW %s",
+			tr.Name, tr.Timing, tr.Event, tr.Table, body)
+	} else {
+		createSQL = fmt.Sprintf("CREATE DEFINER=`root`@`localhost` TRIGGER `%s` %s %s ON `%s` FOR EACH ROW BEGIN\n%s\nEND",
+			tr.Name, tr.Timing, tr.Event, tr.Table, body)
+	}
+
+	sqlMode := "ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION"
+	dbColl := db.CollationName
+	if dbColl == "" {
+		dbColl = "utf8mb4_0900_ai_ci"
+	}
+
+	return &Result{
+		Columns:     []string{"Trigger", "sql_mode", "SQL Original Statement", "character_set_client", "collation_connection", "Database Collation", "Created"},
+		Rows:        [][]interface{}{{tr.Name, sqlMode, createSQL, "utf8mb4", "utf8mb4_0900_ai_ci", dbColl, nil}},
 		IsResultSet: true,
 	}, nil
 }


### PR DESCRIPTION
## Summary

- Fix DELETE trigger execution order to match MySQL semantics: for each row, BEFORE DELETE fires → row is removed → AFTER DELETE fires immediately (per-row, not batch)
- Add `SHOW TRIGGERS [FROM/IN <db>] [LIKE 'pattern']` support
- Add `SHOW CREATE TRIGGER <name>` support

## Root cause

The single-table DELETE path fired all BEFORE DELETE triggers for all matching rows first, then removed all rows, then fired all AFTER DELETE triggers. MySQL's actual behavior is per-row: for each matching row in storage order, fire BEFORE DELETE, remove the row, then fire AFTER DELETE immediately.

This caused `tr_all_type_triggers` to fail: when deleting `c1=6 OR c1=7`, the audit table received entries in the wrong order (BEFORE for c1=6, BEFORE for c1=7, AFTER for c1=6, AFTER for c1=7 instead of BEFORE/AFTER for c1=6 then BEFORE/AFTER for c1=7).

## Fix

Restructured the single-table DELETE loop to snapshot original rows, then process each row individually: fire BEFORE DELETE, remove from `tbl.Rows` using `reflect`-based map pointer identity, fire AFTER DELETE.

## Test results

- `tr_all_type_triggers`: fail → pass
- Pass: 1695 → 1696 (+1)
- Regressions: 0

## Test plan
- [x] `go build ./... && go test ./... -count=1` passes
- [x] `tr_all_type_triggers` now passes
- [x] All existing trigger unit tests pass (`TestTriggerWithIfThen`, `TestBeforeAfterDeleteTriggerOld`, etc.)
- [x] No regressions vs baseline (1695 pass)

🤖 Generated with [Claude Code](https://claude.com/claude-code)