### PR TITLE
feat: dynamic INNODB_TRX from TxnActiveSet and NextTxScope isolation semantics

### DIFF
--- a/cmd/mtrrun/skiplist.json
+++ b/cmd/mtrrun/skiplist.json
@@ -3677,10 +3677,6 @@
       "reason": "SHOW CREATE TABLE ordering issues"
     },
     {
-      "test": "innodb/innodb_i_s_innodb_trx",
-      "reason": "trx_isolation_level and lock_data showing NULL"
-    },
-    {
       "test": "other/cast",
       "reason": "timeout"
     },

--- a/executor/dml_insert.go
+++ b/executor/dml_insert.go
@@ -117,6 +117,8 @@ func (e *Executor) checkGapLockForInsert(dbName, tableName string, stmt *sqlpars
 }
 
 func (e *Executor) execInsert(stmt *sqlparser.Insert) (*Result, error) {
+	// Register this connection in TxnActiveSet for INNODB_TRX when autocommit=0.
+	e.ensureImplicitTxnTracked()
 	// Set insideDML so that sub-SELECTs (INSERT...SELECT, subqueries in
 	// VALUES) acquire row locks, mimicking InnoDB's implicit locking.
 	// InnoDB always acquires shared locks on source rows during INSERT...SELECT,
@@ -391,6 +393,7 @@ func (e *Executor) execInsert(stmt *sqlparser.Insert) (*Result, error) {
 
 			// Enforce FOREIGN KEY constraints: verify parent row exists
 			if err := e.checkForeignKeyOnInsert(insertDB, tableName, row); err != nil {
+				e.recordFKError(err)
 				return nil, err
 			}
 
@@ -2190,6 +2193,7 @@ func (e *Executor) execInsert(stmt *sqlparser.Insert) (*Result, error) {
 				e.addWarning("Warning", 1452, err.Error())
 				continue
 			}
+			e.recordFKError(err)
 			return nil, err
 		}
 

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -166,12 +166,22 @@ type selectLockClause struct {
 	nowait     bool
 }
 
+// txnMeta holds per-connection transaction metadata for INFORMATION_SCHEMA.INNODB_TRX.
+type txnMeta struct {
+	StartedAt       time.Time
+	IsolationLevel  string // e.g. "REPEATABLE-READ"
+	UniqueChecks    int64
+	ForeignKeyChecks int64
+	LastFKError     string
+}
+
 // TxnActiveSet tracks which connections are currently in an active transaction.
 // Used for filtering uncommitted rows during reads.
 type TxnActiveSet struct {
 	mu      sync.RWMutex
 	active  map[int64]bool                    // connectionID -> true if in transaction
 	inserts map[int64]map[string]map[int]bool // connectionID -> "db:table" -> set of row pointers
+	meta    map[int64]*txnMeta               // connectionID -> transaction metadata
 }
 
 // NewTxnActiveSet creates a new TxnActiveSet.
@@ -179,14 +189,77 @@ func NewTxnActiveSet() *TxnActiveSet {
 	return &TxnActiveSet{
 		active:  make(map[int64]bool),
 		inserts: make(map[int64]map[string]map[int]bool),
+		meta:    make(map[int64]*txnMeta),
 	}
 }
 
-// Begin marks a connection as being in a transaction.
-func (t *TxnActiveSet) Begin(connID int64) {
+// Begin marks a connection as being in a transaction and records metadata.
+func (t *TxnActiveSet) Begin(connID int64, isolationLevel string, uniqueChecks, foreignKeyChecks int64) {
 	t.mu.Lock()
 	defer t.mu.Unlock()
 	t.active[connID] = true
+	t.meta[connID] = &txnMeta{
+		StartedAt:       time.Now(),
+		IsolationLevel:  isolationLevel,
+		UniqueChecks:    uniqueChecks,
+		ForeignKeyChecks: foreignKeyChecks,
+	}
+}
+
+// UpdateMeta updates the session-variable metadata for an active transaction.
+func (t *TxnActiveSet) UpdateMeta(connID int64, isolationLevel string, uniqueChecks, foreignKeyChecks int64) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if m, ok := t.meta[connID]; ok {
+		m.IsolationLevel  = isolationLevel
+		m.UniqueChecks    = uniqueChecks
+		m.ForeignKeyChecks = foreignKeyChecks
+	}
+}
+
+// SetFKError records the last FK constraint error message for an active transaction.
+func (t *TxnActiveSet) SetFKError(connID int64, errMsg string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if m, ok := t.meta[connID]; ok {
+		m.LastFKError = errMsg
+	}
+}
+
+// TxnRow is a snapshot of a single active transaction for INNODB_TRX.
+type TxnRow struct {
+	ConnID          int64
+	StartedAt       time.Time
+	IsolationLevel  string
+	UniqueChecks    int64
+	ForeignKeyChecks int64
+	LastFKError     string
+}
+
+// SnapshotTxns returns a snapshot of all active transactions.
+func (t *TxnActiveSet) SnapshotTxns() []TxnRow {
+	t.mu.RLock()
+	defer t.mu.RUnlock()
+	rows := make([]TxnRow, 0, len(t.active))
+	for connID := range t.active {
+		m := t.meta[connID]
+		var row TxnRow
+		row.ConnID = connID
+		if m != nil {
+			row.StartedAt       = m.StartedAt
+			row.IsolationLevel  = m.IsolationLevel
+			row.UniqueChecks    = m.UniqueChecks
+			row.ForeignKeyChecks = m.ForeignKeyChecks
+			row.LastFKError     = m.LastFKError
+		} else {
+			row.StartedAt      = time.Now()
+			row.IsolationLevel = "REPEATABLE-READ"
+			row.UniqueChecks   = 1
+			row.ForeignKeyChecks = 1
+		}
+		rows = append(rows, row)
+	}
+	return rows
 }
 
 // End marks a connection as no longer being in a transaction.
@@ -195,6 +268,7 @@ func (t *TxnActiveSet) End(connID int64) {
 	defer t.mu.Unlock()
 	delete(t.active, connID)
 	delete(t.inserts, connID)
+	delete(t.meta, connID)
 }
 
 // TrackInsert records that a connection inserted a row (identified by pointer identity).
@@ -443,6 +517,11 @@ type Executor struct {
 	// txnActiveSet is a shared set tracking which connections are currently in a transaction.
 	// Used for filtering uncommitted rows from other connections during reads.
 	txnActiveSet *TxnActiveSet
+	// nextTxnIsolationPrev holds the session isolation level that was in place BEFORE
+	// a "next transaction only" SET TRANSACTION ISOLATION LEVEL was applied. When the
+	// CURRENT transaction ends (execCommit / execRollback), sessionScopeVars is restored
+	// to this value. Empty string means no pending restoration needed.
+	nextTxnIsolationPrev string
 	// selectSkipLocked is set when the current SELECT uses SKIP LOCKED.
 	selectSkipLocked bool
 	// selectNowait is set when the current SELECT uses NOWAIT.
@@ -739,6 +818,13 @@ func (e *Executor) setSysVar(name string, value string, isGlobal bool) {
 		e.setGlobalVar(name, value)
 	} else {
 		e.sessionScopeVars[name] = value
+	}
+	// Keep INNODB_TRX metadata in sync when session-level transaction-relevant vars change.
+	if !isGlobal && e.inTransaction && e.txnActiveSet != nil &&
+		(name == "transaction_isolation" || name == "tx_isolation" ||
+			name == "unique_checks" || name == "foreign_key_checks") {
+		iso, uq, fk := e.txnSessionMeta()
+		e.txnActiveSet.UpdateMeta(e.connectionID, iso, uq, fk)
 	}
 }
 

--- a/executor/information_schema.go
+++ b/executor/information_schema.go
@@ -103,7 +103,7 @@ var infoSchemaColumnOrder = map[string][]string{
 	"innodb_cmp_reset":         {"page_size", "compress_ops", "compress_ops_ok", "compress_time", "uncompress_ops", "uncompress_time"},
 	"innodb_cmpmem":            {"page_size", "buffer_pool_instance", "pages_used", "pages_free", "relocation_ops", "relocation_time"},
 	"innodb_cmpmem_reset":      {"page_size", "buffer_pool_instance", "pages_used", "pages_free", "relocation_ops", "relocation_time"},
-	"innodb_trx":               {"trx_id", "trx_state", "trx_started"},
+	"innodb_trx":               {"trx_id", "trx_state", "trx_started", "trx_requested_lock_id", "trx_wait_started", "trx_weight", "trx_mysql_thread_id", "trx_query", "trx_operation_state", "trx_tables_in_use", "trx_tables_locked", "trx_lock_structs", "trx_lock_memory_bytes", "trx_rows_locked", "trx_rows_modified", "trx_concurrency_tickets", "trx_isolation_level", "trx_unique_checks", "trx_foreign_key_checks", "trx_last_foreign_key_error", "trx_adaptive_hash_latched", "trx_adaptive_hash_timeout", "trx_is_read_only", "trx_autocommit_non_locking"},
 	"innodb_foreign_cols":      {"ID", "FOR_COL_NAME", "REF_COL_NAME", "POS"},
 	"innodb_fields":            {"INDEX_ID", "NAME", "POS"},
 	"optimizer_trace":          {"QUERY", "TRACE", "MISSING_BYTES_BEYOND_MAX_MEM_SIZE", "INSUFFICIENT_PRIVILEGES"},
@@ -554,7 +554,7 @@ var singleRowStubTables = map[string]storage.Row{
 	"innodb_cmp_reset":    {"page_size": int64(4096), "compress_ops": int64(0), "compress_ops_ok": int64(0), "compress_time": int64(0), "uncompress_ops": int64(0), "uncompress_time": int64(0)},
 	"innodb_cmpmem":       {"page_size": int64(4096), "buffer_pool_instance": int64(0), "pages_used": int64(0), "pages_free": int64(0), "relocation_ops": int64(0), "relocation_time": int64(0)},
 	"innodb_cmpmem_reset": {"page_size": int64(4096), "buffer_pool_instance": int64(0), "pages_used": int64(0), "pages_free": int64(0), "relocation_ops": int64(0), "relocation_time": int64(0)},
-	"innodb_trx":            {"trx_id": "", "trx_state": "RUNNING", "trx_started": nil},
+	// innodb_trx is handled dynamically in buildInformationSchemaRows (from TxnActiveSet).
 	"innodb_fields":         {"INDEX_ID": int64(0), "NAME": "", "POS": int64(0)},
 	"optimizer_trace":       {"QUERY": "", "TRACE": "", "MISSING_BYTES_BEYOND_MAX_MEM_SIZE": int64(0), "INSUFFICIENT_PRIVILEGES": int64(0)},
 	"files":                 {"FILE_NAME": "", "FILE_TYPE": "", "TABLESPACE_NAME": ""},
@@ -784,6 +784,8 @@ func (e *Executor) buildInformationSchemaRows(tableName, alias string) ([]storag
 		rawRows = e.infoSchemaInnoDBForeignCols()
 	case "innodb_buffer_page":
 		rawRows = []storage.Row{} // empty stub - no buffer pool tracking
+	case "innodb_trx":
+		rawRows = e.infoSchemaInnoDBTrx()
 	case "processlist":
 		if e.processList != nil {
 			entries := e.processList.Snapshot()
@@ -1626,6 +1628,53 @@ func (e *Executor) infoSchemaReferentialConstraints() []storage.Row {
 				})
 			}
 		}
+	}
+	return rows
+}
+
+// infoSchemaInnoDBTrx returns rows for INFORMATION_SCHEMA.INNODB_TRX
+// by reading the current active transactions from TxnActiveSet.
+func (e *Executor) infoSchemaInnoDBTrx() []storage.Row {
+	if e.txnActiveSet == nil {
+		return []storage.Row{}
+	}
+	txns := e.txnActiveSet.SnapshotTxns()
+	rows := make([]storage.Row, 0, len(txns))
+	for _, t := range txns {
+		// Convert isolation level from internal format (REPEATABLE-READ) to
+		// MySQL display format (REPEATABLE READ) used in INNODB_TRX.
+		isoDisplay := strings.ReplaceAll(t.IsolationLevel, "-", " ")
+
+		var lastFKErr interface{}
+		if t.LastFKError != "" {
+			lastFKErr = t.LastFKError
+		}
+		rows = append(rows, storage.Row{
+			"trx_id":                    fmt.Sprintf("%d", t.ConnID),
+			"trx_state":                 "RUNNING",
+			"trx_started":               t.StartedAt.Format("2006-01-02 15:04:05"),
+			"trx_requested_lock_id":     nil,
+			"trx_wait_started":          nil,
+			"trx_weight":                int64(0),
+			"trx_mysql_thread_id":       t.ConnID,
+			"trx_query":                 nil,
+			"trx_operation_state":       nil,
+			"trx_tables_in_use":         int64(0),
+			"trx_tables_locked":         int64(0),
+			"trx_lock_structs":          int64(0),
+			"trx_lock_memory_bytes":     int64(0),
+			"trx_rows_locked":           int64(0),
+			"trx_rows_modified":         int64(0),
+			"trx_concurrency_tickets":   int64(0),
+			"trx_isolation_level":       isoDisplay,
+			"trx_unique_checks":         t.UniqueChecks,
+			"trx_foreign_key_checks":    t.ForeignKeyChecks,
+			"trx_last_foreign_key_error": lastFKErr,
+			"trx_adaptive_hash_latched": int64(0),
+			"trx_adaptive_hash_timeout": int64(0),
+			"trx_is_read_only":          int64(0),
+			"trx_autocommit_non_locking": int64(0),
+		})
 	}
 	return rows
 }

