### PR TITLE
feat: host pattern matching and column-level SELECT privilege checks

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -6608,10 +6608,25 @@ func (e *Executor) checkTablePrivilege(stmt sqlparser.Statement) error {
 			for _, cte := range s.With.CTEs {
 				cteNames[strings.ToLower(cte.ID.String())] = true
 			}
+			// Check privileges inside CTE bodies (e.g. with qn as (select priv from t1) ...)
+			for _, cte := range s.With.CTEs {
+				if innerSel, ok := cte.Subquery.(*sqlparser.Select); ok {
+					if err := e.checkSelectPrivRecursive(innerSel, user, host, activeRoles, e.CurrentDB); err != nil {
+						return err
+					}
+				}
+			}
 		}
 		// Check SELECT privilege on all referenced real tables (skip subqueries and CTEs)
 		for _, tblExpr := range s.From {
 			if err := checkTableExprPrivSkipCTEs(tblExpr, "SELECT", e.CurrentDB, cteNames, checkAccess); err != nil {
+				return err
+			}
+		}
+		// Column-level SELECT enforcement: when user has only column-restricted grants,
+		// verify each explicitly referenced column is in the granted set.
+		for _, tblExpr := range s.From {
+			if err := e.checkColumnSelectPriv(s, tblExpr, user, host, activeRoles, e.CurrentDB, cteNames); err != nil {
 				return err
 			}
 		}
@@ -6792,6 +6807,270 @@ func checkTableExprPriv(tblExpr sqlparser.TableExpr, priv, currentDB string, che
 	return checkTableExprPrivSkipCTEs(tblExpr, priv, currentDB, nil, check)
 }
 
