### PR TITLE
feat: implement SYSDATE() wall-clock semantics and cross-join CAST predicate fix

### DIFF
--- a/executor/expr_eval.go
+++ b/executor/expr_eval.go
@@ -3909,6 +3909,28 @@ func (e *Executor) evalExpr(expr sqlparser.Expr) (interface{}, error) {
 	case *sqlparser.CurTimeFuncExpr:
 		// NOW(), CURRENT_TIMESTAMP(), CURTIME(), etc.
 		name := strings.ToLower(v.Name.String())
+		// MySQL SYSDATE() returns the actual wall-clock time at execution, not the
+		// statement-start cached time (unlike NOW()/CURRENT_TIMESTAMP()).
+		// Handle sysdate separately before computing "now" via the cached nowTime().
+		// Exception: when --sysdate-is-now startup option is set, SYSDATE() behaves
+		// exactly like NOW() (uses the cached statement-start time).
+		if name == "sysdate" {
+			var sysNow time.Time
+			if e.startupVars["sysdate_is_now"] == "1" {
+				sysNow = e.nowTime()
+			} else {
+				sysNow = time.Now()
+				if e.timeZone != nil {
+					sysNow = sysNow.In(e.timeZone)
+				}
+			}
+			fsp := v.Fsp
+			if fsp > 0 && fsp <= 6 {
+				frac := fmt.Sprintf("%06d", sysNow.Nanosecond()/1000)[:fsp]
+				return sysNow.Format("2006-01-02 15:04:05") + "." + frac, nil
+			}
+			return sysNow.Format("2006-01-02 15:04:05"), nil
+		}
 		now := e.nowTime()
 		fsp := v.Fsp // fractional seconds precision (0-6)
 		// Helper to format with fractional seconds precision.
@@ -3924,7 +3946,7 @@ func (e *Executor) evalExpr(expr sqlparser.Expr) (interface{}, error) {
 			return base + "." + frac
 		}
 		switch name {
-		case "now", "current_timestamp", "localtime", "localtimestamp", "sysdate":
+		case "now", "current_timestamp", "localtime", "localtimestamp":
 			return withFrac(now.Format("2006-01-02 15:04:05")), nil
 		case "curdate", "current_date":
 			return now.Format("2006-01-02"), nil

--- a/executor/func_datetime.go
+++ b/executor/func_datetime.go
@@ -130,8 +130,31 @@ func formatTimeDiffMicrosOpt(diffUs int64, e *Executor, origHadMicros bool) stri
 // Returns (result, handled, error).
 func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr, row *storage.Row) (interface{}, bool, error) {
 	switch name {
-	case "now", "current_timestamp", "sysdate":
+	case "now", "current_timestamp":
 		t := e.nowTime()
+		if len(v.Exprs) > 0 {
+			precVal, _, _ := e.evalArg1(v.Exprs, name, row)
+			prec := int(toFloat(precVal))
+			if prec > 0 && prec <= 6 {
+				frac := fmt.Sprintf("%06d", t.Nanosecond()/1000)[:prec]
+				return t.Format("2006-01-02 15:04:05") + "." + frac, true, nil
+			}
+		}
+		return t.Format("2006-01-02 15:04:05"), true, nil
+	case "sysdate":
+		// MySQL SYSDATE() returns the actual current time at execution, not the
+		// statement-start time. Unlike NOW(), it is not cached per statement.
+		// Exception: when --sysdate-is-now startup option is set, SYSDATE() behaves
+		// exactly like NOW() (uses the cached statement-start time).
+		var t time.Time
+		if e.startupVars["sysdate_is_now"] == "1" {
+			t = e.nowTime()
+		} else {
+			t = time.Now()
+			if e.timeZone != nil {
+				t = t.In(e.timeZone)
+			}
+		}
 		if len(v.Exprs) > 0 {
 			precVal, _, _ := e.evalArg1(v.Exprs, name, row)
 			prec := int(toFloat(precVal))

--- a/executor/procedures.go
+++ b/executor/procedures.go
@@ -4310,7 +4310,17 @@ func (e *Executor) execSelectIntoForRoutine(stmtStr string, localVars map[string
 		row := result.Rows[0]
 		for j, vn := range varNames {
 			if j < len(row) {
-				localVars[vn] = row[j]
+				// User variables (@var) must go into e.userVars, not localVars.
+				// Storing them in localVars would cause them to be text-substituted
+				// into subsequent SQL statements via substituteLocalVars.
+				if strings.HasPrefix(vn, "@") && !strings.HasPrefix(vn, "@@") {
+					if e.userVars == nil {
+						e.userVars = make(map[string]interface{})
+					}
+					e.userVars[strings.TrimPrefix(vn, "@")] = row[j]
+				} else {
+					localVars[vn] = row[j]
+				}
 			}
 		}
 	}
@@ -4361,7 +4371,15 @@ func (e *Executor) execSelectIntoLocal(stmtStr string, localVars map[string]inte
 		row := result.Rows[0]
 		for j, vn := range varNames {
 			if j < len(row) {
-				localVars[vn] = row[j]
+				// User variables (@var) must go into e.userVars, not localVars.
+				if strings.HasPrefix(vn, "@") && !strings.HasPrefix(vn, "@@") {
+					if e.userVars == nil {
+						e.userVars = make(map[string]interface{})
+					}
+					e.userVars[strings.TrimPrefix(vn, "@")] = row[j]
+				} else {
+					localVars[vn] = row[j]
+				}
 			}
 		}
 	}

--- a/executor/select.go
+++ b/executor/select.go
@@ -1442,6 +1442,20 @@ func exprReferencedTables(expr sqlparser.Expr, aliases []string) map[int]bool {
 			walk(v.Right)
 		case *sqlparser.UnaryExpr:
 			walk(v.Expr)
+		case *sqlparser.CastExpr:
+			walk(v.Expr)
+		case *sqlparser.ConvertExpr:
+			walk(v.Expr)
+		case *sqlparser.IntervalDateExpr:
+			walk(v.Date)
+			walk(v.Interval)
+		case *sqlparser.CollateExpr:
+			walk(v.Expr)
+		case *sqlparser.IntervalFuncExpr:
+			walk(v.Expr)
+			for _, arg := range v.Exprs {
+				walk(arg)
+			}
 		}
 	}
 	walk(expr)


### PR DESCRIPTION
## Summary

- **SYSDATE() wall-clock time**: `SYSDATE()` now returns the actual wall-clock time at execution (via the `CurTimeFuncExpr` parse path), distinct from `NOW()`/`CURRENT_TIMESTAMP()` which return the cached statement-start time. Respects `--sysdate-is-now` startup option to alias `SYSDATE()` to `NOW()`.
- **Cross-join CAST predicate fix**: `exprReferencedTables` walk function now handles `CastExpr`, `ConvertExpr`, `IntervalDateExpr`, `CollateExpr`, and `IntervalFuncExpr`. Previously `CAST(t1.day AS DATE) BETWEEN ... AND t2.day` was misclassified as a t2-only predicate, causing incorrect cross-join results (all 9 rows instead of expected 5).
- **@var routing in SELECT INTO**: User variables (`@name`) assigned via `SELECT INTO` in stored routines now correctly go to `e.userVars` instead of `localVars`, preventing literal value text-substitution into subsequent SQL.

## Test plan

- [x] `go build ./...` — no errors
- [x] `go test ./... -count=1` — all unit tests pass
- [x] `go run ./cmd/mtrrun` — 1722 passes, zero regressions vs baseline
- [x] `other/sysdate_is_now` test passes (was flaky due to regression, now fixed with `--sysdate-is-now` support)
- [x] `other/func_time` improvements: sysdate/sleep diff line fixed (line 1032), CAST BETWEEN cross-join lines 1120-1125 fixed

Closes #170

🤖 Generated with [Claude Code](https://claude.com/claude-code)