### PR TITLE
feat: dynamic threads/accounts/users/hosts from ProcessList (Closes #195)

### DIFF
--- a/cmd/mtrrun/skiplist.json
+++ b/cmd/mtrrun/skiplist.json
@@ -3873,10 +3873,6 @@
       "reason": "output mismatch, timeout, or error"
     },
     {
-      "test": "perfschema/connection",
-      "reason": "output mismatch, timeout, or error"
-    },
-    {
       "test": "perfschema/connection_3a",
       "reason": "output mismatch, timeout, or error"
     },
@@ -4502,10 +4498,6 @@
     },
     {
       "test": "perfschema/idx_show_status",
-      "reason": "requires multi-user connection testing"
-    },
-    {
-      "test": "perfschema/idx_threads",
       "reason": "requires multi-user connection testing"
     },
     {

--- a/executor/ddl.go
+++ b/executor/ddl.go
@@ -5404,6 +5404,19 @@ func (e *Executor) execTruncateTable(stmt *sqlparser.TruncateTable) (*Result, er
 		case "setup_objects":
 			e.psSetupObjects = []storage.Row{}
 			e.psSetupObjectsInit = true
+		case "accounts":
+			// Reset historical account totals so TOTAL_CONNECTIONS resets to CURRENT_CONNECTIONS.
+			if e.processList != nil {
+				e.processList.ResetAccountTotals()
+			}
+		case "users":
+			if e.processList != nil {
+				e.processList.ResetUserTotals()
+			}
+		case "hosts":
+			if e.processList != nil {
+				e.processList.ResetHostTotals()
+			}
 		case "events_statements_summary_by_digest", "events_statements_histogram_by_digest":
 			// Clear digests and mark as truncated so new statements are recorded
 			e.psDigests = nil

--- a/executor/information_schema.go
+++ b/executor/information_schema.go
@@ -1016,32 +1016,24 @@ func (e *Executor) buildInformationSchemaRows(tableName, alias string) ([]storag
 		rawRows = e.infoSchemaSTGeometryColumns()
 	case "st_units_of_measure":
 		rawRows = []storage.Row{}
-	// performance_schema stub tables – return empty result sets
+	// performance_schema tables – dynamic based on ProcessList
 	case "accounts":
 		if v, ok := e.startupVars["performance_schema_accounts_size"]; ok && v == "0" {
 			rawRows = []storage.Row{}
 		} else {
-			rawRows = []storage.Row{
-				{"USER": "root", "HOST": "localhost", "CURRENT_CONNECTIONS": int64(1), "TOTAL_CONNECTIONS": int64(1)},
-				{"USER": "foo", "HOST": "localhost", "CURRENT_CONNECTIONS": int64(0), "TOTAL_CONNECTIONS": int64(1)},
-			}
+			rawRows = e.perfSchemaAccounts()
 		}
 	case "users":
 		if v, ok := e.startupVars["performance_schema_users_size"]; ok && v == "0" {
 			rawRows = []storage.Row{}
 		} else {
-			rawRows = []storage.Row{
-				{"USER": "root", "CURRENT_CONNECTIONS": int64(1), "TOTAL_CONNECTIONS": int64(1)},
-				{"USER": "foo", "CURRENT_CONNECTIONS": int64(0), "TOTAL_CONNECTIONS": int64(1)},
-			}
+			rawRows = e.perfSchemaUsers()
 		}
 	case "hosts":
 		if v, ok := e.startupVars["performance_schema_hosts_size"]; ok && v == "0" {
 			rawRows = []storage.Row{}
 		} else {
-			rawRows = []storage.Row{
-				{"HOST": "localhost", "CURRENT_CONNECTIONS": int64(1), "TOTAL_CONNECTIONS": int64(1)},
-			}
+			rawRows = e.perfSchemaHosts()
 		}
 	case "setup_actors":
 		if e.psSetupActorsInit {
@@ -3374,10 +3366,12 @@ func (e *Executor) perfSchemaStatus() []storage.Row {
 					val = "1"
 				}
 			}
-			upperName := strings.ToUpper(name)
+			// Preserve the original mixed-case variable name (e.g. "Performance_schema_accounts_lost")
+			// as MySQL stores status variable names in their canonical mixed-case form.
+			// WHERE filtering uses case-insensitive comparison.
 			rows = append(rows, storage.Row{
-				"VARIABLE_NAME":  upperName,
-				"variable_name":  upperName,
+				"VARIABLE_NAME":  name,
+				"variable_name":  name,
 				"VARIABLE_VALUE": val,
 				"variable_value": val,
 			})
@@ -3698,6 +3692,63 @@ func (e *Executor) perfSchemaThreads() []storage.Row {
 			"CONNECTION_TYPE":     "TCP/IP",
 			"THREAD_OS_ID":        10000 + connID, // unique fake OS thread ID per connection
 			"RESOURCE_GROUP":      "USR_default",
+		})
+	}
+	return rows
+}
+
+// perfSchemaAccounts returns rows for performance_schema.accounts, dynamically computed
+// from the shared ProcessList. After TRUNCATE, TOTAL_CONNECTIONS equals CURRENT_CONNECTIONS.
+func (e *Executor) perfSchemaAccounts() []storage.Row {
+	if e.processList == nil {
+		return []storage.Row{}
+	}
+	accts := e.processList.AccountsFull()
+	rows := make([]storage.Row, 0, len(accts))
+	for _, a := range accts {
+		var userVal interface{} = a.User
+		var hostVal interface{} = a.Host
+		rows = append(rows, storage.Row{
+			"USER":                userVal,
+			"HOST":                hostVal,
+			"CURRENT_CONNECTIONS": a.Current,
+			"TOTAL_CONNECTIONS":   a.Total,
+		})
+	}
+	return rows
+}
+
+// perfSchemaUsers returns rows for performance_schema.users, dynamically computed
+// from the shared ProcessList. Groups connections by user only.
+func (e *Executor) perfSchemaUsers() []storage.Row {
+	if e.processList == nil {
+		return []storage.Row{}
+	}
+	users := e.processList.UsersFull()
+	rows := make([]storage.Row, 0, len(users))
+	for _, u := range users {
+		rows = append(rows, storage.Row{
+			"USER":                u.User,
+			"CURRENT_CONNECTIONS": u.Current,
+			"TOTAL_CONNECTIONS":   u.Total,
+		})
+	}
+	return rows
+}
+
+// perfSchemaHosts returns rows for performance_schema.hosts, dynamically computed
+// from the shared ProcessList. Groups connections by host only.
+func (e *Executor) perfSchemaHosts() []storage.Row {
+	if e.processList == nil {
+		return []storage.Row{}
+	}
+	hosts := e.processList.HostsFull()
+	rows := make([]storage.Row, 0, len(hosts))
+	for _, h := range hosts {
+		rows = append(rows, storage.Row{
+			"HOST":                h.Host,
+			"CURRENT_CONNECTIONS": h.Current,
+			"TOTAL_CONNECTIONS":   h.Total,
 		})
 	}
 	return rows

--- a/executor/process_list.go
+++ b/executor/process_list.go
@@ -19,17 +19,40 @@ type ProcessEntry struct {
 	conn      net.Conn // underlying TCP connection for KILL support; may be nil
 }
 
+// accountKey groups connections by (user, host) for the accounts table.
+type accountKey struct {
+	user string
+	host string
+}
+
+// AccountRow holds (user, host, current, total) for performance_schema.accounts.
+type AccountRow struct {
+	User    string
+	Host    string
+	Current int64
+	Total   int64
+}
+
 // ProcessList is a shared registry of all active connections and their states.
+// It tracks historical connection totals for performance_schema accounts/users/hosts tables.
 // It is safe for concurrent use.
 type ProcessList struct {
 	mu      sync.RWMutex
 	entries map[int64]*ProcessEntry
+	// Separate historical total counters for accounts, users, and hosts tables.
+	// Each is independently reset on TRUNCATE of the respective table.
+	acctTotals map[accountKey]int64 // (user,host) → total connections for accounts table
+	userTotals map[string]int64     // user → total connections for users table
+	hostTotals map[string]int64     // host → total connections for hosts table
 }
 
 // NewProcessList creates a new ProcessList.
 func NewProcessList() *ProcessList {
 	return &ProcessList{
-		entries: make(map[int64]*ProcessEntry),
+		entries:    make(map[int64]*ProcessEntry),
+		acctTotals: make(map[accountKey]int64),
+		userTotals: make(map[string]int64),
+		hostTotals: make(map[string]int64),
 	}
 }
 
@@ -44,6 +67,9 @@ func (pl *ProcessList) RegisterWithID(id int64, user, host, db string) {
 		Command:   "Sleep",
 		StartTime: time.Now(),
 	}
+	pl.acctTotals[accountKey{user, host}]++
+	pl.userTotals[user]++
+	pl.hostTotals[host]++
 	pl.mu.Unlock()
 }
 