+// collectColNames walks a sqlparser.Expr tree and appends all ColName references
+// (as lowercased bare column names) to the dst slice.
+func collectColNames(expr sqlparser.Expr, dst *[]string) {
+	if expr == nil {
+		return
+	}
+	switch e := expr.(type) {
+	case *sqlparser.ColName:
+		*dst = append(*dst, strings.ToLower(e.Name.String()))
+	case *sqlparser.BinaryExpr:
+		collectColNames(e.Left, dst)
+		collectColNames(e.Right, dst)
+	case *sqlparser.UnaryExpr:
+		collectColNames(e.Expr, dst)
+	case *sqlparser.FuncExpr:
+		for _, arg := range e.Exprs {
+			if ae, ok := arg.(sqlparser.SelectExpr); ok {
+				if ali, ok2 := ae.(*sqlparser.AliasedExpr); ok2 {
+					collectColNames(ali.Expr, dst)
+				}
+			}
+		}
+	case *sqlparser.CaseExpr:
+		collectColNames(e.Expr, dst)
+		for _, w := range e.Whens {
+			collectColNames(w.Cond, dst)
+			collectColNames(w.Val, dst)
+		}
+		collectColNames(e.Else, dst)
+	case *sqlparser.ComparisonExpr:
+		collectColNames(e.Left, dst)
+		collectColNames(e.Right, dst)
+	case *sqlparser.AndExpr:
+		collectColNames(e.Left, dst)
+		collectColNames(e.Right, dst)
+	case *sqlparser.OrExpr:
+		collectColNames(e.Left, dst)
+		collectColNames(e.Right, dst)
+	case *sqlparser.NotExpr:
+		collectColNames(e.Expr, dst)
+	case *sqlparser.IsExpr:
+		collectColNames(e.Left, dst)
+	case *sqlparser.ConvertExpr:
+		collectColNames(e.Expr, dst)
+	case *sqlparser.CastExpr:
+		collectColNames(e.Expr, dst)
+	case *sqlparser.CollateExpr:
+		collectColNames(e.Expr, dst)
+	}
+}
+
+// collectSelectColNames extracts all column names referenced in a SELECT statement's
+// select expressions and WHERE clause. Returns lowercased column names.
+func collectSelectColNames(s *sqlparser.Select) []string {
+	var cols []string
+	for _, expr := range s.SelectExprs.Exprs {
+		if ae, ok := expr.(*sqlparser.AliasedExpr); ok {
+			collectColNames(ae.Expr, &cols)
+		}
+	}
+	if s.Where != nil {
+		collectColNames(s.Where.Expr, &cols)
+	}
+	if s.GroupBy != nil {
+		for _, g := range s.GroupBy.Exprs {
+			collectColNames(g, &cols)
+		}
+	}
+	if s.Having != nil {
+		collectColNames(s.Having.Expr, &cols)
+	}
+	if s.OrderBy != nil {
+		for _, o := range s.OrderBy {
+			collectColNames(o.Expr, &cols)
+		}
+	}
+	return cols
+}
+
+// hasStarExpr returns true if the SELECT expression list contains a star (SELECT *).
+func hasStarExpr(s *sqlparser.Select) bool {
+	for _, expr := range s.SelectExprs.Exprs {
+		if _, ok := expr.(*sqlparser.StarExpr); ok {
+			return true
+		}
+	}
+	return false
+}
+
+// checkSelectPrivRecursive performs full privilege checking for a SELECT statement,
+// recursing into derived table subqueries. It checks both table-level and column-level
+// SELECT privileges.
+func (e *Executor) checkSelectPrivRecursive(sel *sqlparser.Select, user, host string, activeRoles []string, currentDB string) error {
+	// Collect CTE names to skip privilege check for them (they're virtual tables)
+	cteNames := make(map[string]bool)
+	if sel.With != nil {
+		for _, cte := range sel.With.CTEs {
+			cteNames[strings.ToLower(cte.ID.String())] = true
+			// Recurse into CTE body
+			if innerSel, ok := cte.Subquery.(*sqlparser.Select); ok {
+				if err := e.checkSelectPrivRecursive(innerSel, user, host, activeRoles, currentDB); err != nil {
+					return err
+				}
+			}
+		}
+	}
+
+	// checkAccess checks table-level SELECT privilege
+	checkAccess := func(priv, dbName, tableName string) error {
+		dbLower := strings.ToLower(dbName)
+		if dbLower == "information_schema" || dbLower == "performance_schema" {
+			return nil
+		}
+		if e.tempTables != nil {
+			tblLower := strings.ToLower(tableName)
+			if e.tempTables[tableName] || e.tempTables[tblLower] {
+				return nil
+			}
+		}
+		if !e.grantStore.HasPrivilege(user, host, priv, dbName, tableName, activeRoles) {
+			return mysqlError(1142, "42000", fmt.Sprintf("%s command denied to user '%s'@'%s' for table '%s'",
+				priv, user, host, tableName))
+		}
+		return nil
+	}
+
+	// Walk all table expressions
+	var checkTblExpr func(te sqlparser.TableExpr) error
+	checkTblExpr = func(te sqlparser.TableExpr) error {
+		switch t := te.(type) {
+		case *sqlparser.AliasedTableExpr:
+			if tn, ok := t.Expr.(sqlparser.TableName); ok {
+				tblName := tn.Name.String()
+				if strings.EqualFold(tblName, "dual") {
+					return nil
+				}
+				if cteNames[strings.ToLower(tblName)] {
+					return nil
+				}
+				dbName := currentDB
+				if !tn.Qualifier.IsEmpty() {
+					dbName = tn.Qualifier.String()
+				}
+				// Table-level check
+				if err := checkAccess("SELECT", dbName, tblName); err != nil {
+					return err
+				}
+				// Column-level check
+				if err := e.checkColumnAccessForTable(sel, tblName, dbName, user, host, activeRoles); err != nil {
+					return err
+				}
+			} else if dt, ok := t.Expr.(*sqlparser.DerivedTable); ok {
+				// Recurse into derived table subquery
+				if innerSel, ok2 := dt.Select.(*sqlparser.Select); ok2 {
+					if err := e.checkSelectPrivRecursive(innerSel, user, host, activeRoles, currentDB); err != nil {
+						return err
+					}
+				}
+			}
+		case *sqlparser.JoinTableExpr:
+			if err := checkTblExpr(t.LeftExpr); err != nil {
+				return err
+			}
+			return checkTblExpr(t.RightExpr)
+		case *sqlparser.ParenTableExpr:
+			for _, inner := range t.Exprs {
+				if err := checkTblExpr(inner); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	}
+
+	for _, te := range sel.From {
+		if err := checkTblExpr(te); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// checkColumnAccessForTable checks column-level SELECT privilege for a specific table reference
+// within a SELECT statement. When the user has only column-restricted grants, verifies that
+// each referenced column is in the granted set.
+func (e *Executor) checkColumnAccessForTable(sel *sqlparser.Select, tblName, dbName, user, host string, activeRoles []string) error {
+	dbLower := strings.ToLower(dbName)
+	if dbLower == "information_schema" || dbLower == "performance_schema" {
+		return nil
+	}
+	hasFullAccess, grantedCols := e.grantStore.GetGrantedColumnsForPriv(user, host, "SELECT", dbName, tblName, activeRoles)
+	if hasFullAccess || len(grantedCols) == 0 {
+		// Full access or no column-restricted grant (table-level check already handles denial)
+		return nil
+	}
+	// User has only column-restricted SELECT: verify referenced columns
+	grantedSet := make(map[string]bool, len(grantedCols))
+	for _, c := range grantedCols {
+		grantedSet[strings.ToLower(c)] = true
+	}
+	// If SELECT *, that accesses all columns - deny for any non-granted column
+	if hasStarExpr(sel) {
+		// Find the first non-granted column in the table definition
+		// For simplicity, return generic error (MySQL returns the first column alphabetically)
+		return mysqlError(1143, "42000", fmt.Sprintf("SELECT command denied to user '%s'@'%s' for column '*' in table '%s'",
+			user, host, tblName))
+	}
+	// Check explicitly named columns
+	refCols := collectSelectColNames(sel)
+	for _, col := range refCols {
+		if col == "" {
+			continue
+		}
+		if !grantedSet[col] {
+			return mysqlError(1143, "42000", fmt.Sprintf("SELECT command denied to user '%s'@'%s' for column '%s' in table '%s'",
+				user, host, col, tblName))
+		}
+	}
+	return nil
+}
+
+// checkColumnSelectPriv checks column-level SELECT privilege for a table expression.
+// When the user has only column-restricted SELECT grants (e.g. GRANT SELECT(pub) ON t),
+// each referenced column name is verified against the granted column list.
+// Returns error 1143 if a column is not in the granted set.
+func (e *Executor) checkColumnSelectPriv(sel *sqlparser.Select, tblExpr sqlparser.TableExpr, user, host string, activeRoles []string, currentDB string, cteNames map[string]bool) error {
+	switch t := tblExpr.(type) {
+	case *sqlparser.AliasedTableExpr:
+		if tn, ok := t.Expr.(sqlparser.TableName); ok {
+			tblName := tn.Name.String()
+			if strings.EqualFold(tblName, "dual") {
+				return nil
+			}
+			if cteNames != nil && cteNames[strings.ToLower(tblName)] {
+				return nil
+			}
+			dbName := currentDB
+			if !tn.Qualifier.IsEmpty() {
+				dbName = tn.Qualifier.String()
+			}
+			return e.checkColumnAccessForTable(sel, tblName, dbName, user, host, activeRoles)
+		} else if dt, ok := t.Expr.(*sqlparser.DerivedTable); ok {
+			// Recurse into derived table subquery
+			if innerSel, ok2 := dt.Select.(*sqlparser.Select); ok2 {
+				if err := e.checkSelectPrivRecursive(innerSel, user, host, activeRoles, currentDB); err != nil {
+					return err
+				}
+			}
+		}
+	case *sqlparser.JoinTableExpr:
+		if err := e.checkColumnSelectPriv(sel, t.LeftExpr, user, host, activeRoles, currentDB, cteNames); err != nil {
+			return err
+		}
+		return e.checkColumnSelectPriv(sel, t.RightExpr, user, host, activeRoles, currentDB, cteNames)
+	case *sqlparser.ParenTableExpr:
+		for _, te := range t.Exprs {
+			if err := e.checkColumnSelectPriv(sel, te, user, host, activeRoles, currentDB, cteNames); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
 // checkTableExprPrivSkipCTEs recursively checks privilege for a table expression, skipping CTE virtual tables.
 func checkTableExprPrivSkipCTEs(tblExpr sqlparser.TableExpr, priv, currentDB string, cteNames map[string]bool, check func(priv, db, table string) error) error {
 	switch t := tblExpr.(type) {
@@ -6811,8 +7090,23 @@ func checkTableExprPrivSkipCTEs(tblExpr sqlparser.TableExpr, priv, currentDB str
 				dbName = tn.Qualifier.String()
 			}
 			return check(priv, dbName, tblName)
+		} else if dt, ok := t.Expr.(*sqlparser.DerivedTable); ok {
+			// Recurse into derived table subquery (SELECT priv FROM t checks t's privileges)
+			if innerSel, ok2 := dt.Select.(*sqlparser.Select); ok2 {
+				innerCTEs := make(map[string]bool)
+				if innerSel.With != nil {
+					for _, cte := range innerSel.With.CTEs {
+						innerCTEs[strings.ToLower(cte.ID.String())] = true
+					}
+				}
+				for _, te := range innerSel.From {
+					if err := checkTableExprPrivSkipCTEs(te, priv, currentDB, innerCTEs, check); err != nil {
+						return err
+					}
+				}
+			}
 		}
-		// Subquery or derived table - no table-level privilege check here
+		// Other subquery forms - no table-level privilege check here
 	case *sqlparser.JoinTableExpr:
 		if err := checkTableExprPrivSkipCTEs(t.LeftExpr, priv, currentDB, cteNames, check); err != nil {
 			return err

--- a/executor/grants.go
+++ b/executor/grants.go
@@ -632,17 +632,10 @@ func (gs *GrantStore) HasPrivilege(user, host, priv, db, table string, activeRol
 		return false
 	}
 
-	// Check user's own grants (exact host, then wildcard host)
-	uk := userKey(user, host)
-	if checkEntries(gs.entries[uk]) {
+	// Check user's own grants (exact host, wildcard host, and host patterns like "192.168.%")
+	allUserEntries := gs.findEntriesForUser(user, host)
+	if checkEntries(allUserEntries) {
 		return true
-	}
-	// Also check grants stored with wildcard host "%"
-	if host != "%" {
-		ukWild := userKey(user, "%")
-		if checkEntries(gs.entries[ukWild]) {
-			return true
-		}
 	}
 
 	// Expand active roles recursively
@@ -724,14 +717,9 @@ func (gs *GrantStore) HasFullTablePrivilege(user, host, db, table string, active
 		return false
 	}
 
-	uk := userKey(user, host)
-	if checkEntries(gs.entries[uk]) {
+	allUserEntries2 := gs.findEntriesForUser(user, host)
+	if checkEntries(allUserEntries2) {
 		return true
-	}
-	if host != "%" {
-		if checkEntries(gs.entries[userKey(user, "%")]) {
-			return true
-		}
 	}
 
 	// Check via active roles
@@ -798,14 +786,9 @@ func (gs *GrantStore) HasColumnPrivilege(user, host, db, table, column string, a
 		return false
 	}
 
-	uk := userKey(user, host)
-	if checkEntries(gs.entries[uk]) {
+	allUserEntries := gs.findEntriesForUser(user, host)
+	if checkEntries(allUserEntries) {
 		return true
-	}
-	if host != "%" {
-		if checkEntries(gs.entries[userKey(user, "%")]) {
-			return true
-		}
 	}
 
 	// Check via active roles
@@ -856,18 +839,9 @@ var tablePrivileges = map[string]bool{
 func (gs *GrantStore) UserHasAnyRoleGrant(user, host string) bool {
 	gs.mu.RLock()
 	defer gs.mu.RUnlock()
-	uk := userKey(user, host)
-	for _, e := range gs.entries[uk] {
+	for _, e := range gs.findEntriesForUser(user, host) {
 		if e.Type == GrantTypeRole {
 			return true
-		}
-	}
-	if host != "%" {
-		ukWild := userKey(user, "%")
-		for _, e := range gs.entries[ukWild] {
-			if e.Type == GrantTypeRole {
-				return true
-			}
 		}
 	}
 	return false
@@ -899,17 +873,7 @@ func (gs *GrantStore) UserHasAnyTablePrivGrant(user, host string) bool {
 		return false
 	}
 
-	uk := userKey(user, host)
-	if hasTablePrivEntry(gs.entries[uk]) {
-		return true
-	}
-	if host != "%" {
-		ukWild := userKey(user, "%")
-		if hasTablePrivEntry(gs.entries[ukWild]) {
-			return true
-		}
-	}
-	return false
+	return hasTablePrivEntry(gs.findEntriesForUser(user, host))
 }
 
 // HasAnyTableAccess returns true if the user has any privilege (full or column-level)
@@ -945,14 +909,9 @@ func (gs *GrantStore) HasAnyTableAccess(user, host, db, table string, activeRole
 		return false
 	}
 
-	uk := userKey(user, host)
-	if checkEntries(gs.entries[uk]) {
+	allUserEntries3 := gs.findEntriesForUser(user, host)
+	if checkEntries(allUserEntries3) {
 		return true
-	}
-	if host != "%" {
-		if checkEntries(gs.entries[userKey(user, "%")]) {
-			return true
-		}
 	}
 
 	// Check via active roles
@@ -1000,6 +959,196 @@ func dbNameMatches(pattern, dbName string) bool {
 		return matchLike(strings.ToLower(dbName), strings.ToLower(pattern))
 	}
 	return false
+}
+
+// hostPatternMatches checks if a stored host pattern matches the connecting host.
+// MySQL host patterns support:
+//   - exact match (case-insensitive)
+//   - "%" wildcard (matches any host)
+//   - "%" and "_" wildcards in patterns like "192.168.%", "%.example.com"
+//   - IP subnet masks like "192.168.0.0/255.255.0.0" (not yet implemented: treated as exact)
+func hostPatternMatches(pattern, connectingHost string) bool {
+	// Exact match (most common case)
+	if strings.EqualFold(pattern, connectingHost) {
+		return true
+	}
+	// Wildcard "%" matches any host
+	if pattern == "%" {
+		return true
+	}
+	// Pattern with % or _ wildcard characters
+	if strings.ContainsAny(pattern, "%_") {
+		return matchLike(strings.ToLower(connectingHost), strings.ToLower(pattern))
+	}
+	return false
+}
+
+// findEntriesForUser returns all grant entries for the given user across all stored host
+// patterns that match the connecting host. This supports patterns like "192.168.%" that
+// may not match the exact key but whose pattern matches the connecting host.
+func (gs *GrantStore) findEntriesForUser(user, connectingHost string) []GrantEntry {
+	// Fast path: exact key match
+	uk := userKey(user, connectingHost)
+	exact := gs.entries[uk]
+
+	// Fast path: wildcard host "%"
+	var wildcard []GrantEntry
+	if connectingHost != "%" {
+		ukWild := userKey(user, "%")
+		wildcard = gs.entries[ukWild]
+	}
+
+	// Check all other stored keys for pattern matches
+	// This handles cases like user@'192.168.%'
+	userLower := strings.ToLower(user)
+	var patternMatches []GrantEntry
+	for key, entries := range gs.entries {
+		// Skip exact and wildcard already covered
+		if key == uk || key == userKey(user, "%") {
+			continue
+		}
+		// Parse user@host from key
+		atIdx := strings.LastIndex(key, "@")
+		if atIdx < 0 {
+			continue
+		}
+		keyUser := key[:atIdx]
+		keyHost := key[atIdx+1:]
+		if keyUser != userLower {
+			continue
+		}
+		// Check if this host pattern matches the connecting host
+		if hostPatternMatches(keyHost, connectingHost) {
+			patternMatches = append(patternMatches, entries...)
+		}
+	}
+
+	if len(wildcard) == 0 && len(patternMatches) == 0 {
+		return exact
+	}
+	combined := make([]GrantEntry, 0, len(exact)+len(wildcard)+len(patternMatches))
+	combined = append(combined, exact...)
+	combined = append(combined, wildcard...)
+	combined = append(combined, patternMatches...)
+	return combined
+}
+
+// GetGrantedColumnsForPriv returns the set of columns explicitly granted for a privilege
+// on the given db.table for the user, along with whether the user has full (non-column-restricted)
+// access. If hasFullAccess is true, all columns are accessible. If false, only grantedCols are.
+// Returns hasFullAccess=true if the user has a non-column-restricted grant (global, DB, or table-level).
+// Returns hasFullAccess=false with grantedCols containing the explicit columns otherwise.
+// Returns hasFullAccess=false with empty grantedCols if the user has no privilege at all.
+func (gs *GrantStore) GetGrantedColumnsForPriv(user, host, priv, db, table string, activeRoles []string) (hasFullAccess bool, grantedCols []string) {
+	gs.mu.RLock()
+	defer gs.mu.RUnlock()
+
+	priv = strings.ToUpper(priv)
+
+	var colSet []string
+	var foundAny bool
+
+	checkEntries := func(entries []GrantEntry) {
+		for _, e := range entries {
+			if e.Type == GrantTypeRole {
+				continue
+			}
+			// Check scope
+			covers := false
+			switch e.Type {
+			case GrantTypeGlobal:
+				covers = true
+			case GrantTypeDB:
+				entryDB := strings.TrimSuffix(e.Object, ".*")
+				covers = db != "" && dbNameMatches(entryDB, db)
+			case GrantTypeTable:
+				parts := strings.SplitN(e.Object, ".", 2)
+				covers = len(parts) == 2 && db != "" && table != "" &&
+					dbNameMatches(parts[0], db) && strings.EqualFold(parts[1], table)
+			}
+			if !covers {
+				continue
+			}
+			for _, p := range e.Privs {
+				if p == "ALL PRIVILEGES" {
+					hasFullAccess = true
+					return
+				}
+				if parenIdx := strings.Index(p, "("); parenIdx > 0 {
+					basePriv := strings.TrimSpace(p[:parenIdx])
+					if strings.EqualFold(basePriv, priv) {
+						// Column-restricted grant
+						foundAny = true
+						colPart := strings.Trim(p[parenIdx:], "()")
+						for _, col := range strings.Split(colPart, ",") {
+							col = strings.TrimSpace(col)
+							col = strings.Trim(col, "`'\"")
+							colSet = append(colSet, strings.ToLower(col))
+						}
+					}
+				} else if strings.EqualFold(p, priv) {
+					// Full (non-column-restricted) grant
+					hasFullAccess = true
+					return
+				}
+			}
+		}
+	}
+
+	// Check user's own entries (including host-pattern matches)
+	allEntries := gs.findEntriesForUser(user, host)
+	checkEntries(allEntries)
+	if hasFullAccess {
+		return true, nil
+	}
+
+	// Check via active roles recursively
+	var checkRole func(roleName, roleHost string, visited map[string]bool)
+	checkRole = func(roleName, roleHost string, visited map[string]bool) {
+		rk := userKey(roleName, roleHost)
+		if visited[rk] {
+			return
+		}
+		visited[rk] = true
+		checkEntries(gs.roles[rk])
+		if hasFullAccess {
+			return
+		}
+		allRoleEntries := append(gs.roles[rk], gs.entries[rk]...)
+		for _, e := range allRoleEntries {
+			if e.Type == GrantTypeRole {
+				nh := e.RoleHost
+				if nh == "" {
+					nh = "%"
+				}
+				checkRole(e.RoleName, nh, visited)
+				if hasFullAccess {
+					return
+				}
+			}
+		}
+	}
+	visited := make(map[string]bool)
+	for _, roleName := range activeRoles {
+		checkRole(roleName, "%", visited)
+		if hasFullAccess {
+			return true, nil
+		}
+	}
+
+	if !foundAny && len(colSet) == 0 {
+		return false, nil
+	}
+	// Deduplicate
+	seen := make(map[string]bool)
+	var deduped []string
+	for _, c := range colSet {
+		if !seen[c] {
+			seen[c] = true
+			deduped = append(deduped, c)
+		}
+	}
+	return false, deduped
 }
 
 // BuildShowGrants builds SHOW GRANTS output rows for a user.

--- a/executor/grants_test.go
+++ b/executor/grants_test.go
@@ -5,6 +5,98 @@ import (
 	"testing"
 )
 
+// TestHostPatternMatching verifies that GRANT user@'192.168.%' type patterns match correctly.
+func TestHostPatternMatching(t *testing.T) {
+	gs := NewGrantStore()
+
+	// Grant SELECT on *.* to testuser@'192.168.%'
+	gs.RegisterUser("testuser", "192.168.%")
+	gs.AddPrivGrant("testuser", "192.168.%", "SELECT", "*.*", false)
+
+	// Check that a connecting host matching the pattern gets the privilege
+	if !gs.HasPrivilege("testuser", "192.168.1.100", "SELECT", "db", "tbl", nil) {
+		t.Error("HasPrivilege should return true for host matching pattern 192.168.%")
+	}
+	// Non-matching host should not get the privilege
+	if gs.HasPrivilege("testuser", "10.0.0.1", "SELECT", "db", "tbl", nil) {
+		t.Error("HasPrivilege should return false for host not matching pattern 192.168.%")
+	}
+	// Exact wildcard % matches everything
+	gs.AddPrivGrant("allhosts", "%", "INSERT", "*.*", false)
+	if !gs.HasPrivilege("allhosts", "anything.example.com", "INSERT", "db", "tbl", nil) {
+		t.Error("HasPrivilege should return true for host % pattern")
+	}
+}
+
+// TestColumnLevelSelectPrivilege verifies that GRANT SELECT(col1) restricts col2 access.
+func TestColumnLevelSelectPrivilege(t *testing.T) {
+	e := newTestExecutor(t)
+
+	// Create test table and user
+	if _, err := e.Execute("CREATE TABLE t_colpriv (pub INT, priv INT)"); err != nil {
+		t.Fatalf("CREATE TABLE: %v", err)
+	}
+	if _, err := e.Execute("INSERT INTO t_colpriv VALUES (1, 2)"); err != nil {
+		t.Fatalf("INSERT: %v", err)
+	}
+	if _, err := e.Execute("CREATE USER user1@localhost"); err != nil {
+		t.Fatalf("CREATE USER: %v", err)
+	}
+	// Grant SELECT on only the 'pub' column
+	if _, err := e.Execute("GRANT SELECT(pub) ON test.t_colpriv TO user1@localhost"); err != nil {
+		t.Fatalf("GRANT SELECT(pub): %v", err)
+	}
+
+	// Set current user to user1
+	if _, err := e.Execute("SET @__current_user = 'user1'"); err != nil {
+		t.Fatalf("SET current_user: %v", err)
+	}
+
+	// SELECT pub should succeed
+	if _, err := e.Execute("SELECT pub FROM t_colpriv"); err != nil {
+		t.Fatalf("SELECT pub should succeed: %v", err)
+	}
+
+	// SELECT priv should fail with error 1143
+	_, err := e.Execute("SELECT priv FROM t_colpriv")
+	if err == nil {
+		t.Fatal("SELECT priv should be denied for column-restricted user")
+	}
+	if !strings.Contains(err.Error(), "1143") {
+		t.Fatalf("expected error 1143, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "column 'priv'") {
+		t.Fatalf("expected 'column 'priv'' in error, got: %v", err)
+	}
+
+	// Clear user context
+	if _, err := e.Execute("SET @__current_user = ''"); err != nil {
+		t.Fatalf("SET current_user: %v", err)
+	}
+}
+
+// TestGetGrantedColumnsForPriv verifies the column grant introspection function.
+func TestGetGrantedColumnsForPriv(t *testing.T) {
+	gs := NewGrantStore()
+	gs.RegisterUser("u1", "localhost")
+	gs.AddPrivGrant("u1", "localhost", "SELECT(pub,name)", "db.t1", false)
+
+	hasFullAccess, cols := gs.GetGrantedColumnsForPriv("u1", "localhost", "SELECT", "db", "t1", nil)
+	if hasFullAccess {
+		t.Error("expected hasFullAccess=false for column-restricted grant")
+	}
+	if len(cols) != 2 {
+		t.Errorf("expected 2 granted columns, got %v", cols)
+	}
+
+	// Full SELECT grant
+	gs.AddPrivGrant("u2", "localhost", "SELECT", "db.t1", false)
+	hasFullAccess2, _ := gs.GetGrantedColumnsForPriv("u2", "localhost", "SELECT", "db", "t1", nil)
+	if !hasFullAccess2 {
+		t.Error("expected hasFullAccess=true for full SELECT grant")
+	}
+}
+
 func TestGrantStoreBasic(t *testing.T) {
 	gs := NewGrantStore()
 	gs.RegisterRole("r1")


### PR DESCRIPTION
## Summary

- Implements host pattern matching for GRANT statements (e.g. `user@'192.168.%'`) so wildcard hostname patterns match connecting clients correctly
- Implements column-level SELECT privilege enforcement: `GRANT SELECT(col1) ON t TO user` now causes `SELECT col2 FROM t` to fail with error 1143 (SELECT command denied for column)
- Recursively checks privileges in derived table subqueries and CTE bodies

## Changes

- `executor/grants.go`: Add `hostPatternMatches()`, `findEntriesForUser()`, `GetGrantedColumnsForPriv()` functions; update all privilege check functions to use host pattern matching
- `executor/executor.go`: Add `checkColumnAccessForTable()`, `checkSelectPrivRecursive()`, helper functions (`collectColNames`, `collectSelectColNames`, `hasStarExpr`); update `checkTablePrivilege` to enforce column-level SELECT checks including recursion into derived tables and CTEs
- `executor/grants_test.go`: Add unit tests for host pattern matching, column-level privilege enforcement, and column grant introspection

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./... -count=1` passes (all existing tests pass + 3 new tests added)
- [x] Full mtrrun suite: Passed=1697 (same as baseline), regression=0
- [x] first-diff-line improvements: `with_grant` 15→21, `roles2` 96→143

Closes #167

🤖 Generated with [Claude Code](https://claude.com/claude-code)