### PR TITLE
feat: encode HEX() output in utf16/utf32/ucs2/utf16le charset context

### DIFF
--- a/executor/expr_eval.go
+++ b/executor/expr_eval.go
@@ -2302,6 +2302,14 @@ func (e *Executor) evalIntroducerExpr(v *sqlparser.IntroducerExpr) (interface{},
 		case "ucs2":
 			// Keep UCS-2 as raw bytes for compatibility with JP charset tests
 			return string(bs), nil
+		case "utf16le":
+			// UTF-16 little-endian hex literal: left-pad to even length and return
+			// as HexBytes so HEX() can return the padded bytes directly.
+			// MySQL treats _utf16le 0x44 as the same hex output as _utf16 0x44 (left-padded).
+			for len(bs)%2 != 0 {
+				bs = append([]byte{0}, bs...)
+			}
+			return HexBytes(strings.ToUpper(hex.EncodeToString(bs))), nil
 		default:
 			// For other charsets (latin1, sjis, etc.), return raw bytes as-is.
 			// The existing JP charset conversion tests rely on this behavior.

--- a/executor/func_string.go
+++ b/executor/func_string.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/myuon/mylite/catalog"
 	"github.com/myuon/mylite/storage"
 	"vitess.io/vitess/go/vt/sqlparser"
 )
@@ -467,6 +468,58 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr, row *storag
 						out[i], out[i+1] = out[i+1], out[i]
 					}
 					return strings.ToUpper(hex.EncodeToString(out)), true, nil
+				}
+			}
+		}
+		// For charset introducer expressions (_utf16 x'...', _utf32 x'...', _ucs2 x'...')
+		// or when character_set_connection is a multi-byte charset (utf16/utf32/ucs2),
+		// encode string values to the appropriate charset bytes.
+		// This makes HEX(_utf16 X'0420') return the UTF-16 byte representation (0420),
+		// and HEX('a') with character_set_connection=utf16 return 0061.
+		hexEncodeCharset := ""
+		if colCharset == "" {
+			// Check for explicit charset introducer: _utf16 x'...', _utf32 x'...', etc.
+			if intro, ok := v.Exprs[0].(*sqlparser.IntroducerExpr); ok {
+				cs := strings.ToLower(strings.TrimPrefix(intro.CharacterSet, "_"))
+				switch cs {
+				case "utf16", "utf32", "ucs2", "utf16le":
+					hexEncodeCharset = cs
+				}
+			}
+			// If no introducer charset found, check character_set_connection.
+			// Also check collation_connection as a fallback (setting collation_connection
+			// to utf16le_general_ci implies utf16le connection encoding for literals).
+			if hexEncodeCharset == "" {
+				if connCS, ok := e.getSysVar("character_set_connection"); ok {
+					cs := strings.ToLower(canonicalCharset(connCS))
+					switch cs {
+					case "utf16", "utf32", "ucs2", "utf16le":
+						hexEncodeCharset = cs
+					}
+				}
+			}
+			if hexEncodeCharset == "" {
+				if collCS, ok := e.getSysVar("collation_connection"); ok {
+					if cs, ok2 := catalog.CharsetForCollation(collCS); ok2 {
+						switch strings.ToLower(cs) {
+						case "utf16", "utf32", "utf16le":
+							hexEncodeCharset = strings.ToLower(cs)
+						}
+					}
+				}
+			}
+		}
+		if hexEncodeCharset != "" {
+			switch val.(type) {
+			case int64, uint64, float64:
+				// Numeric values: fall through to default integer hex encoding
+			case HexBytes:
+				// Raw binary data: fall through to HexBytes handler
+			default:
+				// String value: encode to target charset
+				s := toString(val)
+				if encoded, err2 := convertThroughCharset(s, hexEncodeCharset); err2 == nil {
+					return strings.ToUpper(hex.EncodeToString([]byte(encoded))), true, nil
 				}
 			}
 		}


### PR DESCRIPTION
Closes #175

## Summary

- In `HEX()`, encode string values through the target charset (utf16/utf32/ucs2/utf16le) when the argument has a charset introducer expression (`_utf16 x'...'`) or when `character_set_connection` / `collation_connection` implies a multi-byte charset
- Add `utf16le` case to `evalIntroducerExpr` for hex literals: left-pad to even byte length and return as `HexBytes`, matching MySQL's behavior for incomplete UTF-16LE code units

## First-diff-line improvements (no regressions, baseline 1707 passes maintained)

| Test | Before | After | Delta |
|------|--------|-------|-------|
| ctype_utf16 | 5 | 26 | +21 |
| ctype_utf32 | 5 | 26 | +21 |
| ctype_utf16le | 4 | 25 | +21 |
| ctype_utf16_uca | 6 | 12 | +6 |
| ctype_utf32_uca | 6 | 12 | +6 |

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./... -count=1` passes (all unit tests)
- [x] Full mtrrun: 1707 passed (same as baseline, 0 regressions)
- [x] jp suite: 107/107 passed (no regressions in jp charset tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)