### PR TITLE
feat: fix := assignment and generated column recompute in BEFORE triggers (Closes #157)

### DIFF
--- a/cmd/mtrrun/skiplist.json
+++ b/cmd/mtrrun/skiplist.json
@@ -2605,10 +2605,6 @@
       "reason": "FK/SP feature gaps remaining"
     },
     {
-      "test": "gcol/gcol_trigger_sp_myisam",
-      "reason": "generated column decimal formatting and SP cursor/warnings mismatch"
-    },
-    {
       "test": "x/cursor_fetch",
       "reason": "FK/SP feature gaps remaining"
     },
@@ -3635,10 +3631,6 @@
     {
       "test": "gcol/gcol_supported_sql_funcs_myisam",
       "reason": "failures"
-    },
-    {
-      "test": "gcol/gcol_trigger_sp_innodb",
-      "reason": "cursor/procedure failures"
     },
     {
       "test": "parts/partition_icp",

--- a/executor/dml_insert.go
+++ b/executor/dml_insert.go
@@ -1648,6 +1648,14 @@ func (e *Executor) execInsert(stmt *sqlparser.Insert) (*Result, error) {
 			return nil, err
 		}
 
+		// Recompute generated columns after BEFORE trigger may have modified base columns.
+		// MySQL always recomputes generated column values from the (possibly modified) base
+		// columns after a BEFORE trigger fires, ignoring any direct SET NEW.generated_col
+		// assignments inside the trigger body.
+		if err := e.populateGeneratedColumns(fullRow, tbl.Def.Columns); err != nil {
+			return nil, err
+		}
+
 		// Apply trigger modifications back to the row being inserted
 		// Only copy columns that were explicitly set by the user or modified by triggers
 		for _, col := range tbl.Def.Columns {

--- a/executor/dml_update.go
+++ b/executor/dml_update.go
@@ -660,6 +660,20 @@ func (e *Executor) execUpdate(stmt *sqlparser.Update) (*Result, error) {
 		}
 		tbl.Lock()
 
+		// Recompute generated columns after BEFORE UPDATE trigger may have modified base columns.
+		// MySQL always recomputes generated column values from the (possibly modified) base
+		// columns after a BEFORE trigger fires, ignoring any direct SET NEW.generated_col
+		// assignments inside the trigger body.
+		for _, col := range tbl.Def.Columns {
+			genExpr := generatedColumnExpr(col.Type)
+			if genExpr == "" {
+				continue
+			}
+			if v, err := e.evalGeneratedColumnExpr(genExpr, newRow); err == nil {
+				newRow[col.Name] = v
+			}
+		}
+
 		// Enforce NOT NULL constraints on final NEW values.
 		// Convert NULL to the implicit zero/default value first so that
 		// subsequent constraint checks (duplicate key, etc.) see the

--- a/executor/procedures.go
+++ b/executor/procedures.go
@@ -614,10 +614,13 @@ func (e *Executor) fireTriggerWithRoutineInterpreter(tr *catalog.TriggerDef, tim
 		return err
 	}
 
-	// For BEFORE triggers, copy any modified NEW.col values back to newRow
+	// For BEFORE triggers, copy any modified NEW.col values back to newRow.
+	// Use case-insensitive prefix check to handle keys stored with either
+	// "NEW." or "new." prefix (e.g. from SET new.col := val in trigger body).
 	if timing == "BEFORE" && newRow != nil {
 		for k, v := range ctx.localVars {
-			if strings.HasPrefix(k, "NEW.") {
+			kUpper := strings.ToUpper(k)
+			if strings.HasPrefix(kUpper, "NEW.") {
 				colName := k[4:]
 				newRow[colName] = v
 			}
@@ -3144,6 +3147,8 @@ func (e *Executor) execRoutineBodyWithContext(body []string, ctx *routineContext
 			eqIdx := strings.Index(setPart, "=")
 			if eqIdx >= 0 {
 				varName := strings.TrimSpace(setPart[:eqIdx])
+				// Handle := assignment operator (MySQL stored routine syntax): strip trailing colon.
+				varName = strings.TrimSuffix(varName, ":")
 				valStr := strings.TrimSpace(setPart[eqIdx+1:])
 				// User variables (@var) have no declared type, so string-to-number truncation
 				// is only a warning (not an error) even inside strict-mode stored functions.
@@ -3219,7 +3224,25 @@ func (e *Executor) execRoutineBodyWithContext(body []string, ctx *routineContext
 								}
 							}
 						}
-						localVars[varName] = val
+						// Normalize NEW.col and OLD.col variable names to canonical uppercase prefix
+						// so that the copy-back in fireTriggerWithRoutineInterpreter works correctly.
+						varNameUpper := strings.ToUpper(varName)
+						if strings.HasPrefix(varNameUpper, "NEW.") {
+							canonicalKey := "NEW." + varName[4:]
+							localVars[canonicalKey] = val
+							// Also update triggerNewRow immediately so that subsequent condition
+							// evaluations in the same trigger body see the updated value.
+							if ctx.triggerNewRow != nil && ctx.triggerTiming == "BEFORE" {
+								colName := varName[4:]
+								ctx.triggerNewRow[colName] = val
+							}
+						} else if strings.HasPrefix(varNameUpper, "OLD.") {
+							// OLD columns are read-only; assignment should have been caught earlier,
+							// but normalise the key for consistency.
+							localVars["OLD."+varName[4:]] = val
+						} else {
+							localVars[varName] = val
+						}
 					}
 				}
 			} else {


### PR DESCRIPTION
## Summary

- Fix `:=` assignment operator bug in stored routine interpreter: `SET new.col := val` was keeping the colon in the variable name (`new.col:`), preventing trigger row updates from being propagated back
- Normalize `NEW.col` assignments to canonical uppercase prefix and update `triggerNewRow` immediately so subsequent conditions in the same trigger body see the updated value
- After a BEFORE INSERT/UPDATE trigger fires, recompute all generated columns from the (possibly modified) base column values, matching MySQL behaviour

Fixes `gcol/gcol_trigger_sp_innodb` and `gcol/gcol_trigger_sp_myisam` (both now pass, removed from skiplist).

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./... -count=1` passes (including `TestTriggerWithIfThenBeforeSetNew`)
- [x] `gcol/gcol_trigger_sp_innodb` passes
- [x] `gcol/gcol_trigger_sp_myisam` passes
- [x] Full MTR suite: 1709 passed (baseline 1707, +2 from new passes, 0 regressions)

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)