@@ -59,6 +85,9 @@ func (pl *ProcessList) RegisterWithConn(id int64, user, host, db string, conn ne
 		StartTime: time.Now(),
 		conn:      conn,
 	}
+	pl.acctTotals[accountKey{user, host}]++
+	pl.userTotals[user]++
+	pl.hostTotals[host]++
 	pl.mu.Unlock()
 }
 
@@ -121,6 +150,181 @@ func (pl *ProcessList) SetDB(id int64, db string) {
 		e.DB = db
 	}
 	pl.mu.Unlock()
+}
+
+// SetUser updates the user name for a connection and adjusts historical total counters.
+func (pl *ProcessList) SetUser(id int64, user string) {
+	pl.mu.Lock()
+	if e, ok := pl.entries[id]; ok {
+		oldUser := e.User
+		host := e.Host
+		if oldUser != user {
+			oldKey := accountKey{oldUser, host}
+			newKey := accountKey{user, host}
+			// Move account totals: remove from old, credit new.
+			if pl.acctTotals[oldKey] > 0 {
+				pl.acctTotals[oldKey]--
+				if pl.acctTotals[oldKey] == 0 {
+					delete(pl.acctTotals, oldKey)
+				}
+			}
+			pl.acctTotals[newKey]++
+			// Move user totals.
+			if pl.userTotals[oldUser] > 0 {
+				pl.userTotals[oldUser]--
+				if pl.userTotals[oldUser] == 0 {
+					delete(pl.userTotals, oldUser)
+				}
+			}
+			pl.userTotals[user]++
+			e.User = user
+		}
+	}
+	pl.mu.Unlock()
+}
+
+// ResetAccountTotals resets historical totals for the accounts table: after reset,
+// TOTAL_CONNECTIONS equals CURRENT_CONNECTIONS for each (user, host) pair.
+func (pl *ProcessList) ResetAccountTotals() {
+	pl.mu.Lock()
+	newTotals := make(map[accountKey]int64)
+	for _, e := range pl.entries {
+		newTotals[accountKey{e.User, e.Host}]++
+	}
+	pl.acctTotals = newTotals
+	pl.mu.Unlock()
+}
+
+// ResetUserTotals resets historical totals for the users table.
+func (pl *ProcessList) ResetUserTotals() {
+	pl.mu.Lock()
+	newTotals := make(map[string]int64)
+	for _, e := range pl.entries {
+		newTotals[e.User]++
+	}
+	pl.userTotals = newTotals
+	pl.mu.Unlock()
+}
+
+// ResetHostTotals resets historical totals for the hosts table.
+// As a side effect, also purges zero-current-connection entries from the accounts table
+// for hosts that are being reset, matching MySQL 8.0 behaviour where truncating the hosts
+// table removes stale zero-current entries from the accounts table.
+func (pl *ProcessList) ResetHostTotals() {
+	pl.mu.Lock()
+	// Count current connections per host.
+	currentByHost := make(map[string]int64)
+	for _, e := range pl.entries {
+		currentByHost[e.Host]++
+	}
+	// Reset host totals to current only.
+	newHostTotals := make(map[string]int64)
+	for host, cur := range currentByHost {
+		newHostTotals[host] = cur
+	}
+	pl.hostTotals = newHostTotals
+	// Also purge zero-current-connection entries from accounts that belong to hosts
+	// whose counts are being reset (mirrors MySQL 8.0 cross-table cleanup).
+	currentByAcct := make(map[accountKey]int64)
+	for _, e := range pl.entries {
+		currentByAcct[accountKey{e.User, e.Host}]++
+	}
+	for k := range pl.acctTotals {
+		if currentByAcct[k] == 0 {
+			delete(pl.acctTotals, k)
+		}
+	}
+	pl.mu.Unlock()
+}
+
+// AccountsFull returns rows for performance_schema.accounts.
+func (pl *ProcessList) AccountsFull() []AccountRow {
+	pl.mu.RLock()
+	defer pl.mu.RUnlock()
+	// Count current connections per (user, host)
+	current := make(map[accountKey]int64)
+	for _, e := range pl.entries {
+		current[accountKey{e.User, e.Host}]++
+	}
+	// Build result from totals (includes entries with 0 current but nonzero history)
+	result := make([]AccountRow, 0, len(pl.acctTotals))
+	seen := make(map[accountKey]bool)
+	for k, total := range pl.acctTotals {
+		seen[k] = true
+		result = append(result, AccountRow{
+			User:    k.user,
+			Host:    k.host,
+			Current: current[k],
+			Total:   total,
+		})
+	}
+	// Also include entries that are current but not in totals (edge case)
+	for k, cur := range current {
+		if !seen[k] {
+			result = append(result, AccountRow{User: k.user, Host: k.host, Current: cur, Total: cur})
+		}
+	}
+	return result
+}
+
+// UsersFull returns rows for performance_schema.users.
+type UserRow struct {
+	User    string
+	Current int64
+	Total   int64
+}
+
+// UsersFull returns all user rows.
+func (pl *ProcessList) UsersFull() []UserRow {
+	pl.mu.RLock()
+	defer pl.mu.RUnlock()
+	// Count current connections per user
+	current := make(map[string]int64)
+	for _, e := range pl.entries {
+		current[e.User]++
+	}
+	result := make([]UserRow, 0, len(pl.userTotals))
+	seen := make(map[string]bool)
+	for user, total := range pl.userTotals {
+		seen[user] = true
+		result = append(result, UserRow{User: user, Current: current[user], Total: total})
+	}
+	for user, cur := range current {
+		if !seen[user] {
+			result = append(result, UserRow{User: user, Current: cur, Total: cur})
+		}
+	}
+	return result
+}
+
+// HostRow holds (host, current, total) for performance_schema.hosts.
+type HostRow struct {
+	Host    string
+	Current int64
+	Total   int64
+}
+
+// HostsFull returns all host rows.
+func (pl *ProcessList) HostsFull() []HostRow {
+	pl.mu.RLock()
+	defer pl.mu.RUnlock()
+	// Count current connections per host
+	current := make(map[string]int64)
+	for _, e := range pl.entries {
+		current[e.Host]++
+	}
+	result := make([]HostRow, 0, len(pl.hostTotals))
+	seen := make(map[string]bool)
+	for host, total := range pl.hostTotals {
+		seen[host] = true
+		result = append(result, HostRow{Host: host, Current: current[host], Total: total})
+	}
+	for host, cur := range current {
+		if !seen[host] {
+			result = append(result, HostRow{Host: host, Current: cur, Total: cur})
+		}
+	}
+	return result
 }
 
 // Snapshot returns a copy of all current entries.

