### PR TITLE
feat: implement CREATE/DROP FUNCTION (UDF) with characteristics

### DIFF
--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -147,12 +147,15 @@ type TriggerDef struct {
 
 // ProcedureDef represents a stored procedure definition.
 type ProcedureDef struct {
-	Name        string
-	Params      []ProcParam
-	Body        []string // SQL statements in the procedure body
-	BodyText    string   // original body text (begin...end or full body) for information_schema
-	OriginalSQL string   // original CREATE PROCEDURE statement
-	SqlMode     string   // sql_mode at procedure creation time
+	Name          string
+	Params        []ProcParam
+	Body          []string // SQL statements in the procedure body
+	BodyText      string   // original body text (begin...end or full body) for information_schema
+	SecurityType  string   // "DEFINER" or "INVOKER" (default: "DEFINER")
+	Comment       string   // optional COMMENT string
+	SqlDataAccess string   // "CONTAINS SQL", "NO SQL", "READS SQL DATA", "MODIFIES SQL DATA"
+	OriginalSQL   string   // original CREATE PROCEDURE statement
+	SqlMode       string   // sql_mode at procedure creation time
 }
 
 // ProcParam represents a parameter in a stored procedure.
@@ -170,6 +173,9 @@ type FunctionDef struct {
 	Body          []string // SQL statements in the function body
 	BodyText      string   // original body text for information_schema
 	Deterministic bool     // true if declared DETERMINISTIC
+	SecurityType  string   // "DEFINER" or "INVOKER" (default: "DEFINER")
+	Comment       string   // optional COMMENT string
+	SqlDataAccess string   // "CONTAINS SQL", "NO SQL", "READS SQL DATA", "MODIFIES SQL DATA"
 	OriginalSQL   string   // original CREATE FUNCTION statement
 	SqlMode       string   // sql_mode at function creation time
 }

--- a/executor/information_schema.go
+++ b/executor/information_schema.go
@@ -4945,6 +4945,50 @@ func (e *Executor) routineDefinitionText(stmts []string, bodyText string) string
 	return strings.Join(stmts, ";\n")
 }
 
