### PR TITLE
feat: LOAD DATA improvements - gb18030, ER_SP_BADSTATEMENT, ER_BLOBS_AND_NO_TERMINATED, view check

### DIFF
--- a/executor/procedures.go
+++ b/executor/procedures.go
@@ -1222,6 +1222,11 @@ func validateRoutineBody(bodyStmts []string) error {
 			return mysqlError(1295, "0A000", "USE is not allowed in stored procedures")
 		}
 
+		// Error ER_SP_BADSTATEMENT (1295): LOAD DATA is not allowed in stored routines
+		if strings.HasPrefix(upper, "LOAD DATA ") || strings.HasPrefix(upper, "LOAD DATA\t") {
+			return mysqlError(1295, "0A000", "LOAD DATA is not allowed in stored procedures")
+		}
+
 		// Check OPEN/CLOSE/FETCH for undeclared cursor names (error 1324)
 		var opCursorName string
 		if strings.HasPrefix(upper, "OPEN ") {

--- a/executor/select.go
+++ b/executor/select.go
@@ -7945,6 +7945,12 @@ func (e *Executor) execLoadData(query string) (*Result, error) {
 		return nil, err
 	}
 
+	// Check if the target is a non-updatable view before attempting file I/O.
+	// MySQL validates the target table first (before reading the file).
+	if _, isView, _, viewErr := e.resolveViewToBaseTable(opts.tableName); viewErr != nil && isView {
+		return nil, mysqlError(1288, "HY000", fmt.Sprintf("The target table %s of the LOAD is not updatable", opts.tableName))
+	}
+
 	// Enforce secure_file_priv before attempting to open the file.
 	if !opts.isLocal {
 		if err := e.checkSecureFilePriv(opts.filePath); err != nil {
@@ -8029,6 +8035,11 @@ func (e *Executor) execLoadData(query string) (*Result, error) {
 		if decoded, err := decodeEUCJP(data); err == nil {
 			data = decoded
 		}
+	case "gb18030", "gbk", "gb2312":
+		// GB18030/GBK: multi-byte charset where the second byte of a multi-byte
+		// sequence can be 0x5C (backslash). Store raw bytes so HEX() reflects the
+		// gb18030 encoding. Escape processing in processLoadDataField is byte-level
+		// and correctly handles the leading escape before a multi-byte sequence.
 	case "latin1", "utf8", "utf8mb3", "utf8mb4", "binary", "ascii":
 		// latin1 is a superset of ASCII; Go strings handle bytes directly.
 		// utf8/utf8mb4 is Go's native encoding. No conversion needed.
@@ -8112,6 +8123,17 @@ func (e *Executor) execLoadData(query string) (*Result, error) {
 	tableColNames := make([]string, len(tbl.Def.Columns))
 	for i, col := range tbl.Def.Columns {
 		tableColNames[i] = col.Name
+	}
+
+	// ER_BLOBS_AND_NO_TERMINATED (1162): if the table has a BLOB/TEXT column and
+	// FIELDS TERMINATED BY is empty (fixed-row mode), MySQL rejects the statement.
+	if opts.fieldsTermBy == "" {
+		for _, col := range tbl.Def.Columns {
+			upperColType := strings.ToUpper(col.Type)
+			if strings.Contains(upperColType, "BLOB") || strings.Contains(upperColType, "TEXT") {
+				return nil, mysqlError(1162, "42000", "You can't use fixed rowlength with BLOBs; please use 'fields terminated by'")
+			}
+		}
 	}
 
 	var pkCols []string


### PR DESCRIPTION
## Summary

Implements four LOAD DATA INFILE specification requirements from issue #185:

- **gb18030 charset**: Add `gb18030`/`gbk`/`gb2312` to the charset switch in `execLoadData` as a no-conversion case, storing raw bytes so that `HEX()` correctly returns the GB18030-encoded byte representation (e.g. `815C825C` for multi-byte sequences with `0x5C` as the second byte)
- **ER_SP_BADSTATEMENT**: Detect `LOAD DATA` in stored procedure bodies during `validateRoutineBody` at `CREATE PROCEDURE` time, returning error 1295/0A000 "LOAD DATA is not allowed in stored procedures"
- **ER_BLOBS_AND_NO_TERMINATED**: Check for BLOB/TEXT columns when `FIELDS TERMINATED BY ''` is specified (fixed-rowlength mode), returning error 1162/42000 "You can't use fixed rowlength with BLOBs; please use 'fields terminated by'"
- **Early view check**: Move the non-updatable view check before file I/O so that `LOAD DATA INTO TABLE <non-updatable-view>` returns `ER_NON_UPDATABLE_TABLE` rather than a file-not-found error

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./... -count=1` all pass (executor + harness)
- [ ] `other/loaddata` test: ER_SP_BADSTATEMENT, ER_BLOBS_AND_NO_TERMINATED, and ER_NON_UPDATABLE_TABLE cases correctly handled (test still errors at line 374 due to pre-existing DUMPFILE unsupported, unrelated to this PR)
- [ ] No regressions in `other` suite (249 pass, consistent with baseline)

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)