--- a/executor/transaction.go
+++ b/executor/transaction.go
@@ -8,6 +8,37 @@ import (
 	"github.com/myuon/mylite/storage"
 )
 
+// recordFKError stores the FK constraint message from err into the active
+// transaction's metadata (trx_last_foreign_key_error in INNODB_TRX).
+// The error message format is:
+//
+//	Cannot add or update a child row: a foreign key constraint fails (`db`.`tbl`, CONSTRAINT ...)
+//
+// or
+//
+//	Cannot delete or update a parent row: a foreign key constraint fails (`db`.`tbl`, CONSTRAINT ...)
+//
+// We extract and store only the content inside the outermost parentheses (after "constraint fails ").
+func (e *Executor) recordFKError(err error) {
+	if err == nil || e.txnActiveSet == nil || !e.inTransaction {
+		return
+	}
+	msg := err.Error()
+	// Find "constraint fails (" to locate the start of the constraint description.
+	const marker = "constraint fails ("
+	idx := strings.Index(strings.ToLower(msg), marker)
+	if idx < 0 {
+		return
+	}
+	start := idx + len(marker)
+	part := msg[start:]
+	// Remove the trailing ')' (the matching close of "constraint fails (...")
+	if strings.HasSuffix(part, ")") {
+		part = part[:len(part)-1]
+	}
+	e.txnActiveSet.SetFKError(e.connectionID, part)
+}
+
 // txSavepoint holds the catalog and storage state captured at BEGIN time.
 type txSavepoint struct {
 	// Storage snapshot per database name.
@@ -75,9 +106,92 @@ func (e *Executor) execBegin() (*Result, error) {
 	e.namedSavepoints = make(map[string]bool)
 	e.inTransaction = true
 	if e.txnActiveSet != nil {
-		e.txnActiveSet.Begin(e.connectionID)
+		iso, uq, fk := e.txnSessionMeta()
+		e.txnActiveSet.Begin(e.connectionID, iso, uq, fk)
 	}
+	// nextTxnIsolationPrev stays set until the transaction ends (execCommit/execRollback),
+	// at which point we restore sessionScopeVars["transaction_isolation"] to the saved
+	// previous value. While the transaction is active, sessionScopeVars still holds the
+	// NextTxScope value so all isolation-level reads (gap locks, SERIALIZABLE checks, etc.)
+	// see the correct isolation level.
 	return &Result{}, nil
+}
+
+// ensureImplicitTxnTracked registers the current connection in TxnActiveSet when
+// autocommit=0 is active. MySQL treats autocommit=0 as starting an implicit
+// transaction on the first DML, so we need it to show in INNODB_TRX.
+// This is a no-op when already in an explicit transaction or when autocommit is ON.
+func (e *Executor) ensureImplicitTxnTracked() {
+	if e.txnActiveSet == nil {
+		return
+	}
+	if e.inTransaction {
+		// Already tracked via execBegin.
+		return
+	}
+	// Check autocommit=0
+	v, ok := e.getSysVar("autocommit")
+	if !ok {
+		return
+	}
+	upper := strings.ToUpper(v)
+	if upper != "0" && upper != "OFF" {
+		return
+	}
+	// autocommit=0: register in TxnActiveSet if not already there.
+	e.txnActiveSet.mu.RLock()
+	_, alreadyActive := e.txnActiveSet.active[e.connectionID]
+	e.txnActiveSet.mu.RUnlock()
+	if alreadyActive {
+		return
+	}
+	iso, uq, fk := e.txnSessionMeta()
+	e.txnActiveSet.Begin(e.connectionID, iso, uq, fk)
+}
+
+// endImplicitTxnTracked removes the connection from TxnActiveSet after an
+// autocommit=0 implicit transaction ends (COMMIT/ROLLBACK when !inTransaction).
+func (e *Executor) endImplicitTxnTracked() {
+	if e.txnActiveSet == nil || e.inTransaction {
+		return
+	}
+	e.txnActiveSet.End(e.connectionID)
+}
+
+// restoreNextTxnIsolation restores the session isolation level after a transaction
+// that was started with a NextTxScope (SET TRANSACTION ISOLATION LEVEL) override.
+// If nextTxnIsolationPrev is set, it means the current session's transaction_isolation
+// was temporarily overridden for the last transaction. We restore it here.
+func (e *Executor) restoreNextTxnIsolation() {
+	if e.nextTxnIsolationPrev == "" {
+		return
+	}
+	e.sessionScopeVars["transaction_isolation"] = e.nextTxnIsolationPrev
+	e.nextTxnIsolationPrev = ""
+}
+
+// txnSessionMeta returns the current session's isolation level, unique_checks,
+// and foreign_key_checks values for INNODB_TRX metadata.
+func (e *Executor) txnSessionMeta() (isolationLevel string, uniqueChecks, foreignKeyChecks int64) {
+	isolationLevel = "REPEATABLE-READ"
+	uniqueChecks = 1
+	foreignKeyChecks = 1
+	if iso, ok := e.getSysVar("transaction_isolation"); ok {
+		isolationLevel = iso
+	} else if iso, ok := e.getSysVar("tx_isolation"); ok {
+		isolationLevel = iso
+	}
+	if uq, ok := e.getSysVar("unique_checks"); ok {
+		if uq == "0" || strings.EqualFold(uq, "OFF") {
+			uniqueChecks = 0
+		}
+	}
+	if fk, ok := e.getSysVar("foreign_key_checks"); ok {
+		if fk == "0" || strings.EqualFold(fk, "OFF") {
+			foreignKeyChecks = 0
+		}
+	}
+	return
 }
 
 func (e *Executor) execCommit() (*Result, error) {
@@ -86,6 +200,9 @@ func (e *Executor) execCommit() (*Result, error) {
 		e.rowLockManager.ReleaseRowLocks(e.connectionID)
 	}
 	if !e.inTransaction {
+		// End implicit autocommit=0 transaction tracking if present.
+		e.endImplicitTxnTracked()
+		e.restoreNextTxnIsolation()
 		return &Result{}, nil
 	}
 	// Block COMMIT if another connection holds FLUSH TABLES WITH READ LOCK
@@ -111,6 +228,8 @@ func (e *Executor) execCommit() (*Result, error) {
 	if e.txnActiveSet != nil {
 		e.txnActiveSet.End(e.connectionID)
 	}
+	// Restore session isolation level if it was temporarily overridden by a NextTxScope set.
+	e.restoreNextTxnIsolation()
 	return &Result{}, nil
 }
 
@@ -201,6 +320,9 @@ func (e *Executor) execRollback() (*Result, error) {
 		e.rowLockManager.ReleaseRowLocks(e.connectionID)
 	}
 	if !e.inTransaction {
+		// End implicit autocommit=0 transaction tracking if present.
+		e.endImplicitTxnTracked()
+		e.restoreNextTxnIsolation()
 		return &Result{}, nil
 	}
 	sp := e.savepoint
@@ -211,6 +333,8 @@ func (e *Executor) execRollback() (*Result, error) {
 	if e.txnActiveSet != nil {
 		e.txnActiveSet.End(e.connectionID)
 	}
+	// Restore session isolation level if it was temporarily overridden by a NextTxScope set.
+	e.restoreNextTxnIsolation()
 
 	// If we have an undo log, use it for precise per-connection rollback
 	// instead of the snapshot-based approach which can clobber other connections' data.

--- a/executor/variables.go
+++ b/executor/variables.go
@@ -571,6 +571,23 @@ func (e *Executor) execSet(stmt *sqlparser.Set) (*Result, error) {
 				cleanName = strings.TrimPrefix(cleanName, "session.")
 				cleanName = strings.TrimPrefix(cleanName, "local.")
 				isGlobal := scope == sqlparser.GlobalScope
+				// SET TRANSACTION ISOLATION LEVEL (NextTxScope) and SET @@transaction_isolation
+				// in MySQL apply only to the NEXT transaction. We store the value in
+				// sessionScopeVars (so getSysVar returns it for locking/isolation checks),
+				// but also save the PREVIOUS session value in nextTxnIsolation so that
+				// execBegin can restore it after the transaction ends (see execCommit/execRollback).
+				if scope == sqlparser.NextTxScope && (cleanName == "transaction_isolation" || cleanName == "tx_isolation") {
+					// Save the current session isolation level for restoration after the next transaction.
+					if prev, ok := e.sessionScopeVars[cleanName]; ok {
+						e.nextTxnIsolationPrev = prev
+					} else if gv, ok := e.getGlobalVar(cleanName); ok {
+						e.nextTxnIsolationPrev = gv
+					} else {
+						e.nextTxnIsolationPrev = "REPEATABLE-READ"
+					}
+					// Fall through to the normal setSysVar path (validates and stores the value).
+					// The restoration happens in execCommit/execRollback via prevSessionIsolation.
+				}
 				// Enforce SUPER or SYSTEM_VARIABLES_ADMIN privilege for setting global variables.
 				// Non-privileged users get ER_SPECIFIC_ACCESS_DENIED_ERROR (1227).
 				if isGlobal {


### PR DESCRIPTION
## Summary

- `INFORMATION_SCHEMA.INNODB_TRX` now returns live rows from `TxnActiveSet` instead of a single stub row, including `trx_id`, `trx_state`, `trx_started`, `trx_isolation_level`, `trx_unique_checks`, `trx_foreign_key_checks`, and `trx_last_foreign_key_error`
- Added `txnMeta` struct to `TxnActiveSet` to track per-connection metadata (start time, isolation level, unique/FK checks, last FK error)
- Implemented `NextTxScope` semantics: `SET TRANSACTION ISOLATION LEVEL` without `SESSION`/`GLOBAL` applies only to the next transaction, then reverts to the previous session value
- Added `ensureImplicitTxnTracked()` so `autocommit=0` connections appear in `INNODB_TRX` even without explicit `BEGIN`
- Added `recordFKError()` to capture the last FK constraint error message for `trx_last_foreign_key_error`
- Removed `innodb/innodb_i_s_innodb_trx` from skiplist (test now runs and fails only on InnoDB-specific lock metrics like `trx_weight`, `trx_rows_locked` which require deep lock tracking)

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./... -count=1` passes
- [x] Full mtrrun: 1699 passed (matches baseline, zero regressions)
- [x] `sys_vars/transaction_isolation_basic` passes (NextTxScope semantics)
- [x] `other/unsafe_binlog_innodb` passes (READ-COMMITTED via NextTxScope applied during transaction)
- [x] `innodb/innodb_i_s_innodb_trx` improves significantly (was skipped, now fails only at line 58 on InnoDB lock metrics)

Closes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)