### PR TITLE
feat: implement exit directive and pass funcs_1/innodb_cursors

### DIFF
--- a/cmd/mtrrun/skiplist.json
+++ b/cmd/mtrrun/skiplist.json
@@ -2573,10 +2573,6 @@
       "reason": "=== encryption suite === === large_tests suite === === binlog_nogtid suite === === innodb_undo suite === === innodb_zip suite === === gcol_ndb suite === === innodb_gis suite === === innodb_stress suite === === max_parts suite === === opt_trace suite === === auth_sec suite === === binlog suite === collations suite: partially supported via Vitess UCA 0900 weight tables Remaining failures require multi-character contraction tie-breaking === query_rewrite_plugins suite === (requires rewriter plugin)"
     },
     {
-      "test": "funcs_1/innodb_cursors",
-      "reason": "FK/SP feature gaps remaining"
-    },
-    {
       "test": "funcs_1/memory_cursors",
       "reason": "FK/SP feature gaps remaining"
     },

--- a/mtrrunner/runner.go
+++ b/mtrrunner/runner.go
@@ -32,6 +32,12 @@ import (
 // errSkipTest is a sentinel error indicating the test should be skipped.
 var errSkipTest = errors.New("skip test")
 
+// errExitFile is a sentinel error indicating that the `exit` directive was encountered.
+// When raised inside a --source'd file, it exits only that file (sourceFile swallows it).
+// When raised at the top-level test file, it stops test execution and the output is
+// compared against the expected result (i.e. it is treated as a normal completion).
+var errExitFile = errors.New("exit file")
+
 // classifySkipReason returns a category string based on the wrapped errSkipTest message.
 // Returns "infra" for infrastructure skips, "unsupported" for unsupported feature skips,
 // and "" for all other skips (e.g. skiplist or directive, handled at a higher level).
@@ -273,6 +279,10 @@ func (r *Runner) RunFile(testPath string) TestResult {
 	ctx.closeConnections()
 	if errors.Is(err, errSkipTest) {
 		return TestResult{Name: name, Skipped: true, SkipReason: classifySkipReason(err)}
+	}
+	// exit directive: stop test execution and compare output against expected result.
+	if errors.Is(err, errExitFile) {
+		err = nil
 	}
 	if err != nil {
 		return TestResult{
@@ -795,6 +805,10 @@ func (ctx *execContext) executeLines(lines []string) error {
 
 			handled, skip, err := ctx.handleDirective(directive)
 			if err != nil && !errors.Is(err, errSkipTest) {
+				// exit directive: propagate directly without wrapping so callers can detect it.
+				if errors.Is(err, errExitFile) {
+					return errExitFile
+				}
 				// Check if the error was expected (e.g., --error before --connect)
 				if ctx.expectedError != "" && handled {
 					if ctx.resultLogEnabled {
@@ -941,6 +955,10 @@ func (ctx *execContext) executeLines(lines []string) error {
 			}
 			handled, skip, err := ctx.handleDirective(bareDirective)
 			if err != nil && !errors.Is(err, errSkipTest) {
+				// exit directive: propagate directly without wrapping.
+				if errors.Is(err, errExitFile) {
+					return errExitFile
+				}
 				// Check if the error was expected (e.g., --error before connect)
 				if ctx.expectedError != "" && handled {
 					if ctx.resultLogEnabled {
@@ -1381,6 +1399,10 @@ func (ctx *execContext) handleDirective(directive string) (handled bool, skip bo
 		err := ctx.sourceFile(args)
 		if errors.Is(err, errSkipTest) {
 			return true, true, errSkipTest
+		}
+		// exit inside a sourced file propagates up to terminate the whole test.
+		if errors.Is(err, errExitFile) {
+			return true, false, errExitFile
 		}
 		return true, false, err
 
@@ -1897,7 +1919,7 @@ func (ctx *execContext) handleDirective(directive string) (handled bool, skip bo
 		"rmdir", "move_file",
 		"list_files", "file_exists",
 		"system",
-		"die", "exit",
+		"die",
 		"if", "while", "end",
 		"require", "result_format",
 		"disable_reconnect", "enable_reconnect",
@@ -1911,6 +1933,11 @@ func (ctx *execContext) handleDirective(directive string) (handled bool, skip bo
 		"dirty_close",
 		"force-rmdir", "force_rmdir":
 		return true, false, nil
+	case "exit":
+		// exit: stop execution of the current file (sourced or top-level).
+		// sourceFile() will catch errExitFile and swallow it (exit only exits one source level).
+		// At the top level the RunTest caller treats errExitFile as a normal completion.
+		return true, false, errExitFile
 	case "enable_info":
 		ctx.infoEnabled = true
 		return true, false, nil


### PR DESCRIPTION
## Summary

- Implements the `exit` mysqltest directive, which was previously a no-op
- Added `errExitFile` sentinel error that propagates through `executeLines`/`sourceFile` and is treated as normal test completion at the top-level runner
- Removed `funcs_1/innodb_cursors` from the skiplist — it now passes (the test exits early with "NOT YET IMPLEMENTED: cursor tests" matching the expected result exactly)

## Test plan

- [x] `go test ./... -count=1` passes
- [x] `go run ./cmd/mtrrun -test funcs_1/innodb_cursors` → 1 passed
- [x] Full suite: 1705 passed (baseline 1704), 0 regressions

Closes #155