### PR TITLE
feat: partition validation - ER_SAME_NAME_PARTITION, ER_PARTITION_FUNCTION_IS_NOT_ALLOWED, COLUMNS format

### DIFF
--- a/executor/ddl.go
+++ b/executor/ddl.go
@@ -8,6 +8,10 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"unicode"
+
+	"golang.org/x/text/unicode/norm"
+
 	"github.com/myuon/mylite/catalog"
 	"github.com/myuon/mylite/storage"
 	"vitess.io/vitess/go/vt/sqlparser"
@@ -25,6 +29,109 @@ func isKnownStorageEngine(engineUpper string) bool {
 		return true
 	}
 	return false
+}
+
+// normalizePartitionName normalizes a partition name for duplicate detection.
+// MySQL uses case-insensitive and accent-insensitive comparison for partition names,
+// consistent with the utf8mb4_0900_ai_ci collation behavior.
+func normalizePartitionName(name string) string {
+	// Apply NFKD normalization to decompose accented characters
+	nfkd := norm.NFKD.String(strings.ToLower(name))
+	// Remove Unicode combining marks (diacritics)
+	var result []rune
+	for _, r := range nfkd {
+		if unicode.Is(unicode.Mn, r) {
+			continue
+		}
+		result = append(result, r)
+	}
+	return string(result)
+}
+
+// disallowedPartitionFunctions is the set of function names not allowed in partition expressions.
+// MySQL allows only a specific subset of functions; these are explicitly disallowed.
+var disallowedPartitionFunctions = map[string]bool{
+	"greatest":         true,
+	"least":            true,
+	"isnull":           true,
+	"nullif":           true,
+	"ifnull":           true,
+	"ascii":            true, // string function, not allowed in partition expressions
+	"bit_length":       true,
+	"char_length":      true,
+	"character_length": true,
+	"find_in_set":      true,
+	"instr":            true,
+	"length":           true,
+	"locate":           true,
+	"octet_length":     true,
+	"position":         true,
+	"strcmp":           true,
+	"crc32":            true,
+	"round":            true,
+	"sign":             true,
+	"period_add":       true,
+	"period_diff":      true,
+	"timestampdiff":    true,
+	"week":             true,
+	"bit_count":        true,
+	"inet_aton":        true,
+}
+
+// validatePartitionExpr walks a partition expression and returns true
+// if it contains disallowed functions or operators (ER_PARTITION_FUNCTION_IS_NOT_ALLOWED).
+// Returns false if expression is allowed.
+func validatePartitionExpr(expr sqlparser.Expr) (disallowed bool, wrongExpr bool) {
+	if expr == nil {
+		return false, false
+	}
+	switch e := expr.(type) {
+	case *sqlparser.FuncExpr:
+		name := strings.ToLower(e.Name.String())
+		if disallowedPartitionFunctions[name] {
+			return true, false
+		}
+		// Recurse into arguments (FuncExpr.Exprs is []Expr in vitess)
+		for _, arg := range e.Exprs {
+			if d, w := validatePartitionExpr(arg); d || w {
+				return d, w
+			}
+		}
+	case *sqlparser.CastExpr:
+		return true, false
+	case *sqlparser.ConvertExpr:
+		return true, false
+	case *sqlparser.CaseExpr:
+		return true, false
+	case *sqlparser.BinaryExpr:
+		switch e.Operator {
+		case sqlparser.BitAndOp, sqlparser.BitOrOp, sqlparser.BitXorOp,
+			sqlparser.ShiftLeftOp, sqlparser.ShiftRightOp:
+			return true, false
+		}
+		// Recurse into children
+		if d, w := validatePartitionExpr(e.Left); d || w {
+			return d, w
+		}
+		if d, w := validatePartitionExpr(e.Right); d || w {
+			return d, w
+		}
+	case *sqlparser.UnaryExpr:
+		if e.Operator == sqlparser.TildaOp {
+			return true, false
+		}
+		if d, w := validatePartitionExpr(e.Expr); d || w {
+			return d, w
+		}
+	case *sqlparser.LocateExpr:
+		// locate(substr, str) and position(substr IN str) - always disallowed
+		return true, false
+	case *sqlparser.ColName:
+		// Column references are always allowed
+	case *sqlparser.Literal:
+		// Literal values are always allowed
+	}
+	return false, false
 }
 
 // validateUTF8StringForDDL checks if a string contains valid utf8mb3 (3-byte UTF-8) when character_set_client=binary.
