### PR TITLE
feat: enforce GRANT/REVOKE privilege checks (Closes #166)

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -2085,6 +2085,10 @@ func (e *Executor) Execute(query string) (res *Result, retErr error) {
 						object = strings.ToLower(e.CurrentDB) + "." + object
 					}
 				}
+				// Check if the current user has permission to issue this GRANT.
+				if grantErr := e.checkGrantPrivilege(privs, object, isRoleGrant); grantErr != nil {
+					return nil, grantErr
+				}
 				if isRoleGrant {
 					// GRANT role TO user - record role membership
 					// Handle comma-separated roles: "GRANT r1, r2 TO user"
@@ -6950,6 +6954,110 @@ func (e *Executor) checkTablePrivilege(stmt sqlparser.Statement) error {
 		}
 		return checkAccess("CREATE", dbName, s.Table.Name.String())
 	}
+	return nil
+}
+
+// checkGrantPrivilege checks if the current (non-root) user is allowed to execute a GRANT statement.
+// In MySQL, granting requires the grantor to have the privilege WITH GRANT OPTION on the same or wider scope.
+// Returns an appropriate MySQL error if access is denied, or nil if allowed.
+func (e *Executor) checkGrantPrivilege(privs, object string, isRoleGrant bool) error {
+	if e.grantStore == nil {
+		return nil
+	}
+	user, host, activeRoles := e.getCurrentUserAndRoles()
+	if user == "" {
+		return nil // root or no user context — always allowed
+	}
+
+	// Role grants (GRANT role TO user) require:
+	// - SUPER privilege, OR
+	// - ROLE_ADMIN privilege, OR
+	// - The grantor has WITH ADMIN OPTION for each role being granted (directly or via active roles)
+	if isRoleGrant {
+		// Check if user has SUPER privilege (superUsers map)
+		if e.superUsersMu != nil {
+			e.superUsersMu.RLock()
+			isSuper := e.superUsers[strings.ToLower(user)]
+			e.superUsersMu.RUnlock()
+			if isSuper {
+				return nil
+			}
+		}
+		// Check if user has ROLE_ADMIN privilege (allows granting any role)
+		if e.grantStore.HasPrivilege(user, host, "ROLE_ADMIN", "", "", activeRoles) {
+			return nil
+		}
+
+		// Check WITH ADMIN OPTION for each role being granted.
+		// privs is a comma-separated list of role names.
+		for _, roleName := range strings.Split(privs, ",") {
+			roleName = strings.TrimSpace(roleName)
+			roleName = strings.Trim(roleName, "`'\"")
+			rh := "%"
+			if atIdx := strings.Index(roleName, "@"); atIdx >= 0 {
+				rh = strings.Trim(roleName[atIdx+1:], "`'\"")
+				roleName = strings.Trim(roleName[:atIdx], "`'\"")
+			}
+			if !e.grantStore.HasAdminOption(user, host, roleName, rh, activeRoles) {
+				// ER_SPECIFIC_ACCESS_DENIED_ERROR
+				return mysqlError(1227, "42000", fmt.Sprintf("Access denied; you need (at least one of) the WITH GRANT OPTION privilege(s) for this operation"))
+			}
+		}
+		return nil
+	}
+
+	// For privilege grants: check each requested privilege individually.
+	// MySQL requires the grantor to have WITH GRANT OPTION for each privilege being granted.
+	gtype := objectToGrantType(object)
+
+	// Parse db name for error messages
+	var dbName, tableName string
+	switch gtype {
+	case GrantTypeDB:
+		dbName = strings.TrimSuffix(object, ".*")
+	case GrantTypeTable:
+		parts := strings.SplitN(object, ".", 2)
+		if len(parts) == 2 {
+			dbName = parts[0]
+			tableName = parts[1]
+		}
+	}
+
+	// Check each privilege in the privs list
+	privList := normalizePrivList(privs)
+	for _, priv := range privList {
+		// Extract base priv (without column list)
+		basePriv := priv
+		if idx := strings.Index(priv, "("); idx > 0 {
+			basePriv = strings.TrimSpace(priv[:idx])
+		}
+
+		if !e.grantStore.HasGrantOption(user, host, basePriv, object, activeRoles) {
+			// Return appropriate error based on grant scope
+			switch gtype {
+			case GrantTypeGlobal:
+				// ER_ACCESS_DENIED_ERROR
+				return mysqlError(1045, "28000", fmt.Sprintf("Access denied for user '%s'@'%s' (using password: YES)", user, host))
+			case GrantTypeDB:
+				// ER_DBACCESS_DENIED_ERROR
+				return mysqlError(1044, "42000", fmt.Sprintf("Access denied for user '%s'@'%s' to database '%s'", user, host, dbName))
+			case GrantTypeTable:
+				// ER_TABLEACCESS_DENIED_ERROR for GRANT.
+				// MySQL format differs based on whether the user has DB-level or global GRANT OPTION
+				// that could cover the target table's database:
+				// - Has DB/global GRANT OPTION covering target DB → "<PRIV>, GRANT command denied"
+				// - Has only table-level GRANT OPTION (different table) or no GRANT OPTION → "GRANT command denied"
+				var errMsg string
+				if e.grantStore.HasDbOrGlobalGrantOption(user, host, basePriv, dbName, activeRoles) {
+					errMsg = fmt.Sprintf("%s, GRANT command denied to user '%s'@'%s' for table '%s'", basePriv, user, host, tableName)
+				} else {
+					errMsg = fmt.Sprintf("GRANT command denied to user '%s'@'%s' for table '%s'", user, host, tableName)
+				}
+				return mysqlError(1142, "42000", errMsg)
+			}
+		}
+	}
+
 	return nil
 }
 

