### PR TITLE
feat: EXPLAIN Extra column - Using index, Using where, Using temporary, Using filesort

### DIFF
--- a/executor/explain.go
+++ b/executor/explain.go
@@ -1714,7 +1714,9 @@ func (e *Executor) explainSelect(sel *sqlparser.Select, idCounter *int64, select
 				// When GROUP BY is on a constant expression (e.g. GROUP BY 1), MySQL does
 				// not need a filesort because all rows share the same group key.
 				if !explainGroupByIsAllConstant(sel.GroupBy) {
-					extra = "Using filesort"
+					// GROUP BY on non-constant columns → MySQL uses a temporary table for
+					// grouping and then filesort to order the groups.
+					extra = "Using temporary; Using filesort"
 				}
 			}
 			// "Range checked for each record" detection: applies to any table in a
@@ -1818,6 +1820,18 @@ func (e *Executor) explainSelect(sel *sqlparser.Select, idCounter *int64, select
 						extra = "Using where"
 					} else {
 						extra = fmt.Sprintf("Using where; %v", extra)
+					}
+				}
+			}
+
+			// Add "Using index" when all selected columns are covered by the chosen index.
+			if accessInfo.usingIndex {
+				if extra == nil {
+					extra = "Using index"
+				} else {
+					extraStr := fmt.Sprintf("%v", extra)
+					if !strings.Contains(extraStr, "Using index") {
+						extra = extraStr + "; Using index"
 					}
 				}
 			}
@@ -4489,6 +4503,7 @@ type explainAccessInfo struct {
 	key          interface{} // chosen key name or nil
 	keyLen       interface{} // string representation of key length or nil
 	ref          interface{} // "const", column ref, or nil
+	usingIndex   bool        // true when all selected columns are covered by the chosen index
 }
 
 // explainDetectAccessType analyzes a SELECT's WHERE clause against available indexes
@@ -4512,7 +4527,30 @@ func (e *Executor) explainDetectAccessType(sel *sqlparser.Select, tableName stri
 	}
 
 	if len(whereCols) == 0 {
-		// No WHERE conditions, check if all selected columns are covered by an index → "index" type
+		// No WHERE conditions: check if all selected columns are covered by a secondary index
+		// → "index" access type (full index scan) + "Using index".
+		// Only applies when the SELECT references specific columns (not SELECT *).
+		if sel.SelectExprs != nil {
+			selectCols, isStar := explainExtractSelectColumns(sel.SelectExprs, tableName)
+			if !isStar && len(selectCols) > 0 {
+				for _, idx := range td.Indexes {
+					if explainIndexCoversColumns(td, idx.Name, selectCols) {
+						keyLen := 0
+						for _, col := range idx.Columns {
+							colDef := findColumnDef(td, col)
+							if colDef != nil {
+								keyLen += explainKeyLen(colDef, td.Charset)
+							}
+						}
+						result.accessType = "index"
+						result.key = idx.Name
+						result.keyLen = strconv.Itoa(keyLen)
+						result.usingIndex = true
+						return result
+					}
+				}
+			}
+		}
 		return result
 	}
 
@@ -4728,7 +4766,86 @@ func (e *Executor) explainDetectAccessType(sel *sqlparser.Select, tableName stri
 		result.accessType = "range"
 	}
 
+	// Check if the chosen key covers all selected columns → "Using index".
+	// This applies when access type is ref, eq_ref, const, range (and the key is set).
+	if result.key != nil && result.accessType != "ALL" && sel.SelectExprs != nil {
+		keyName := fmt.Sprintf("%v", result.key)
+		selectCols, isStar := explainExtractSelectColumns(sel.SelectExprs, tableName)
+		if !isStar && len(selectCols) > 0 && explainIndexCoversColumns(td, keyName, selectCols) {
+			result.usingIndex = true
+		}
+	}
+
 	return result
+}
+
+// explainExtractSelectColumns returns the set of column names referenced in a SELECT
+// expression list, lower-cased. Returns (cols, false) normally; returns (nil, true) when
+// SELECT * is used or when any non-column expression is found (i.e. covering check is N/A).
+func explainExtractSelectColumns(exprs *sqlparser.SelectExprs, tableName string) (map[string]bool, bool) {
+	if exprs == nil {
+		return nil, true
+	}
+	cols := map[string]bool{}
+	for _, expr := range exprs.Exprs {
+		switch e := expr.(type) {
+		case *sqlparser.StarExpr:
+			// SELECT * — not coverable unless the index contains all columns, which we don't verify here.
+			return nil, true
+		case *sqlparser.AliasedExpr:
+			col, ok := e.Expr.(*sqlparser.ColName)
+			if !ok {
+				// Non-column expression (function, literal, etc.) — cannot be covered.
+				return nil, true
+			}
+			qual := col.Qualifier.Name.String()
+			if qual != "" && !strings.EqualFold(qual, tableName) {
+				// Column from a different table — skip
+				continue
+			}
+			cols[strings.ToLower(col.Name.String())] = true
+		default:
+			return nil, true
+		}
+	}
+	return cols, false
+}
+
+// explainIndexCoversColumns returns true when all columns in wantCols are present in the
+// given index (for secondary indexes) or primary key columns.
+func explainIndexCoversColumns(td *catalog.TableDef, indexName string, wantCols map[string]bool) bool {
+	if len(wantCols) == 0 {
+		return false
+	}
+	var indexCols []string
+	if strings.EqualFold(indexName, "PRIMARY") {
+		indexCols = td.PrimaryKey
+	} else {
+		for _, idx := range td.Indexes {
+			if strings.EqualFold(idx.Name, indexName) {
+				indexCols = idx.Columns
+				break
+			}
+		}
+	}
+	if len(indexCols) == 0 {
+		return false
+	}
+	idxColSet := map[string]bool{}
+	for _, c := range indexCols {
+		idxColSet[strings.ToLower(c)] = true
+	}
+	// InnoDB secondary indexes implicitly include the primary key columns.
+	// Add them so that "SELECT idx_col, pk_col FROM t WHERE idx_col=val" is also considered covering.
+	for _, pkc := range td.PrimaryKey {
+		idxColSet[strings.ToLower(pkc)] = true
+	}
+	for c := range wantCols {
+		if !idxColSet[c] {
+			return false
+		}
+	}
+	return true
 }
 
 // explainWhereCondition represents a column condition extracted from a WHERE clause.

