### PR TITLE
feat: enable semijoin strategy tests by fixing ALTER TABLE ENGINE= and SJ-Mat Scan EXPLAIN

### DIFF
--- a/executor/ddl.go
+++ b/executor/ddl.go
@@ -3283,10 +3283,14 @@ func (e *Executor) execAlterTable(stmt *sqlparser.AlterTable) (*Result, error) {
 							return nil, mysqlError(1579, "HY000", "This storage engine cannot be used for log tables")
 						}
 					}
-					// Reject non-InnoDB engines not supported by mylite
+					// Accept known MySQL engines that we treat as InnoDB internally.
+					// MyISAM, MEMORY, etc. are accepted (not returning ErrUnsupported) so that
+					// tests using force_myisam_default.inc and similar patterns can run.
+					// The table is always stored using our InnoDB-compatible engine regardless.
 					switch engineVal {
 					case "MYISAM", "MEMORY", "HEAP", "MERGE", "MRG_MYISAM", "BLACKHOLE", "ARCHIVE":
-						return nil, ErrUnsupported(fmt.Sprintf("ENGINE=%s (only InnoDB is supported)", tableOptionString(to)))
+						// Rewrite to InnoDB so that SHOW CREATE TABLE reflects the actual storage
+						to.String = "InnoDB"
 					}
 				}
 			}