--- a/executor/grants.go
+++ b/executor/grants.go
@@ -948,6 +948,306 @@ func (gs *GrantStore) HasAnyTableAccess(user, host, db, table string, activeRole
 	return false
 }
 
+// HasAdminOption checks if a user (with active roles) has WITH ADMIN OPTION for the given role.
+// This is required to grant a role to others. The user must have the role granted to them
+// WITH ADMIN OPTION, either directly or via an active role with WITH ADMIN OPTION.
+func (gs *GrantStore) HasAdminOption(user, host, roleName, roleHost string, activeRoles []string) bool {
+	gs.mu.RLock()
+	defer gs.mu.RUnlock()
+
+	checkEntriesForAdminOption := func(entries []GrantEntry) bool {
+		for _, e := range entries {
+			if e.Type != GrantTypeRole {
+				continue
+			}
+			if !e.GrantOption {
+				continue
+			}
+			if strings.EqualFold(e.RoleName, roleName) {
+				rh := e.RoleHost
+				if rh == "" {
+					rh = "%"
+				}
+				if strings.EqualFold(rh, roleHost) {
+					return true
+				}
+			}
+		}
+		return false
+	}
+
+	// Check user's direct grants
+	allUserEntries := gs.findEntriesForUser(user, host)
+	if checkEntriesForAdminOption(allUserEntries) {
+		return true
+	}
+
+	// Check via active roles recursively
+	var checkRole func(rn, rh string, visited map[string]bool) bool
+	checkRole = func(rn, rh string, visited map[string]bool) bool {
+		rk := userKey(rn, rh)
+		if visited[rk] {
+			return false
+		}
+		visited[rk] = true
+		// Check role's privilege grants (in gs.roles) AND membership grants (in gs.entries)
+		// Role membership grants for a role go into gs.entries (via AddRoleGrant).
+		if checkEntriesForAdminOption(gs.roles[rk]) {
+			return true
+		}
+		if checkEntriesForAdminOption(gs.entries[rk]) {
+			return true
+		}
+		// Recurse into nested roles
+		allEntries := append(gs.roles[rk], gs.entries[rk]...)
+		for _, e := range allEntries {
+			if e.Type == GrantTypeRole {
+				nh := e.RoleHost
+				if nh == "" {
+					nh = "%"
+				}
+				if checkRole(e.RoleName, nh, visited) {
+					return true
+				}
+			}
+		}
+		return false
+	}
+
+	visited := make(map[string]bool)
+	for _, r := range activeRoles {
+		if checkRole(r, "%", visited) {
+			return true
+		}
+	}
+	return false
+}
+
+// HasGrantOption checks if a user (with active roles) has GRANT OPTION for the given privilege
+// on the given scope (object like "*.*", "db.*", "db.table"). Returns true if they can grant
+// that privilege on that scope. A wider-scope GRANT OPTION covers narrower scopes.
+func (gs *GrantStore) HasGrantOption(user, host, priv, object string, activeRoles []string) bool {
+	gs.mu.RLock()
+	defer gs.mu.RUnlock()
+
+	priv = strings.ToUpper(priv)
+	gtype := objectToGrantType(object)
+
+	// Parse object to db/table for scope checking.
+	var targetDB, targetTable string
+	switch gtype {
+	case GrantTypeGlobal:
+		// no db/table needed
+	case GrantTypeDB:
+		targetDB = strings.TrimSuffix(object, ".*")
+	case GrantTypeTable:
+		parts := strings.SplitN(object, ".", 2)
+		if len(parts) == 2 {
+			targetDB = parts[0]
+			targetTable = parts[1]
+		}
+	}
+
+	// checkEntriesForGrantOption checks if a list of entries grants GRANT OPTION
+	// for the given privilege covering the given scope (object/gtype).
+	checkEntriesForGrantOption := func(entries []GrantEntry) bool {
+		for _, e := range entries {
+			if e.Type == GrantTypeRole || !e.GrantOption {
+				continue
+			}
+			// Check if this entry has the required privilege
+			hasPriv := false
+			for _, p := range e.Privs {
+				if p == "ALL PRIVILEGES" || strings.EqualFold(p, priv) {
+					hasPriv = true
+					break
+				}
+				// Column-level grants count for base priv
+				if parenIdx := strings.Index(p, "("); parenIdx > 0 {
+					if strings.EqualFold(strings.TrimSpace(p[:parenIdx]), priv) {
+						hasPriv = true
+						break
+					}
+				}
+			}
+			if !hasPriv {
+				continue
+			}
+			// Check if this entry's scope covers the target scope.
+			// For GRANT authority, a stored grant on pattern P covers requested scope T
+			// if P (as a LIKE pattern) matches T (as a literal string).
+			// Example: stored "db%.*" covers "db_.*" because "db_" matches LIKE "db%".
+			// Example: stored "secdb1.*" does NOT cover "secdb_.*" because "secdb_" does NOT match LIKE "secdb1".
+			switch e.Type {
+			case GrantTypeGlobal:
+				// Global GRANT OPTION covers everything
+				return true
+			case GrantTypeDB:
+				// DB GRANT OPTION covers db.* and db.table grants if the stored DB pattern matches targetDB
+				if gtype == GrantTypeDB || gtype == GrantTypeTable {
+					entryDB := strings.TrimSuffix(e.Object, ".*")
+					if targetDB != "" && grantScopeCovers(entryDB, targetDB) {
+						return true
+					}
+				}
+			case GrantTypeTable:
+				// Table GRANT OPTION only covers the exact table (with optional LIKE matching for DB part)
+				if gtype == GrantTypeTable {
+					parts := strings.SplitN(e.Object, ".", 2)
+					if len(parts) == 2 && targetDB != "" && targetTable != "" &&
+						grantScopeCovers(parts[0], targetDB) && strings.EqualFold(parts[1], targetTable) {
+						return true
+					}
+				}
+			}
+		}
+		return false
+	}
+
+	// Check user's own entries
+	allUserEntries := gs.findEntriesForUser(user, host)
+	if checkEntriesForGrantOption(allUserEntries) {
+		return true
+	}
+
+	// Check via active roles recursively
+	var checkRole func(roleName, roleHost string, visited map[string]bool) bool
+	checkRole = func(roleName, roleHost string, visited map[string]bool) bool {
+		rk := userKey(roleName, roleHost)
+		if visited[rk] {
+			return false
+		}
+		visited[rk] = true
+		if checkEntriesForGrantOption(gs.roles[rk]) {
+			return true
+		}
+		allEntries := append(gs.roles[rk], gs.entries[rk]...)
+		for _, e := range allEntries {
+			if e.Type == GrantTypeRole {
+				nh := e.RoleHost
+				if nh == "" {
+					nh = "%"
+				}
+				if checkRole(e.RoleName, nh, visited) {
+					return true
+				}
+			}
+		}
+		return false
+	}
+
+	visited := make(map[string]bool)
+	for _, roleName := range activeRoles {
+		if checkRole(roleName, "%", visited) {
+			return true
+		}
+	}
+	return false
+}
+
+// HasDbOrGlobalGrantOption checks if a user (with active roles) has GRANT OPTION at DB level
+// or global level that covers the given database. This is used to determine the format of
+// GRANT denial error messages at the table level:
+// - If yes: format is "<priv>, GRANT command denied" (user has broader authority but not exact table)
+// - If no: format is "GRANT command denied" (user has no relevant GRANT OPTION)
+func (gs *GrantStore) HasDbOrGlobalGrantOption(user, host, priv, db string, activeRoles []string) bool {
+	gs.mu.RLock()
+	defer gs.mu.RUnlock()
+
+	priv = strings.ToUpper(priv)
+
+	checkEntriesForDbOrGlobalGrantOption := func(entries []GrantEntry) bool {
+		for _, e := range entries {
+			if e.Type == GrantTypeRole || !e.GrantOption {
+				continue
+			}
+			// Only check global and DB-level grants (not table-level)
+			if e.Type != GrantTypeGlobal && e.Type != GrantTypeDB {
+				continue
+			}
+			// Check if this entry has the required privilege
+			hasPriv := false
+			for _, p := range e.Privs {
+				if p == "ALL PRIVILEGES" || strings.EqualFold(p, priv) {
+					hasPriv = true
+					break
+				}
+			}
+			if !hasPriv {
+				continue
+			}
+			// Check if this entry covers the target DB.
+			// We check if the stored entry DB (as a literal) matches the target DB (as a pattern).
+			// e.g., stored="secdb1", target="secdb_" → matchLike("secdb1", "secdb_") = true
+			switch e.Type {
+			case GrantTypeGlobal:
+				return true
+			case GrantTypeDB:
+				entryDB := strings.TrimSuffix(e.Object, ".*")
+				// Check if the stored DB (literal) matches the target DB (possibly a pattern)
+				if db != "" && dbNameMatches(db, entryDB) {
+					return true
+				}
+			}
+		}
+		return false
+	}
+
+	allUserEntries := gs.findEntriesForUser(user, host)
+	if checkEntriesForDbOrGlobalGrantOption(allUserEntries) {
+		return true
+	}
+
+	var checkRole func(roleName, roleHost string, visited map[string]bool) bool
+	checkRole = func(roleName, roleHost string, visited map[string]bool) bool {
+		rk := userKey(roleName, roleHost)
+		if visited[rk] {
+			return false
+		}
+		visited[rk] = true
+		if checkEntriesForDbOrGlobalGrantOption(gs.roles[rk]) {
+			return true
+		}
+		allEntries := append(gs.roles[rk], gs.entries[rk]...)
+		for _, e := range allEntries {
+			if e.Type == GrantTypeRole {
+				nh := e.RoleHost
+				if nh == "" {
+					nh = "%"
+				}
+				if checkRole(e.RoleName, nh, visited) {
+					return true
+				}
+			}
+		}
+		return false
+	}
+
+	visited := make(map[string]bool)
+	for _, roleName := range activeRoles {
+		if checkRole(roleName, "%", visited) {
+			return true
+		}
+	}
+	return false
+}
+
+// grantScopeCovers checks if a stored grant scope (entryScope) covers the requested scope (targetScope)
+// for GRANT authority purposes. The stored scope may contain LIKE wildcards (% and _).
+// A stored pattern P covers target T if the literal string T matches the LIKE pattern P.
+// This means: stored "db%.*" covers "db_.*" (db_ matches LIKE db%), but
+// stored "secdb1.*" does NOT cover "secdb_.*" (secdb_ does NOT match LIKE secdb1).
+// For literal stored scopes (no wildcards), exact case-insensitive match is required.
+func grantScopeCovers(entryScope, targetScope string) bool {
+	if strings.EqualFold(entryScope, targetScope) {
+		return true
+	}
+	if strings.ContainsAny(entryScope, "%_") {
+		return matchLike(strings.ToLower(targetScope), strings.ToLower(entryScope))
+	}
+	return false
+}
+
 // dbNameMatches checks if a stored DB name pattern matches the actual DB name.
 // Supports MySQL LIKE patterns (% and _) for database name matching.
 func dbNameMatches(pattern, dbName string) bool {

--- a/executor/variables.go
+++ b/executor/variables.go
@@ -4638,7 +4638,14 @@ func (e *Executor) showStatus(upper string) (*Result, error) {
 		// SSL / OpenSSL status variables (stubs for MTR have_openssl.inc)
 		{Name: "Rsa_public_key", Value: ""},
 		// ACL cache status variables
-		{Name: "Acl_cache_items_count", Value: "0"},
+		// Count = 1 (root) + number of known users in the grant store
+		{Name: "Acl_cache_items_count", Value: func() string {
+			count := 1 // root is always counted
+			if e.grantStore != nil {
+				count += len(e.grantStore.ListAllUserHosts())
+			}
+			return fmt.Sprintf("%d", count)
+		}()},
 	}
 	rows := make([][]interface{}, 0, len(statusVars))
 	for _, sv := range statusVars {


### PR DESCRIPTION
## Summary

- Implements privilege enforcement when a non-root user executes `GRANT` statements
- `GRANT privs ON *.* TO user` → ER_ACCESS_DENIED_ERROR (1045/28000) if no global GRANT OPTION
- `GRANT privs ON db.* TO user` → ER_DBACCESS_DENIED_ERROR (1044/42000) if no DB GRANT OPTION
- `GRANT privs ON db.tbl TO user` → ER_TABLEACCESS_DENIED_ERROR (1142/42000) with correct message format
- Role grant enforcement via `HasAdminOption` (WITH ADMIN OPTION or ROLE_ADMIN privilege)
- Dynamic `Acl_cache_items_count` in SHOW STATUS (returns actual user count + 1 for root)

## Key additions

- `HasGrantOption()` — checks if user/active-roles have GRANT OPTION for a given scope, with correct LIKE-pattern scope-coverage semantics
- `HasAdminOption()` — checks if user/active-roles have WITH ADMIN OPTION for a role
- `HasDbOrGlobalGrantOption()` — used for error message format selection
- `grantScopeCovers()` — determines if a stored LIKE-pattern grant covers a target pattern

## Test results

- `other/roles2`: first-diff-line improved from 143 → PASS
- No regressions: all 155 previously-passing `other` suite tests still pass
- sys_vars: 497 pass (↑ from 474 baseline)
- innodb: 87 pass (↑ from 84 baseline)

## Test plan

- [x] `go build ./... && go test ./... -count=1` passes
- [x] `go run ./cmd/mtrrun -test other/roles2` passes
- [x] All 155 previously-passing `other` tests still pass
- [x] No regressions in sys_vars/innodb suites

Closes #166

🤖 Generated with [Claude Code](https://claude.com/claude-code)