--- a/executor/plan_explain.go
+++ b/executor/plan_explain.go
@@ -77,8 +77,10 @@ func (pe *PlanExplainer) collectRows(node PlanNode, rows *[][]interface{}, extra
 		})
 
 	case *FilterNode:
-		// Propagate "Using where" down to the leaf
-		pe.collectRows(n.Child, rows, append(extraAccum, "Using where"))
+		// Do not unconditionally propagate "Using where" here; the planner's optimizeNode
+		// already adds "Using where" to the TableScanNode.Extra when appropriate (ALL access only).
+		// Just recurse without adding to extraAccum.
+		pe.collectRows(n.Child, rows, extraAccum)
 
 	case *ProjectNode:
 		pe.collectRows(n.Child, rows, extraAccum)

--- a/executor/planner.go
+++ b/executor/planner.go
@@ -357,6 +357,9 @@ func (p *Planner) optimizeNode(node PlanNode, sel *sqlparser.Select, hasSortAbov
 			if n.AccessPath.Type == "" {
 				n.AccessPath.Type = "ALL"
 			}
+			if ai.usingIndex {
+				n.Extra = appendUnique(n.Extra, "Using index")
+			}
 		} else {
 			if n.AccessPath.Type == "" {
 				n.AccessPath.Type = "ALL"
@@ -364,14 +367,19 @@ func (p *Planner) optimizeNode(node PlanNode, sel *sqlparser.Select, hasSortAbov
 		}
 
 		// Propagate Extra hints from above.
-		if hasFilterAbove {
+		// "Using where" is only shown when the access type is ALL (table scan) and
+		// the WHERE filter is applied by the server after reading from the engine.
+		// For index-based access (ref, const, eq_ref, range), the WHERE condition is
+		// handled by the index lookup and "Using where" is not added.
+		if hasFilterAbove && n.AccessPath.Type == "ALL" {
 			n.Extra = appendUnique(n.Extra, "Using where")
+		}
+		// MySQL Extra order: Using temporary before Using filesort.
+		if hasAggAbove {
+			n.Extra = appendUnique(n.Extra, "Using temporary")
 		}
 		if hasSortAbove {
 			n.Extra = appendUnique(n.Extra, "Using filesort")
-		}
-		if hasAggAbove {
-			n.Extra = appendUnique(n.Extra, "Using temporary")
 		}
 
 	case *FilterNode:
@@ -381,7 +389,9 @@ func (p *Planner) optimizeNode(node PlanNode, sel *sqlparser.Select, hasSortAbov
 		p.optimizeNode(n.Child, sel, true, hasAggAbove, hasFilterAbove)
 
 	case *AggregateNode:
-		p.optimizeNode(n.Child, sel, hasSortAbove, true, hasFilterAbove)
+		// GROUP BY always requires a temporary table + filesort when no index covers the grouping.
+		// Propagate both hasSortAbove and hasAggAbove so the leaf gets "Using temporary; Using filesort".
+		p.optimizeNode(n.Child, sel, true, true, hasFilterAbove)
 
 	case *ProjectNode:
 		p.optimizeNode(n.Child, sel, hasSortAbove, hasAggAbove, hasFilterAbove)


### PR DESCRIPTION
## Summary

- Implements `Using index` (covering index) detection in EXPLAIN Extra column: shown when all SELECTed columns are served from the chosen index, both for ref/range/const access and for full index scans (`type=index`, no WHERE)
- Fixes `Using where` to only appear for `ALL`-scan tables (previously shown incorrectly for index-based access too)
- Fixes GROUP BY Extra from `Using filesort` → `Using temporary; Using filesort` to match MySQL's actual behavior (temp table + sort for non-indexed GROUP BY)
- Orders Extra hints in correct MySQL order: `Using temporary` before `Using filesort`

Closes #192

## Test plan

- [x] `go build ./... && go test ./... -count=1` passes
- [x] Full mtrrun: Passed=1697 (baseline: 1697, no regressions)
- [x] `Using index` verified for covering ref/range/index access types
- [x] `Using where` only for ALL scan with WHERE condition
- [x] `Using filesort` for ORDER BY without suitable index
- [x] `Using temporary; Using filesort` for GROUP BY on non-indexed columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)