@@ -2274,6 +2381,12 @@ func (e *Executor) execCreateTable(stmt *sqlparser.CreateTable) (*Result, error)
 		// Expression (HASH/RANGE/LIST with expression)
 		if po.Expr != nil {
 			def.PartitionExpression = sqlparser.String(po.Expr)
+			// Validate partition expression for disallowed functions/operators.
+			if po.Type != sqlparser.KeyType {
+				if disallowed, _ := validatePartitionExpr(po.Expr); disallowed {
+					return nil, mysqlError(1491, "HY000", "This partition function is not allowed")
+				}
+			}
 		}
 		// Column list (KEY or RANGE/LIST COLUMNS)
 		if len(po.ColList) > 0 {
@@ -2362,6 +2475,28 @@ func (e *Executor) execCreateTable(stmt *sqlparser.CreateTable) (*Result, error)
 				}
 			}
 			def.PartitionDefs = append(def.PartitionDefs, pdef)
+		}
+		// Check for duplicate partition names (case-insensitive, accent-insensitive).
+		if len(def.PartitionDefs) > 0 {
+			seen := make(map[string]bool, len(def.PartitionDefs))
+			for _, pd := range def.PartitionDefs {
+				key := normalizePartitionName(pd.Name)
+				if seen[key] {
+					return nil, mysqlError(1517, "HY000", fmt.Sprintf("Duplicate partition name %s", pd.Name))
+				}
+				seen[key] = true
+			}
+		}
+		// For KEY partitions, check for duplicate column names in the partition key.
+		if po.Type == sqlparser.KeyType && len(po.ColList) > 0 {
+			seenCols := make(map[string]bool, len(po.ColList))
+			for _, partCol := range po.ColList {
+				colLower := strings.ToLower(partCol.String())
+				if seenCols[colLower] {
+					return nil, mysqlError(1473, "HY000", fmt.Sprintf("Duplicate partition field name '%s'", strings.ToLower(partCol.String())))
+				}
+				seenCols[colLower] = true
+			}
 		}
 		// For KEY partitions, validate that the total byte length of partition
 		// columns does not exceed 3072 bytes (MySQL's max partition key length).
@@ -3077,10 +3212,20 @@ func (e *Executor) execAlterTable(stmt *sqlparser.AlterTable) (*Result, error) {
 				Rows:        [][]interface{}{{qualTable, opStr, "status", "OK"}},
 				IsResultSet: true,
 			}, nil
+		case sqlparser.ExchangeAction:
+			// EXCHANGE PARTITION: check if the target table is a view.
+			// MySQL returns ER_CHECK_NO_SUCH_TABLE (1177) when the target is a view.
+			if !stmt.PartitionSpec.TableName.IsEmpty() {
+				exchangeTableName := stmt.PartitionSpec.TableName.Name.String()
+				if _, _, isView := e.lookupView(exchangeTableName); isView {
+					return nil, mysqlError(1177, "42000", "Can't open table")
+				}
+			}
+			// Not fully implemented; ignore silently.
+			return &Result{}, nil
 		case sqlparser.TruncateAction, sqlparser.DiscardAction, sqlparser.ImportAction,
 			sqlparser.CoalesceAction, sqlparser.RemoveAction, sqlparser.UpgradeAction,
-			sqlparser.ReorganizeAction, sqlparser.AddAction, sqlparser.DropAction,
-			sqlparser.ExchangeAction:
+			sqlparser.ReorganizeAction, sqlparser.AddAction, sqlparser.DropAction:
 			// These partition DDL operations are not fully implemented; ignore silently.
 			return &Result{}, nil
 		}

--- a/executor/show.go
+++ b/executor/show.go
@@ -2481,11 +2481,19 @@ func formatPartitionExpr(exprStr string) string {
 	return mysqlGenExprNode(parsed, "")
 }
 