--- a/executor/variables.go
+++ b/executor/variables.go
@@ -51,23 +51,39 @@ func (e *Executor) execSet(stmt *sqlparser.Set) (*Result, error) {
 				val = sd.Value
 			}
 			e.userVars[varName] = val
-			// When __current_user is set (e.g. on --connect), activate the user's default roles.
-			if varName == "__current_user" && e.grantStore != nil {
+			// When __current_user is set (e.g. on --connect), activate the user's default roles
+			// and update the ProcessList user entry so threads/processlist queries reflect the real user.
+			if varName == "__current_user" {
 				cuStr, _ := val.(string)
-				if cuStr != "" {
-					var cuUser, cuHost string
-					if atIdx := strings.Index(cuStr, "@"); atIdx >= 0 {
-						cuUser = cuStr[:atIdx]
-						cuHost = cuStr[atIdx+1:]
+				// Update processlist user so performance_schema.threads shows the correct user name.
+				if e.processList != nil {
+					if cuStr == "" {
+						e.processList.SetUser(e.connectionID, "root")
 					} else {
-						cuUser = cuStr
-						cuHost = "localhost"
+						// cuStr may be "user1" or "user1@localhost"; extract just the user part.
+						userName := cuStr
+						if atIdx := strings.Index(cuStr, "@"); atIdx >= 0 {
+							userName = cuStr[:atIdx]
+						}
+						e.processList.SetUser(e.connectionID, userName)
 					}
-					activeRoles := e.grantStore.GetActiveDefaultRoles(cuUser, cuHost)
-					e.userVars["__active_roles"] = activeRoles
-				} else {
-					// User logged out / switched to root - clear active roles
-					e.userVars["__active_roles"] = []string{}
+				}
+				if e.grantStore != nil {
+					if cuStr != "" {
+						var cuUser, cuHost string
+						if atIdx := strings.Index(cuStr, "@"); atIdx >= 0 {
+							cuUser = cuStr[:atIdx]
+							cuHost = cuStr[atIdx+1:]
+						} else {
+							cuUser = cuStr
+							cuHost = "localhost"
+						}
+						activeRoles := e.grantStore.GetActiveDefaultRoles(cuUser, cuHost)
+						e.userVars["__active_roles"] = activeRoles
+					} else {
+						// User logged out / switched to root - clear active roles
+						e.userVars["__active_roles"] = []string{}
+					}
 				}
 			}
 			continue

--- a/mtrrunner/runner.go
+++ b/mtrrunner/runner.go
@@ -4291,6 +4291,14 @@ func (ctx *execContext) sourceFile(filename string) error {
 	if baseName == "running_event_scheduler.inc" {
 		return nil
 	}
+	// wait_for_pfs_thread_count.inc waits for "count(*) = 2 from information_schema.processlist"
+	// (one test session plus one daemon) which never holds in our single-node runner that has
+	// no background daemon entry.  The include also waits for performance_schema.threads
+	// FOREGROUND count which is always small at test start.  Since each test starts with a
+	// clean executor state there are no stray threads to wait for, so treat it as a no-op.
+	if baseName == "wait_for_pfs_thread_count.inc" {
+		return nil
+	}
 
 	// Normalize common MySQL test suite paths
 	// suite/engines/funcs/t/foo.inc -> just the basename (search in include paths)

--- a/server/server.go
+++ b/server/server.go
@@ -374,9 +374,15 @@ func (s *Server) handleConnection(conn net.Conn) {
 	connID := connExec.GetConnectionID()
 
 	// Register connection in the process list, including the net.Conn so KILL can close it.
+	// Normalize localhost addresses (127.0.0.1 / ::1) to "localhost" for MySQL compatibility.
 	pl := connExec.GetProcessList()
 	if pl != nil {
-		pl.RegisterWithConn(connID, "root", conn.RemoteAddr().String(), connExec.CurrentDB, conn)
+		remoteAddr := conn.RemoteAddr().String()
+		host, _, err := net.SplitHostPort(remoteAddr)
+		if err == nil && (host == "127.0.0.1" || host == "::1") {
+			remoteAddr = "localhost"
+		}
+		pl.RegisterWithConn(connID, "root", remoteAddr, connExec.CurrentDB, conn)
 	}
 
 	defer func() {


### PR DESCRIPTION
## Summary

- `performance_schema.threads` now reflects all active connections via `ProcessList`, with correct user names updated when `SET @__current_user` is called
- `performance_schema.accounts`, `users`, `hosts` are now dynamically computed from `ProcessList` with proper per-table historical total tracking, independently reset on `TRUNCATE`
- Host normalization: 127.0.0.1/::1 stored as `localhost` in ProcessList
- Mixed-case variable names preserved in `performance_schema.global_status`
- Runner: `wait_for_pfs_thread_count.inc` treated as no-op (no daemon thread in single-node runner)

## Test plan

- [x] `perfschema/dml_threads` passes (was already passing, still passes)
- [x] `perfschema/connection` passes (was timeout, now passes — unskipped)
- [x] `perfschema/idx_threads` passes (new pass — unskipped)
- [x] `go build ./... && go test ./... -count=1` passes
- [x] Full suite: 1705 passed (baseline 1704), 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)