--- a/executor/explain.go
+++ b/executor/explain.go
@@ -4176,15 +4176,21 @@ func (e *Executor) walkForSubqueries(node sqlparser.SQLNode, idCounter *int64, r
 								selectType = "MATERIALIZED"
 							} else if !materializationDisabledByHint && !firstMatchOn && (!looseScanOn || correlatedIN) && !outerINIsConst {
 								// When FirstMatch is disabled AND (LooseScan is also disabled OR LooseScan is not
-								// applicable for correlated subqueries) and Materialization is allowed, use MATERIALIZED.
+								// applicable for correlated subqueries) and Materialization is allowed, use MATERIALIZED
+								// only when the inner subquery would benefit from materialization (large/no-index tables).
 								// This handles:
-								// - NO_SEMIJOIN(@subq FIRSTMATCH, LOOSESCAN): both disabled → MATERIALIZED
+								// - NO_SEMIJOIN(@subq FIRSTMATCH, LOOSESCAN): both disabled → MATERIALIZED for large tables
 								// - NO_SEMIJOIN(@subq FIRSTMATCH, DUPSWEEDOUT) with correlated subquery: FirstMatch
-								//   disabled and LooseScan not applicable (correlated) → MATERIALIZED
+								//   disabled and LooseScan not applicable (correlated) → MATERIALIZED for large tables
 								// Note: if only FirstMatch is disabled but LooseScan is still available and applicable,
 								// LooseScan takes priority over MATERIALIZED.
+								// Note: when the inner table has a PRIMARY KEY on the join column, MySQL uses
+								// SJ-Mat Scan (shows as SIMPLE join rows) rather than SJ-Mat Lookup (shows MATERIALIZED).
 								if e.isOptimizerSwitchEnabled("materialization") {
-									selectType = "MATERIALIZED"
+									if e.inSubqueryTypesCompatibleForMat(outerSel, inner, sub) && e.shouldMaterializeSubquery(inner, outerIsSystem) {
+										selectType = "MATERIALIZED"
+									}
+									// else: SJ-Mat Scan → inline semijoin (SIMPLE rows, no placeholder)
 								}
 							} else if outerSemijoinHint.strategyForced("MATERIALIZATION") && !outerINIsConst && !looseScanForcedAndApplicable && !firstMatchForced {
 								// SEMIJOIN(@subq MATERIALIZATION) hint forces materialization strategy.

--- a/executor/features.go
+++ b/executor/features.go
@@ -20,15 +20,14 @@ type Feature struct {
 // Features is the canonical registry of MySQL feature support in mylite.
 var Features = []Feature{
 	// Storage Engines
-	// CREATE TABLE accepts MyISAM/MEMORY/etc without NO_ENGINE_SUBSTITUTION; treated as InnoDB.
-	// ALTER TABLE to MyISAM/MEMORY/HEAP/MERGE/BLACKHOLE/ARCHIVE returns Error 50001.
+	// CREATE TABLE and ALTER TABLE both accept MyISAM/MEMORY/etc; all treated as InnoDB internally.
 	{Name: "ENGINE=InnoDB", Category: "Storage Engine", Status: Supported, Description: "Default and only storage engine"},
-	{Name: "ENGINE=MyISAM", Category: "Storage Engine", Status: Unsupported, Description: "Accepted in CREATE TABLE (treated as InnoDB); ALTER TABLE to MyISAM returns Error 50001"},
-	{Name: "ENGINE=MEMORY / HEAP", Category: "Storage Engine", Status: Unsupported, Description: "Accepted in CREATE TABLE (treated as InnoDB); ALTER TABLE returns Error 50001"},
-	{Name: "ENGINE=MERGE / MRG_MYISAM", Category: "Storage Engine", Status: Unsupported, Description: "Accepted in CREATE TABLE (treated as InnoDB); ALTER TABLE returns Error 50001"},
-	{Name: "ENGINE=CSV", Category: "Storage Engine", Status: Unsupported, Description: "Accepted but requires all columns to be NOT NULL; ALTER TABLE returns Error 50001"},
-	{Name: "ENGINE=ARCHIVE", Category: "Storage Engine", Status: Unsupported, Description: "Accepted in CREATE TABLE (treated as InnoDB); ALTER TABLE returns Error 50001"},
-	{Name: "ENGINE=BLACKHOLE", Category: "Storage Engine", Status: Unsupported, Description: "Accepted in CREATE TABLE (treated as InnoDB); ALTER TABLE returns Error 50001"},
+	{Name: "ENGINE=MyISAM", Category: "Storage Engine", Status: Unsupported, Description: "Accepted in CREATE TABLE and ALTER TABLE (treated as InnoDB)"},
+	{Name: "ENGINE=MEMORY / HEAP", Category: "Storage Engine", Status: Unsupported, Description: "Accepted in CREATE TABLE and ALTER TABLE (treated as InnoDB)"},
+	{Name: "ENGINE=MERGE / MRG_MYISAM", Category: "Storage Engine", Status: Unsupported, Description: "Accepted in CREATE TABLE and ALTER TABLE (treated as InnoDB)"},
+	{Name: "ENGINE=CSV", Category: "Storage Engine", Status: Unsupported, Description: "Accepted but requires all columns to be NOT NULL"},
+	{Name: "ENGINE=ARCHIVE", Category: "Storage Engine", Status: Unsupported, Description: "Accepted in CREATE TABLE and ALTER TABLE (treated as InnoDB)"},
+	{Name: "ENGINE=BLACKHOLE", Category: "Storage Engine", Status: Unsupported, Description: "Accepted in CREATE TABLE and ALTER TABLE (treated as InnoDB)"},
 	{Name: "ENGINE=FEDERATED", Category: "Storage Engine", Status: Unsupported, Description: "Returns ER_UNKNOWN_STORAGE_ENGINE (1286)"},
 	{Name: "ENGINE=NDB / NDBCLUSTER", Category: "Storage Engine", Status: Unsupported, Description: "Accepted in ALTER TABLE but ignored (substituted with InnoDB)"},
 

--- a/mtrrunner/runner.go
+++ b/mtrrunner/runner.go
@@ -2372,7 +2372,13 @@ func (ctx *execContext) evaluateIfConditionInner(condStr string) bool {
 			if val == nil {
 				return false
 			}
-			s := fmt.Sprintf("%v", val)
+			var s string
+			switch v := val.(type) {
+			case []byte:
+				s = string(v)
+			default:
+				s = fmt.Sprintf("%v", v)
+			}
 			// In mysqltest, backtick returns "1" for true
 			return s != "0" && s != "" && s != "FALSE"
 		}
@@ -3661,6 +3667,8 @@ func (ctx *execContext) queryRows(stmt string) ([][]string, error) {
 		for i, v := range vals {
 			if v == nil {
 				row[i] = "NULL"
+			} else if b, ok := v.([]byte); ok {
+				row[i] = string(b)
 			} else {
 				row[i] = fmt.Sprintf("%v", v)
 			}


### PR DESCRIPTION
## Summary

- `executor/ddl.go`: Accept `ALTER TABLE ENGINE=MyISAM/MEMORY/etc` by silently rewriting to InnoDB (instead of returning `ErrUnsupported`). This prevents the test runner's auto-skip triggered by error 50001 inside `subquery_sj.inc` line 5256-5257.
- `mtrrunner/runner.go`: Fix `[]byte` handling in `evaluateIfConditionInner` and `queryRows` so MySQL driver byte slices are correctly stringified (not `[48]`).
- `executor/explain.go`: When `firstmatch=off` and `loosescan=off` (only `materialization=on`), use `shouldMaterializeSubquery()` to distinguish SJ-Mat Scan (shows as SIMPLE join rows, for small/PK-indexed tables) from SJ-Mat Lookup (shows `<subqueryN>` + MATERIALIZED rows, for large/no-index tables). Previously all cases unconditionally produced MATERIALIZED rows, causing `subquery_sj_mat` to fail at line 20.

## Results

- All 5 target tests (`subquery_sj_mat`, `subquery_sj_firstmatch`, `subquery_sj_loosescan`, `subquery_sj_dupsweed`, `subquery_sj_all`) now **run** (previously all skipped due to `ALTER TABLE ENGINE=MyISAM` triggering auto-skip)
- `subquery_sj_mat` first-diff-line: **20 → 299** (+279 lines improvement)
- Full suite: **1707 → 1711 passing** (+4 net), no regressions

## Test plan

- [x] `go build ./... && go test ./... -count=1` passes
- [x] Full mtrrun suite: 1711 passed, 322 failed, 129 errors (vs 1707/367/191 baseline)
- [x] `other/subquery_sj_mat` first-diff-line improved from 20 to 299
- [x] No regressions: 0 tests went from pass to fail/error

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)