-// buildPartitionClause renders the /*!50100 PARTITION BY ... */ block for SHOW CREATE TABLE.
-// MySQL format: /*!50100 PARTITION BY RANGE (`col`)\n(PARTITION p0 ...) */
+// buildPartitionClause renders the /*!50100 or /*!50500 PARTITION BY ... */ block for SHOW CREATE TABLE.
+// MySQL uses /*!50100 for basic partitioning (RANGE/LIST/HASH/KEY with expression)
+// and /*!50500 for COLUMNS-based partitioning (RANGE COLUMNS, LIST COLUMNS) introduced in MySQL 5.5.
 func buildPartitionClause(def *catalog.TableDef) string {
 	var b strings.Builder
-	b.WriteString("/*!50100 PARTITION BY ")
+	// Use 50500 for COLUMNS-based partitioning (RANGE COLUMNS or LIST COLUMNS)
+	isColumns := len(def.PartitionExprCols) > 0 &&
+		(def.PartitionType == "RANGE" || def.PartitionType == "LIST")
+	if isColumns {
+		b.WriteString("/*!50500 PARTITION BY ")
+	} else {
+		b.WriteString("/*!50100 PARTITION BY ")
+	}
 
 	// Partition type
 	switch def.PartitionType {
@@ -2500,14 +2508,13 @@ func buildPartitionClause(def *catalog.TableDef) string {
 			b.WriteString(formatPartitionExpr(def.PartitionExpression))
 			b.WriteString(")")
 		} else if len(def.PartitionExprCols) > 0 {
-			b.WriteString("COLUMNS (")
+			// RANGE COLUMNS: output " COLUMNS(col1,col2)" - no backticks, no space before "("
+			b.WriteString(" COLUMNS(")
 			for i, c := range def.PartitionExprCols {
 				if i > 0 {
 					b.WriteString(",")
 				}
-				b.WriteString("`")
 				b.WriteString(c)
-				b.WriteString("`")
 			}
 			b.WriteString(")")
 		}
@@ -2522,14 +2529,13 @@ func buildPartitionClause(def *catalog.TableDef) string {
 			b.WriteString(formatPartitionExpr(def.PartitionExpression))
 			b.WriteString(")")
 		} else if len(def.PartitionExprCols) > 0 {
-			b.WriteString("COLUMNS (")
+			// LIST COLUMNS: output " COLUMNS(col1,col2)" - no backticks, no space before "("
+			b.WriteString(" COLUMNS(")
 			for i, c := range def.PartitionExprCols {
 				if i > 0 {
 					b.WriteString(",")
 				}
-				b.WriteString("`")
 				b.WriteString(c)
-				b.WriteString("`")
 			}
 			b.WriteString(")")
 		}


### PR DESCRIPTION
## Summary

Closes #186

Implements partition DDL validation and SHOW CREATE TABLE fixes for partition metadata output.

### Changes

**`executor/ddl.go`:**
- Add `normalizePartitionName()` using NFKD+case fold+diacritics strip for unicode-aware partition name comparison
- Add `disallowedPartitionFunctions` map of functions not allowed in partition expressions per MySQL spec
- Add `validatePartitionExpr()` walker that detects disallowed functions/operators in partition expressions
- In CREATE TABLE partition processing:
  - Validate partition expression after collection (ER_PARTITION_FUNCTION_IS_NOT_ALLOWED / 1491)
  - Check for duplicate partition names using normalized comparison (ER_SAME_NAME_PARTITION / 1517)
  - Check for duplicate KEY partition columns (error 1473)
- In ALTER TABLE EXCHANGE PARTITION: check if target table is a view and return error 1177

**`executor/show.go`:**
- Use `/*!50500` version comment for RANGE/LIST COLUMNS partitioning (MySQL 5.5+ feature)
- Fix COLUMNS format: output `LIST  COLUMNS(a)` (double space, no backticks) matching MySQL's output

### Test Results

- **1703 passed** (baseline: 1702, net **+1**)
- **0 regressions** from baseline
- `other/partition_charset` now passes (was failing)
- 113+ tests improved by first-diff-line metric

## Test plan

- [x] `go build ./... && go test ./... -count=1` passes
- [x] Full mtrrun: 1703 passed, 0 regressions vs baseline 1702
- [x] `other/partition_charset` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)