### PR TITLE
fix: sort resultRows and uniqueSourceRows in tandem for DISTINCT+ORDER BY

### DIFF
--- a/executor/select.go
+++ b/executor/select.go
@@ -2893,8 +2893,18 @@ func (e *Executor) execSelect(stmt *sqlparser.Select) (*Result, error) {
 				fromExprD = stmt.From[0]
 			}
 			defaultCollationD := resolveOrderByCollation(selectTableDefs, fromExprD)
-			srcRows := uniqueSourceRows
-			sort.SliceStable(resultRows, func(a, b int) bool {
+			// Build a combined slice so that resultRows and uniqueSourceRows are sorted
+			// in tandem. Sorting resultRows alone while reading from uniqueSourceRows by
+			// index is incorrect because uniqueSourceRows does not move with resultRows.
+			type distinctPair struct {
+				result []interface{}
+				source storage.Row
+			}
+			pairs := make([]distinctPair, len(resultRows))
+			for i := range resultRows {
+				pairs[i] = distinctPair{result: resultRows[i], source: uniqueSourceRows[i]}
+			}
+			sort.SliceStable(pairs, func(a, b int) bool {
 				for _, order := range stmt.OrderBy {
 					expr := order.Expr
 					orderCollation := defaultCollationD
@@ -2908,8 +2918,8 @@ func (e *Executor) execSelect(stmt *sqlparser.Select) (*Result, error) {
 							expr = convExpr.Expr
 						}
 					}
-					va := resolveOrderByExprValue(e, expr, srcRows[a])
-					vb := resolveOrderByExprValue(e, expr, srcRows[b])
+					va := resolveOrderByExprValue(e, expr, pairs[a].source)
+					vb := resolveOrderByExprValue(e, expr, pairs[b].source)
 					cmp := compareByCollation(va, vb, orderCollation)
 					if cmp == 0 {
 						continue
@@ -2922,7 +2932,10 @@ func (e *Executor) execSelect(stmt *sqlparser.Select) (*Result, error) {
 				}
 				return false
 			})
-			// Also sort uniqueSourceRows to keep in sync (needed if further sorts happen)
+			for i, p := range pairs {
+				resultRows[i] = p.result
+				uniqueSourceRows[i] = p.source
+			}
 			preSortedOrderBy = true // mark as sorted, skip second ORDER BY pass
 		}
 	}


### PR DESCRIPTION
Closes #164

## Summary

- Fixed a bug in `executor/select.go` where `SELECT DISTINCT ... ORDER BY` with columns not in the SELECT list (pre-projection ORDER BY) produced incorrect sort order
- The root cause: `sort.SliceStable(resultRows, ...)` rearranges `resultRows` in place, but the less function read from `uniqueSourceRows` by the same indices — since `uniqueSourceRows` was not rearranged alongside, the indices became misaligned after the first swap
- Fix: build a combined `(result, source)` pair slice and sort that, then unpack back into both arrays

## Test plan

- `go build ./... && go test ./... -count=1` — all tests pass
- Targeted mtrrun: `other/order_by_all`, `other/order_by_none`, `other/order_by_icp_mrr` — DISTINCT+ORDER BY diff lines removed (lines 93-97 in previous diff)
- Full mtrrun: passed=1712 vs baseline 1713 — the difference is a flaky `sp-big` timeout (pre-existing flakiness), not caused by this change
- jp suite (sjis/ujis ORDER BY) remains at 100% pass — no regression for non-supported charsets

🤖 Generated with [Claude Code](https://claude.com/claude-code)