### PR TITLE
fix: allow newlines as whitespace in TIMESTAMP literal parsing

### DIFF
--- a/executor/expr_eval.go
+++ b/executor/expr_eval.go
@@ -252,8 +252,9 @@ func normalizeTimestampLiteral(s string) (string, error) {
 		}
 		return "", errFn()
 	}
-	// Must contain at least a space separator (date + time)
-	spaceIdx := strings.Index(s, " ")
+	// Must contain at least a space (or newline) separator (date + time).
+	// SQL literals may have embedded newlines when the query wraps across lines.
+	spaceIdx := strings.IndexAny(s, " \t\n\r")
 	if spaceIdx < 0 {
 		return "", errFn()
 	}


### PR DESCRIPTION
## Summary

- Fixed `normalizeTimestampLiteral` to accept newline (`\n`), tab (`\t`), and carriage return (`\r`) as valid date/time separators, in addition to space
- SQL timestamp literals that wrap across lines (e.g. `timestamp '2005-05-05\n05:05:05.555555'`) were incorrectly rejected with `ER_INCORRECT_DATETIME_VALUE`
- `other/func_test` improved from error status (execution aborted mid-test) to fail status (first-diff-line: 10)
- No regressions: baseline 1699 passed tests maintained

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./... -count=1` passes
- [x] `other/with_recursive_bugs` still passes
- [x] `other/func_test` improved: error → fail (no longer aborts on TIMESTAMP newline literal)
- [x] Full suite: 1699 passed (same as baseline), 0 regressions

Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)