+// normalizeDTDIdentifier converts a function return type string to the canonical
+// DTD_IDENTIFIER format as shown by MySQL INFORMATION_SCHEMA.ROUTINES.
+// For example, MySQL always reports YEAR as "year(4)".
+func normalizeDTDIdentifier(returnType string) string {
+	lower := strings.ToLower(strings.TrimSpace(returnType))
+	switch lower {
+	case "year":
+		return "year(4)"
+	}
+	return lower
+}
+
+// procSecurityTypeVal returns the SECURITY_TYPE for a ProcedureDef.
+func procSecurityTypeVal(p *catalogPkg.ProcedureDef) string {
+	if p.SecurityType != "" {
+		return p.SecurityType
+	}
+	return "DEFINER"
+}
+
+// procSqlDataAccessVal returns the SQL_DATA_ACCESS for a ProcedureDef.
+func procSqlDataAccessVal(p *catalogPkg.ProcedureDef) string {
+	if p.SqlDataAccess != "" {
+		return p.SqlDataAccess
+	}
+	return "CONTAINS SQL"
+}
+
+// funcSecurityType returns the SECURITY_TYPE for a FunctionDef.
+func funcSecurityType(f *catalogPkg.FunctionDef) string {
+	if f.SecurityType != "" {
+		return f.SecurityType
+	}
+	return "DEFINER"
+}
+
+// funcSqlDataAccess returns the SQL_DATA_ACCESS for a FunctionDef.
+func funcSqlDataAccess(f *catalogPkg.FunctionDef) string {
+	if f.SqlDataAccess != "" {
+		return f.SqlDataAccess
+	}
+	return "CONTAINS SQL"
+}
+
 // infoSchemaRoutines returns rows for INFORMATION_SCHEMA.ROUTINES.
 func (e *Executor) infoSchemaRoutines() []storage.Row {
 	var rows []storage.Row
@@ -4988,13 +5032,13 @@ func (e *Executor) infoSchemaRoutines() []storage.Row {
 					"EXTERNAL_LANGUAGE":         "SQL",
 					"PARAMETER_STYLE":           "SQL",
 					"IS_DETERMINISTIC":          "NO",
-					"SQL_DATA_ACCESS":           "CONTAINS SQL",
+					"SQL_DATA_ACCESS":           procSqlDataAccessVal(p),
 					"SQL_PATH":                  nil,
-					"SECURITY_TYPE":             "DEFINER",
+					"SECURITY_TYPE":             procSecurityTypeVal(p),
 					"CREATED":                   "2024-01-01 00:00:00",
 					"LAST_ALTERED":              "2024-01-01 00:00:00",
 					"SQL_MODE":                  "ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION",
-					"ROUTINE_COMMENT":           "",
+					"ROUTINE_COMMENT":           p.Comment,
 					"DEFINER":                   "root@localhost",
 					"CHARACTER_SET_CLIENT":      "utf8mb4",
 					"COLLATION_CONNECTION":      "utf8mb4_general_ci",
@@ -5021,7 +5065,7 @@ func (e *Executor) infoSchemaRoutines() []storage.Row {
 					"ROUTINE_SCHEMA":            dbName,
 					"ROUTINE_NAME":              f.Name,
 					"ROUTINE_TYPE":              "FUNCTION",
-					"DATA_TYPE":                 f.ReturnType,
+					"DATA_TYPE":                 strings.ToLower(strings.TrimSpace(f.ReturnType)),
 					"CHARACTER_MAXIMUM_LENGTH":  nil,
 					"CHARACTER_OCTET_LENGTH":    nil,
 					"NUMERIC_PRECISION":         nil,
@@ -5029,20 +5073,20 @@ func (e *Executor) infoSchemaRoutines() []storage.Row {
 					"DATETIME_PRECISION":        nil,
 					"CHARACTER_SET_NAME":        nil,
 					"COLLATION_NAME":            nil,
-					"DTD_IDENTIFIER":            f.ReturnType,
+					"DTD_IDENTIFIER":            normalizeDTDIdentifier(f.ReturnType),
 					"ROUTINE_BODY":              "SQL",
 					"ROUTINE_DEFINITION":        e.routineDefinitionText(f.Body, f.BodyText),
 					"EXTERNAL_NAME":             nil,
 					"EXTERNAL_LANGUAGE":         "SQL",
 					"PARAMETER_STYLE":           "SQL",
 					"IS_DETERMINISTIC":          det,
-					"SQL_DATA_ACCESS":           "CONTAINS SQL",
+					"SQL_DATA_ACCESS":           funcSqlDataAccess(f),
 					"SQL_PATH":                  nil,
-					"SECURITY_TYPE":             "DEFINER",
+					"SECURITY_TYPE":             funcSecurityType(f),
 					"CREATED":                   "2024-01-01 00:00:00",
 					"LAST_ALTERED":              "2024-01-01 00:00:00",
 					"SQL_MODE":                  "ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,NO_ZERO_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_ENGINE_SUBSTITUTION",
-					"ROUTINE_COMMENT":           "",
+					"ROUTINE_COMMENT":           f.Comment,
 					"DEFINER":                   "root@localhost",
 					"CHARACTER_SET_CLIENT":      "utf8mb4",
 					"COLLATION_CONNECTION":      "utf8mb4_general_ci",

--- a/executor/procedures.go
+++ b/executor/procedures.go
@@ -1058,21 +1058,100 @@ func (e *Executor) execCreateProcedure(query string) (*Result, error) {
 		return nil, mysqlError(1304, "42000", fmt.Sprintf("PROCEDURE %s already exists", procName))
 	}
 
+	// Extract characteristics (SQL SECURITY, COMMENT, etc.) from the text before the body.
+	procSecurityType := "DEFINER" // default
+	procComment := ""
+	procSqlDataAccess := "CONTAINS SQL" // default
+	{
+		upperAfterParams := strings.ToUpper(afterParams)
+		if strings.Contains(upperAfterParams, "SQL SECURITY INVOKER") {
+			procSecurityType = "INVOKER"
+		} else if strings.Contains(upperAfterParams, "SQL SECURITY DEFINER") {
+			procSecurityType = "DEFINER"
+		}
+		if strings.Contains(upperAfterParams, "NO SQL") {
+			procSqlDataAccess = "NO SQL"
+		} else if strings.Contains(upperAfterParams, "READS SQL DATA") {
+			procSqlDataAccess = "READS SQL DATA"
+		} else if strings.Contains(upperAfterParams, "MODIFIES SQL DATA") {
+			procSqlDataAccess = "MODIFIES SQL DATA"
+		} else if strings.Contains(upperAfterParams, "CONTAINS SQL") {
+			procSqlDataAccess = "CONTAINS SQL"
+		}
+		if commentIdx := strings.Index(upperAfterParams, "COMMENT "); commentIdx >= 0 {
+			commentRest := strings.TrimSpace(afterParams[commentIdx+len("COMMENT "):])
+			if len(commentRest) > 0 && (commentRest[0] == '\'' || commentRest[0] == '"') {
+				q := commentRest[0]
+				end := strings.IndexByte(commentRest[1:], q)
+				if end >= 0 {
+					procComment = commentRest[1 : end+1]
+				}
+			}
+		}
+	}
+
 	currentSqlMode := ""
 	if v, ok := e.getSysVar("sql_mode"); ok {
 		currentSqlMode = v
 	}
 	procDef := &catalog.ProcedureDef{
-		Name:        procName,
-		Params:      params,
-		Body:        bodyStmts,
-		BodyText:    bodyText,
-		OriginalSQL: query,
-		SqlMode:     currentSqlMode,
+		Name:          procName,
+		Params:        params,
+		Body:          bodyStmts,
+		BodyText:      bodyText,
+		SecurityType:  procSecurityType,
+		Comment:       procComment,
+		SqlDataAccess: procSqlDataAccess,
+		OriginalSQL:   query,
+		SqlMode:       currentSqlMode,
 	}
 	db.CreateProcedure(procDef)
 
 	return &Result{}, nil
+}
+
+// extractFuncReturnType extracts the SQL type from the text that follows the RETURNS keyword
+// in a CREATE FUNCTION statement. It stops at the first characteristic keyword or BEGIN/RETURN.
+// For example: "YEAR SQL SECURITY INVOKER BEGIN" -> "YEAR"
+//              "VARCHAR(100) DETERMINISTIC BEGIN" -> "VARCHAR(100)"
+//              "INT(11) UNSIGNED DETERMINISTIC BEGIN" -> "INT(11) UNSIGNED"
+func extractFuncReturnType(afterReturns string) string {
+	// characteristic keywords that terminate the return type
+	stopKeywords := []string{
+		"DETERMINISTIC", "NOT DETERMINISTIC",
+		"CONTAINS SQL", "NO SQL", "READS SQL DATA", "MODIFIES SQL DATA",
+		"SQL SECURITY DEFINER", "SQL SECURITY INVOKER",
+		"COMMENT ", // followed by a string literal
+		"BEGIN",
+		"RETURN ",
+	}
+
+	upper := strings.ToUpper(afterReturns)
+	minIdx := -1
+	for _, kw := range stopKeywords {
+		idx := strings.Index(upper, kw)
+		if idx < 0 {
+			continue
+		}
+		// Make sure it's a word boundary (preceded by whitespace, newline, or start)
+		if idx > 0 {
+			prev := afterReturns[idx-1]
+			if (prev >= 'a' && prev <= 'z') || (prev >= 'A' && prev <= 'Z') || (prev >= '0' && prev <= '9') || prev == '_' {
+				continue // not a word boundary
+			}
+		}
+		if minIdx < 0 || idx < minIdx {
+			minIdx = idx
+		}
+	}
+
+	var raw string
+	if minIdx < 0 {
+		raw = afterReturns
+	} else {
+		raw = afterReturns[:minIdx]
+	}
+	return strings.TrimSpace(raw)
 }
 
 // parseProcParams parses a procedure parameter list string.
@@ -2177,29 +2256,59 @@ func (e *Executor) execCreateFunction(query string) (*Result, error) {
 	returnType := ""
 	if returnsIdx >= 0 {
 		afterReturns := strings.TrimSpace(afterParams[returnsIdx+len("RETURNS "):])
-		// Return type ends at BEGIN/RETURN or at a characteristic keyword
-		beginIdx := strings.Index(strings.ToUpper(afterReturns), "BEGIN")
-		returnIdx := strings.Index(strings.ToUpper(afterReturns), "RETURN ")
-		endIdx := beginIdx
-		if endIdx < 0 || (returnIdx >= 0 && returnIdx < endIdx) {
-			endIdx = returnIdx
+		returnType = extractFuncReturnType(afterReturns)
+	}
+
+	// Parse characteristics (DETERMINISTIC, SQL SECURITY, COMMENT, etc.) from afterParams.
+	isDeterministic := false
+	securityType := "DEFINER" // default
+	routineComment := ""
+	sqlDataAccess := "CONTAINS SQL" // default
+	{
+		upperAfterParams := strings.ToUpper(afterParams)
+		if strings.Contains(upperAfterParams, "DETERMINISTIC") && !strings.Contains(upperAfterParams, "NOT DETERMINISTIC") {
+			isDeterministic = true
 		}
-		if endIdx < 0 {
-			endIdx = len(afterReturns)
+		if strings.Contains(upperAfterParams, "SQL SECURITY INVOKER") {
+			securityType = "INVOKER"
+		} else if strings.Contains(upperAfterParams, "SQL SECURITY DEFINER") {
+			securityType = "DEFINER"
 		}
-		returnType = strings.TrimSpace(afterReturns[:endIdx])
-		// Strip optional characteristics like CONTAINS SQL, NO SQL, READS SQL DATA, etc.
-		for _, kw := range []string{"DETERMINISTIC", "NOT DETERMINISTIC", "CONTAINS SQL", "NO SQL", "READS SQL DATA", "MODIFIES SQL DATA", "SQL SECURITY DEFINER", "SQL SECURITY INVOKER"} {
-			returnType = strings.TrimSuffix(strings.TrimSpace(returnType), kw)
+		if strings.Contains(upperAfterParams, "NO SQL") {
+			sqlDataAccess = "NO SQL"
+		} else if strings.Contains(upperAfterParams, "READS SQL DATA") {
+			sqlDataAccess = "READS SQL DATA"
+		} else if strings.Contains(upperAfterParams, "MODIFIES SQL DATA") {
+			sqlDataAccess = "MODIFIES SQL DATA"
+		} else if strings.Contains(upperAfterParams, "CONTAINS SQL") {
+			sqlDataAccess = "CONTAINS SQL"
 		}
-		returnType = strings.TrimSpace(returnType)
+		// Extract COMMENT 'text' characteristic
+		if commentIdx := strings.Index(upperAfterParams, "COMMENT "); commentIdx >= 0 {
+			commentRest := strings.TrimSpace(afterParams[commentIdx+len("COMMENT "):])
+			if len(commentRest) > 0 && (commentRest[0] == '\'' || commentRest[0] == '"') {
+				q := commentRest[0]
+				end := strings.IndexByte(commentRest[1:], q)
+				if end >= 0 {
+					routineComment = commentRest[1 : end+1]
+				}
+			}
+		}
 	}
 
 	// Extract body: BEGIN...END or single RETURN expression.
 	var bodyStmts []string
+	var bodyText string
 	var hasReturnInBody bool
 	beginIdx := strings.Index(strings.ToUpper(afterParams), "BEGIN")
 	if beginIdx >= 0 {
+		// bodyText for INFORMATION_SCHEMA: full BEGIN...END block
+		rawBodyBlock := strings.TrimSpace(afterParams[beginIdx:])
+		// Strip trailing semicolons
+		rawBodyBlock = strings.TrimRight(rawBodyBlock, ";")
+		rawBodyBlock = strings.TrimSpace(rawBodyBlock)
+		bodyText = rawBodyBlock
+
 		bodyStr := strings.TrimSpace(afterParams[beginIdx+len("BEGIN"):])
 		// Only apply the 1320 check when the body is complete (ends with END).
 		// If the body is truncated (e.g., sent without the closing END due to
@@ -2235,6 +2344,7 @@ func (e *Executor) execCreateFunction(query string) (*Result, error) {
 		returnExpr := strings.TrimSpace(afterParams[returnIdx:])
 		returnExpr = strings.TrimSuffix(returnExpr, ";")
 		bodyStmts = []string{returnExpr}
+		bodyText = returnExpr
 	}
 
 	// Validate routine body: cursor-for-non-SELECT (1064) and condition handler refs (1319).
@@ -2252,12 +2362,17 @@ func (e *Executor) execCreateFunction(query string) (*Result, error) {
 		funcSqlMode = v
 	}
 	funcDef := &catalog.FunctionDef{
-		Name:        funcName,
-		Params:      params,
-		ReturnType:  returnType,
-		Body:        bodyStmts,
-		OriginalSQL: query,
-		SqlMode:     funcSqlMode,
+		Name:          funcName,
+		Params:        params,
+		ReturnType:    returnType,
+		Body:          bodyStmts,
+		BodyText:      bodyText,
+		Deterministic: isDeterministic,
+		SecurityType:  securityType,
+		Comment:       routineComment,
+		SqlDataAccess: sqlDataAccess,
+		OriginalSQL:   query,
+		SqlMode:       funcSqlMode,
 	}
 	db.CreateFunction(funcDef)
 

--- a/executor/show.go
+++ b/executor/show.go
@@ -1899,9 +1899,13 @@ func (e *Executor) showRoutineStatus(routineType string, rest string) (*Result, 
 						continue
 					}
 				}
+				secType := funcDef.SecurityType
+				if secType == "" {
+					secType = "DEFINER"
+				}
 				rows = append(rows, []interface{}{
 					dbName, name, "FUNCTION", "root@localhost",
-					now, now, "DEFINER", "",
+					now, now, secType, funcDef.Comment,
 					"utf8mb4", "utf8mb4_0900_ai_ci", "utf8mb4_0900_ai_ci",
 				})
 			}
@@ -1918,9 +1922,13 @@ func (e *Executor) showRoutineStatus(routineType string, rest string) (*Result, 
 						continue
 					}
 				}
+				secType := procDef.SecurityType
+				if secType == "" {
+					secType = "DEFINER"
+				}
 				rows = append(rows, []interface{}{
 					dbName, name, "PROCEDURE", "root@localhost",
-					now, now, "DEFINER", "",
+					now, now, secType, procDef.Comment,
 					"utf8mb4", "utf8mb4_0900_ai_ci", "utf8mb4_0900_ai_ci",
 				})
 			}


### PR DESCRIPTION
## Summary

Closes #154

- Implement proper parsing of CREATE FUNCTION characteristics (SQL SECURITY, COMMENT, data access keywords)
- Fix `INFORMATION_SCHEMA.ROUTINES` output for user-defined functions: correct `DATA_TYPE` (lowercase), `DTD_IDENTIFIER` (normalized, e.g. `year(4)` for YEAR), `ROUTINE_DEFINITION` includes `BEGIN...END`, `SECURITY_TYPE` and `ROUTINE_COMMENT` from definition
- Fix `SHOW FUNCTION STATUS` / `SHOW PROCEDURE STATUS` to use stored SecurityType and Comment
- Add `SecurityType`, `Comment`, `SqlDataAccess` fields to both `FunctionDef` and `ProcedureDef` in catalog
- Add `extractFuncReturnType` helper that properly stops return type at characteristic keywords (fixing bug where `SQL SECURITY INVOKER` was included in return type)

## KPI

- `funcs_1/myisam_storedproc_08` first-diff-line: **103 → 123** (+20)
- Zero regressions: **1699 passed** (baseline maintained)

## Test plan

- [x] `go build ./... && go test ./... -count=1` passes
- [x] Full suite: 1699 passed (same as baseline)
- [x] `funcs_1/myisam_storedproc_08` first-diff-line improved from 103 to 123
- [x] `SELECT my_func(arg)` returns correct values
- [x] `CREATE FUNCTION ... RETURNS INT BEGIN ... END` parses and executes correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)