### PR TITLE
feat: implement VIEW + generated column compatibility (Closes #159)

### DIFF
--- a/cmd/mtrrun/skiplist.json
+++ b/cmd/mtrrun/skiplist.json
@@ -3469,10 +3469,6 @@
       "reason": "complex query failures"
     },
     {
-      "test": "gcol/gcol_view_innodb",
-      "reason": "view update failures"
-    },
-    {
       "test": "gcol/gcol_view_myisam",
       "reason": "view update failures"
     },

--- a/executor/dml_insert.go
+++ b/executor/dml_insert.go
@@ -156,11 +156,29 @@ func (e *Executor) execInsert(stmt *sqlparser.Insert) (*Result, error) {
 	// Also capture any WITH CHECK OPTION condition for enforcement.
 	originalViewName := tableName
 	var viewCheckExpr sqlparser.Expr
+	var isInsertThroughView bool
 	if baseTable, isView, _, err := e.resolveViewToBaseTable(tableName); err != nil {
 		return nil, err
 	} else if isView {
+		isInsertThroughView = true
 		viewCheckExpr = e.getViewCheckCondition(originalViewName)
 		tableName = baseTable
+	}
+	// When inserting through a view, check that all specified columns are updatable (direct col refs).
+	if isInsertThroughView && len(stmt.Columns) > 0 {
+		viewColMap := e.getViewExprMapping(originalViewName)
+		if viewColMap != nil {
+			for _, col := range stmt.Columns {
+				colLower := strings.ToLower(col.String())
+				if m, found := viewColMap[colLower]; found {
+					if m.baseColName == "" {
+						// Computed expression column - not updatable
+						return nil, mysqlError(1348, "HY000",
+							fmt.Sprintf("Column '%s' is not updatable", col.String()))
+					}
+				}
+			}
+		}
 	}
 
 	// MySQL error 1442: can't modify a table inside a trigger if the triggering statement is

--- a/executor/dml_update.go
+++ b/executor/dml_update.go
@@ -162,11 +162,32 @@ func (e *Executor) execUpdate(stmt *sqlparser.Update) (*Result, error) {
 	// Resolve views: if tableName is a view, replace with the underlying base table.
 	// Also collect the view's WHERE condition to merge with the UPDATE's WHERE.
 	var viewWhereExpr sqlparser.Expr
+	var viewColMap map[string]viewColumnMapping // non-nil when updating through a view
+	originalTableName := tableName
 	if baseTable, isView, viewWhere, err := e.resolveViewToBaseTable(tableName); err != nil {
 		return nil, err
 	} else if isView {
+		// Build view column mapping before overwriting tableName
+		viewColMap = e.getViewExprMapping(originalTableName)
 		tableName = baseTable
 		viewWhereExpr = viewWhere
+	}
+	// If updating through a view, validate that SET targets are updatable columns (direct col refs).
+	if viewColMap != nil {
+		for _, upd := range stmt.Exprs {
+			if _, isDefault := upd.Expr.(*sqlparser.Default); isDefault {
+				continue
+			}
+			colName := strings.ToLower(upd.Name.Name.String())
+			if m, found := viewColMap[colName]; found {
+				// View column exists in the mapping - check if it's a direct column reference
+				if m.baseColName == "" {
+					// Computed expression - not updatable
+					return nil, mysqlError(1348, "HY000",
+						fmt.Sprintf("Column '%s' is not updatable", upd.Name.Name.String()))
+				}
+			}
+		}
 	}
 	// Merge view's WHERE condition into the UPDATE's WHERE clause.
 	// If the view has a WHERE clause, AND it with the UPDATE's WHERE clause.
@@ -421,6 +442,31 @@ func (e *Executor) execUpdate(stmt *sqlparser.Update) (*Result, error) {
 		newRow := make(storage.Row, len(row))
 		for k, v := range row {
 			newRow[k] = v
+		}
+		// When updating through a view, populate view alias values so that RHS expressions
+		// like "a = a + e" can resolve view alias "e" to its underlying expression value.
+		if viewColMap != nil {
+			for alias, m := range viewColMap {
+				if m.expr != nil {
+					// Computed expression - evaluate it against the base row
+					if v, err2 := e.evalRowExpr(m.expr, newRow); err2 == nil {
+						newRow[alias] = v
+					}
+				} else if m.baseColName != "" {
+					// Direct column reference - map alias to base col value
+					if v, ok := newRow[m.baseColName]; ok {
+						newRow[alias] = v
+					} else {
+						// Try case-insensitive lookup
+						for k, v2 := range newRow {
+							if strings.EqualFold(k, m.baseColName) {
+								newRow[alias] = v2
+								break
+							}
+						}
+					}
+				}
+			}
 		}
 		for _, upd := range stmt.Exprs {
 			colName := upd.Name.Name.String()

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -403,6 +403,11 @@ type Executor struct {
 	viewSecurity map[string]string
 	// viewCreateStatements stores the full CREATE VIEW SQL for SHOW CREATE VIEW (view name -> full SQL).
 	viewCreateStatements map[string]string
+	// viewColumnNames stores the column alias list for views (view name -> []string).
+	// This is the explicit column list from CREATE VIEW v (col1, col2, ...) AS SELECT ...
+	viewColumnNames map[string][]string
+	// viewAlgorithm stores the algorithm for views (view name -> "temptable", "merge", or "undefined").
+	viewAlgorithm map[string]string
 	// viewStore is a shared view store across all connections. Views created on any connection
 	// are accessible by all other connections (like MySQL's shared information_schema).
 	viewStore *ViewStore
@@ -418,6 +423,11 @@ type Executor struct {
 	lastErrorCount   int64
 	// currentQuery holds the current raw SQL text for display-name reconstruction.
 	currentQuery string
+	// executingViewSQL is true when the current query is a re-serialized view SELECT
+	// (from sqlparser.String(), not from the original user-typed query). Used to
+	// decide whether to compact arithmetic operators in column names (e.g. "b + 1" → "b+1"),
+	// since sqlparser re-serialization adds spaces that the original query text did not have.
+	executingViewSQL bool
 	// showCreateDBIfNotExists is set by preprocessQuery when the original query was
 	// "SHOW CREATE DATABASE IF NOT EXISTS db", so that execShow can include the
 	// /*!32312 IF NOT EXISTS*/ comment in the Create Database column value.
@@ -3048,9 +3058,39 @@ func (e *Executor) Execute(query string) (res *Result, retErr error) {
 			e.viewCreateStatements = make(map[string]string)
 		}
 		e.viewCreateStatements[viewName] = e.buildCreateViewSQLFromQuery(s, query)
+		// Store the explicit column list from CREATE VIEW v (col1, col2, ...) AS SELECT ...
+		if len(s.Columns) > 0 {
+			if e.viewColumnNames == nil {
+				e.viewColumnNames = make(map[string][]string)
+			}
+			cols := make([]string, len(s.Columns))
+			for i, c := range s.Columns {
+				cols[i] = c.String()
+			}
+			e.viewColumnNames[viewName] = cols
+		}
+		// Store the view algorithm.
+		if s.Algorithm != "" {
+			if e.viewAlgorithm == nil {
+				e.viewAlgorithm = make(map[string]string)
+			}
+			e.viewAlgorithm[viewName] = strings.ToLower(s.Algorithm)
+		}
 		// Also write to the shared view store so other connections can see this view.
 		if e.viewStore != nil {
 			e.viewStore.Set(viewDB, viewName, selectSQL, buildViewSelectSQL(s, query), s.CheckOption, e.viewCreateStatements[viewName], s.Security)
+			// Store column list in shared view store too.
+			if len(s.Columns) > 0 {
+				cols := make([]string, len(s.Columns))
+				for i, c := range s.Columns {
+					cols[i] = c.String()
+				}
+				e.viewStore.SetColumnList(viewDB, viewName, cols)
+			}
+			// Store algorithm in shared view store.
+			if s.Algorithm != "" {
+				e.viewStore.SetAlgorithm(viewDB, viewName, s.Algorithm)
+			}
 		}
 		return &Result{}, nil
 	case *sqlparser.DropView:
@@ -3066,6 +3106,12 @@ func (e *Executor) Execute(query string) (res *Result, retErr error) {
 			}
 			if e.viewCreateStatements != nil {
 				delete(e.viewCreateStatements, viewName)
+			}
+			if e.viewColumnNames != nil {
+				delete(e.viewColumnNames, viewName)
+			}
+			if e.viewAlgorithm != nil {
+				delete(e.viewAlgorithm, viewName)
 			}
 			if e.viewStore != nil {
 				e.viewStore.Delete(viewDB, viewName)
@@ -3170,10 +3216,48 @@ func (e *Executor) Execute(query string) (res *Result, retErr error) {
 			CheckOption: s.CheckOption,
 		}
 		e.viewCreateStatements[viewName] = e.buildCreateViewSQLFromQuery(cv, query)
+		// Store the explicit column list from ALTER VIEW v (col1, col2, ...) AS SELECT ...
+		if len(s.Columns) > 0 {
+			if e.viewColumnNames == nil {
+				e.viewColumnNames = make(map[string][]string)
+			}
+			cols := make([]string, len(s.Columns))
+			for i, c := range s.Columns {
+				cols[i] = c.String()
+			}
+			e.viewColumnNames[viewName] = cols
+		} else if e.viewColumnNames != nil {
+			delete(e.viewColumnNames, viewName)
+		}
+		// Store the view algorithm.
+		if s.Algorithm != "" {
+			if e.viewAlgorithm == nil {
+				e.viewAlgorithm = make(map[string]string)
+			}
+			e.viewAlgorithm[viewName] = strings.ToLower(s.Algorithm)
+		} else if e.viewAlgorithm != nil {
+			delete(e.viewAlgorithm, viewName)
+		}
 		// Also write to the shared view store so other connections can see this view.
 		if e.viewStore != nil {
 			displaySQL := buildViewSelectSQL(cv, query)
 			e.viewStore.Set(viewDB, viewName, selectSQL, displaySQL, s.CheckOption, e.viewCreateStatements[viewName], s.Security)
+			// Update column list in shared view store.
+			if len(s.Columns) > 0 {
+				cols := make([]string, len(s.Columns))
+				for i, c := range s.Columns {
+					cols[i] = c.String()
+				}
+				e.viewStore.SetColumnList(viewDB, viewName, cols)
+			} else {
+				e.viewStore.SetColumnList(viewDB, viewName, nil)
+			}
+			// Update algorithm in shared view store.
+			if s.Algorithm != "" {
+				e.viewStore.SetAlgorithm(viewDB, viewName, s.Algorithm)
+			} else {
+				e.viewStore.SetAlgorithm(viewDB, viewName, "")
+			}
 		}
 		return &Result{}, nil
 	case *sqlparser.CommentOnly:
@@ -5557,6 +5641,229 @@ func (e *Executor) resolveViewToBaseTableVisited(tableName string, visited map[s
 		// Nested view is also a simple single-table view - it's OK.
 	}
 	return baseTableName, true, viewWhere, nil
+}
+
+// getViewAlgorithm returns the view algorithm ("temptable", "merge", "undefined", or "").
+func (e *Executor) getViewAlgorithm(viewName string) string {
+	if e.viewAlgorithm != nil {
+		for vn, algo := range e.viewAlgorithm {
+			if strings.EqualFold(vn, viewName) {
+				return algo
+			}
+		}
+	}
+	if e.viewStore != nil {
+		return e.viewStore.LookupAlgorithm(e.CurrentDB, viewName)
+	}
+	return ""
+}
+
+// isViewUpdatable checks whether a view is updatable.
+// A view is updatable if it is a simple single-table SELECT with no GROUP BY, HAVING,
+// DISTINCT, aggregate functions, and all SELECT columns are direct column references
+// (not computed expressions). Subquery-based views are also not updatable.
+func (e *Executor) isViewUpdatable(viewName string) bool {
+	viewSQL, _, ok := e.lookupView(viewName)
+	if !ok {
+		return false
+	}
+	stmt, err := e.parser().Parse(viewSQL)
+	if err != nil {
+		return false
+	}
+	sel, ok := stmt.(*sqlparser.Select)
+	if !ok {
+		return false // UNION etc.
+	}
+	if len(sel.From) != 1 {
+		return false // JOIN
+	}
+	ate, ok := sel.From[0].(*sqlparser.AliasedTableExpr)
+	if !ok {
+		return false
+	}
+	if _, isSubq := ate.Expr.(*sqlparser.DerivedTable); isSubq {
+		return false
+	}
+	if sel.GroupBy != nil || sel.Having != nil || sel.Distinct {
+		return false
+	}
+	for _, sexpr := range sel.SelectExprs.Exprs {
+		ae, ok := sexpr.(*sqlparser.AliasedExpr)
+		if !ok {
+			return false
+		}
+		if containsAggregate(ae.Expr) {
+			return false
+		}
+		// Each SELECT expression must be a direct column reference
+		if _, ok := ae.Expr.(*sqlparser.ColName); !ok {
+			return false
+		}
+	}
+	return true
+}
+
+// isViewNonMerge returns true if the view must be materialized (non-merge) for EXPLAIN purposes.
+// MySQL uses TEMPTABLE (non-merge) when:
+//   - ALGORITHM=TEMPTABLE is specified
+//   - ALGORITHM=UNDEFINED and view contains DISTINCT, GROUP BY, HAVING, aggregate functions,
+//     LIMIT, UNION, or a subquery in FROM
+//
+// A simple single-table SELECT (even with computed expressions) is MERGE.
+func (e *Executor) isViewNonMerge(viewName string) bool {
+	algo := strings.ToLower(e.getViewAlgorithm(viewName))
+	if algo == "temptable" {
+		return true
+	}
+	if algo == "merge" {
+		return false
+	}
+	// ALGORITHM=UNDEFINED: inspect the view SQL
+	viewSQL, _, ok := e.lookupView(viewName)
+	if !ok {
+		return false
+	}
+	stmt, err := e.parser().Parse(viewSQL)
+	if err != nil {
+		return false
+	}
+	switch s := stmt.(type) {
+	case *sqlparser.Select:
+		// Non-merge if DISTINCT, GROUP BY, HAVING, LIMIT, or subquery in FROM
+		if s.Distinct {
+			return true
+		}
+		if s.GroupBy != nil && len(s.GroupBy.Exprs) > 0 {
+			return true
+		}
+		if s.Having != nil {
+			return true
+		}
+		if s.Limit != nil {
+			return true
+		}
+		// Check for aggregate functions in SELECT expressions
+		for _, sexpr := range s.SelectExprs.Exprs {
+			if ae, ok := sexpr.(*sqlparser.AliasedExpr); ok {
+				if containsAggregate(ae.Expr) {
+					return true
+				}
+			}
+		}
+		// Check for subqueries in FROM
+		for _, te := range s.From {
+			if hasSubqueryInTableExpr(te) {
+				return true
+			}
+		}
+		return false
+	default:
+		// UNION etc. — always non-merge
+		return true
+	}
+}
+
+// hasSubqueryInTableExpr returns true if a table expression contains a subquery (DerivedTable).
+func hasSubqueryInTableExpr(te sqlparser.TableExpr) bool {
+	switch t := te.(type) {
+	case *sqlparser.AliasedTableExpr:
+		if _, ok := t.Expr.(*sqlparser.DerivedTable); ok {
+			return true
+		}
+	case *sqlparser.JoinTableExpr:
+		return hasSubqueryInTableExpr(t.LeftExpr) || hasSubqueryInTableExpr(t.RightExpr)
+	case *sqlparser.ParenTableExpr:
+		for _, expr := range t.Exprs {
+			if hasSubqueryInTableExpr(expr) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// getViewColumnNames returns the ordered column alias list for a view.
+// Returns nil if the view has no explicit column list.
+func (e *Executor) getViewColumnNames(viewName string) []string {
+	// Check local map first
+	if e.viewColumnNames != nil {
+		for vn, cols := range e.viewColumnNames {
+			if strings.EqualFold(vn, viewName) {
+				return cols
+			}
+		}
+	}
+	// Fall back to shared view store
+	if e.viewStore != nil {
+		if cols := e.viewStore.LookupColumnList(e.CurrentDB, viewName); cols != nil {
+			return cols
+		}
+	}
+	return nil
+}
+
+// viewColumnMapping holds per-view-column info for UPDATE/INSERT through view.
+type viewColumnMapping struct {
+	// expr is the underlying SELECT expression (non-nil for computed cols, nil for direct col refs)
+	expr sqlparser.Expr
+	// baseColName is the underlying base table column name (non-empty if this is a direct col ref)
+	baseColName string
+}
+
+// getViewExprMapping parses the view's SELECT SQL and returns a map from view column name
+// (lowercased) to viewColumnMapping. This is used to resolve view aliases in UPDATE SET
+// and INSERT column lists.
+// Returns nil if the view SQL cannot be parsed or has no column mapping.
+func (e *Executor) getViewExprMapping(viewName string) map[string]viewColumnMapping {
+	viewSQL, _, ok := e.lookupView(viewName)
+	if !ok {
+		return nil
+	}
+	stmt, err := e.parser().Parse(viewSQL)
+	if err != nil {
+		return nil
+	}
+	sel, ok := stmt.(*sqlparser.Select)
+	if !ok {
+		return nil
+	}
+
+	// Get column alias names (either from explicit CREATE VIEW column list or SELECT AS aliases)
+	columnNames := e.getViewColumnNames(viewName)
+
+	result := make(map[string]viewColumnMapping)
+	for i, sexpr := range sel.SelectExprs.Exprs {
+		ae, ok := sexpr.(*sqlparser.AliasedExpr)
+		if !ok {
+			continue
+		}
+		// Determine the alias name for this position
+		var alias string
+		if i < len(columnNames) {
+			alias = columnNames[i]
+		} else if !ae.As.IsEmpty() {
+			alias = ae.As.String()
+		} else {
+			// Use the expression string as the alias (e.g. a simple column name)
+			alias = sqlparser.String(ae.Expr)
+			alias = strings.Trim(alias, "`")
+		}
+		if alias == "" {
+			continue
+		}
+		// Determine if this is a direct column reference
+		var mapping viewColumnMapping
+		if cn, ok2 := ae.Expr.(*sqlparser.ColName); ok2 {
+			// Direct column reference
+			mapping.baseColName = cn.Name.String()
+		} else {
+			// Computed expression
+			mapping.expr = ae.Expr
+		}
+		result[strings.ToLower(alias)] = mapping
+	}
+	return result
 }
 
 // getViewCheckCondition returns the WHERE expression from a view definition if it has WITH CHECK OPTION.

--- a/executor/explain.go
+++ b/executor/explain.go
@@ -1097,7 +1097,7 @@ func (e *Executor) queryCanBeSemijoinFlattened(sel *sqlparser.Select) bool {
 	}
 	numDerivedOuter := 0
 	for _, te := range sel.From {
-		numDerivedOuter += countDerivedTablesInExpr(te)
+		numDerivedOuter += e.countDerivedTablesInExpr(te)
 	}
 	hasRealTable := numDerivedOuter > 0 // derived tables also count as "real" outer tables
 	for _, tn := range outerTables {
@@ -1372,7 +1372,7 @@ func (e *Executor) queryHasPartialSemijoin(sel *sqlparser.Select) bool {
 	}
 	numDerivedOuter := 0
 	for _, te := range sel.From {
-		numDerivedOuter += countDerivedTablesInExpr(te)
+		numDerivedOuter += e.countDerivedTablesInExpr(te)
 	}
 	hasRealTable := numDerivedOuter > 0
 	for _, tn := range outerTables {
@@ -1513,6 +1513,7 @@ func (e *Executor) tableExprHasStraightJoin(te sqlparser.TableExpr) bool {
 }
 
 // extractAllTableNames collects all real table names from a table expression tree.
+// Non-merge views (which will be shown as derived tables in EXPLAIN) are excluded.
 func (e *Executor) extractAllTableNames(te sqlparser.TableExpr) []string {
 	switch t := te.(type) {
 	case *sqlparser.AliasedTableExpr:
@@ -1520,7 +1521,12 @@ func (e *Executor) extractAllTableNames(te sqlparser.TableExpr) []string {
 			return nil
 		}
 		if tn, ok := t.Expr.(sqlparser.TableName); ok {
-			return []string{tn.Name.String()}
+			name := tn.Name.String()
+			// Non-merge views are treated as derived tables in EXPLAIN output.
+			if e.isViewNonMerge(name) {
+				return nil
+			}
+			return []string{name}
 		}
 	case *sqlparser.JoinTableExpr:
 		left := e.extractAllTableNames(t.LeftExpr)
@@ -1536,20 +1542,44 @@ func (e *Executor) extractAllTableNames(te sqlparser.TableExpr) []string {
 	return nil
 }
 
+// tableExprHasNonMergeView returns true if any table in the expression is a non-merge view.
+func (e *Executor) tableExprHasNonMergeView(te sqlparser.TableExpr) bool {
+	switch t := te.(type) {
+	case *sqlparser.AliasedTableExpr:
+		if tn, ok := t.Expr.(sqlparser.TableName); ok {
+			return e.isViewNonMerge(tn.Name.String())
+		}
+	case *sqlparser.JoinTableExpr:
+		return e.tableExprHasNonMergeView(t.LeftExpr) || e.tableExprHasNonMergeView(t.RightExpr)
+	case *sqlparser.ParenTableExpr:
+		for _, expr := range t.Exprs {
+			if e.tableExprHasNonMergeView(expr) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
 // countDerivedTablesInExpr counts how many direct derived tables (subqueries in FROM) exist
-// in a table expression.
-func countDerivedTablesInExpr(te sqlparser.TableExpr) int {
+// in a table expression. Non-merge views are also counted as derived tables.
+func (e *Executor) countDerivedTablesInExpr(te sqlparser.TableExpr) int {
 	switch t := te.(type) {
 	case *sqlparser.AliasedTableExpr:
 		if _, ok := t.Expr.(*sqlparser.DerivedTable); ok {
 			return 1
 		}
+		if tn, ok := t.Expr.(sqlparser.TableName); ok {
+			if e.isViewNonMerge(tn.Name.String()) {
+				return 1
+			}
+		}
 	case *sqlparser.JoinTableExpr:
-		return countDerivedTablesInExpr(t.LeftExpr) + countDerivedTablesInExpr(t.RightExpr)
+		return e.countDerivedTablesInExpr(t.LeftExpr) + e.countDerivedTablesInExpr(t.RightExpr)
 	case *sqlparser.ParenTableExpr:
 		n := 0
 		for _, expr := range t.Exprs {
-			n += countDerivedTablesInExpr(expr)
+			n += e.countDerivedTablesInExpr(expr)
 		}
 		return n
 	}
@@ -1571,10 +1601,10 @@ func (e *Executor) explainSelect(sel *sqlparser.Select, idCounter *int64, select
 		}
 	}
 
-	// Count direct derived tables in FROM clause
+	// Count direct derived tables in FROM clause (including non-merge views)
 	numDerived := 0
 	for _, te := range sel.From {
-		numDerived += countDerivedTablesInExpr(te)
+		numDerived += e.countDerivedTablesInExpr(te)
 	}
 
 	// Check for GROUP BY / SQL_BIG_RESULT
@@ -1597,14 +1627,20 @@ func (e *Executor) explainSelect(sel *sqlparser.Select, idCounter *int64, select
 			accessType: nil,
 		})
 	} else if len(allTableNames) == 0 && numDerived > 0 {
-		// Only derived tables in FROM - add a row for each derived table reference.
+		// Only derived tables in FROM (either subquery-derived tables or non-merge views).
 		// Derived tables will get ids starting at *idCounter+1 (assigned in explainFromExpr).
+		// When the derived tables come from non-merge views (and the outer selectType is SIMPLE),
+		// MySQL shows "PRIMARY" in the outer row.
+		outerSelectType := selectType
+		if outerSelectType == "SIMPLE" {
+			outerSelectType = "PRIMARY"
+		}
 		nextID := *idCounter + 1
 		for i := 0; i < numDerived; i++ {
 			derivedRef := fmt.Sprintf("<derived%d>", nextID)
 			result = append(result, explainSelectType{
 				id:           myID,
-				selectType:   selectType,
+				selectType:   outerSelectType,
 				table:        derivedRef,
 				extra:        nil,
 				rows:         int64(1),
@@ -1921,7 +1957,7 @@ func (e *Executor) explainSelect(sel *sqlparser.Select, idCounter *int64, select
 	return result
 }
 
-// explainFromExpr processes table expressions to find derived tables.
+// explainFromExpr processes table expressions to find derived tables and non-merge views.
 func (e *Executor) explainFromExpr(te sqlparser.TableExpr, idCounter *int64, result *[]explainSelectType) {
 	switch t := te.(type) {
 	case *sqlparser.AliasedTableExpr:
@@ -1944,6 +1980,32 @@ func (e *Executor) explainFromExpr(te sqlparser.TableExpr, idCounter *int64, res
 					innerRows[0].id = myID
 				}
 				*result = append(*result, innerRows...)
+			}
+		} else if tn, ok := t.Expr.(sqlparser.TableName); ok {
+			// Check if this is a non-merge view (should appear as DERIVED in EXPLAIN)
+			viewName := tn.Name.String()
+			if e.isViewNonMerge(viewName) {
+				if viewSQL, _, found := e.lookupView(viewName); found {
+					*idCounter++
+					myID := *idCounter
+					if innerStmt, err := e.parser().Parse(viewSQL); err == nil {
+						switch inner := innerStmt.(type) {
+						case *sqlparser.Select:
+							innerRows := e.explainSelect(inner, idCounter, "DERIVED")
+							if len(innerRows) > 0 {
+								innerRows[0].id = myID
+							}
+							*result = append(*result, innerRows...)
+						case *sqlparser.Union:
+							derived := e.explainUnion(inner, idCounter, false)
+							if len(derived) > 0 {
+								derived[0].selectType = "DERIVED"
+								derived[0].id = myID
+							}
+							*result = append(*result, derived...)
+						}
+					}
+				}
 			}
 		}
 	case *sqlparser.JoinTableExpr:
@@ -2442,7 +2504,7 @@ func (e *Executor) outerQueryHasOnlyDerivedTables(sel *sqlparser.Select) bool {
 	numDerived := 0
 	numBase := 0
 	for _, te := range sel.From {
-		numDerived += countDerivedTablesInExpr(te)
+		numDerived += e.countDerivedTablesInExpr(te)
 		baseNames := e.extractAllTableNames(te)
 		for _, name := range baseNames {
 			if !strings.EqualFold(name, "dual") {
@@ -8783,6 +8845,13 @@ func (e *Executor) tryPlanBasedExplainTraditional(sel *sqlparser.Select) ([][]in
 	// Fall back for queries with complex parts (subqueries / derived tables).
 	if e.queryHasComplexParts(sel) {
 		return nil, false
+	}
+	// Fall back when any FROM table is a non-merge view (requires PRIMARY+DERIVED rows in EXPLAIN).
+	// The explainMultiRows/explainSelect path handles this correctly.
+	for _, te := range sel.From {
+		if e.tableExprHasNonMergeView(te) {
+			return nil, false
+		}
 	}
 
 	// Check for "Impossible WHERE" due to constant out-of-range for multi-table joins.

--- a/executor/information_schema.go
+++ b/executor/information_schema.go
@@ -5627,13 +5627,17 @@ func (e *Executor) infoSchemaViews() []storage.Row {
 					checkOpt = co
 				}
 			}
+			isUpdatableStr := "NO"
+			if e.isViewUpdatable(vName) {
+				isUpdatableStr = "YES"
+			}
 			rows = append(rows, storage.Row{
 				"TABLE_CATALOG":        "def",
 				"TABLE_SCHEMA":         e.CurrentDB,
 				"TABLE_NAME":           vName,
 				"VIEW_DEFINITION":      e.viewDefinitionForDisplay(vName),
 				"CHECK_OPTION":         checkOpt,
-				"IS_UPDATABLE":         "YES",
+				"IS_UPDATABLE":         isUpdatableStr,
 				"DEFINER":              "root@localhost",
 				"SECURITY_TYPE":        secType,
 				"CHARACTER_SET_CLIENT": "utf8mb4",
@@ -5680,13 +5684,17 @@ func (e *Executor) infoSchemaViews() []storage.Row {
 			if co == "CASCADED" || co == "LOCAL" {
 				checkOpt = co
 			}
+			isUpdatableStr2 := "NO"
+			if e.isViewUpdatable(ve.name) {
+				isUpdatableStr2 = "YES"
+			}
 			rows = append(rows, storage.Row{
 				"TABLE_CATALOG":        "def",
 				"TABLE_SCHEMA":         ve.db,
 				"TABLE_NAME":           ve.name,
 				"VIEW_DEFINITION":      ve.displaySQL,
 				"CHECK_OPTION":         checkOpt,
-				"IS_UPDATABLE":         "YES",
+				"IS_UPDATABLE":         isUpdatableStr2,
 				"DEFINER":              "root@localhost",
 				"SECURITY_TYPE":        ve.secType,
 				"CHARACTER_SET_CLIENT": "utf8mb4",

--- a/executor/select.go
+++ b/executor/select.go
@@ -97,6 +97,16 @@ func (e *Executor) collectTableDefsWithAliases(expr sqlparser.TableExpr) ([]*cat
 // its SELECT SQL and resolving column names from the underlying tables.
 // Returns nil if the view SQL cannot be resolved to a known set of columns.
 func (e *Executor) syntheticTableDefFromViewSQL(viewName, viewSQL string) *catalog.TableDef {
+	// If the view has an explicit column list (CREATE VIEW v (c1,c2,...) AS SELECT ...),
+	// use those column names directly — they override the SELECT expression names.
+	if viewColNames := e.getViewColumnNames(viewName); len(viewColNames) > 0 {
+		synCols := make([]catalog.ColumnDef, len(viewColNames))
+		for i, name := range viewColNames {
+			synCols[i] = catalog.ColumnDef{Name: name}
+		}
+		return &catalog.TableDef{Name: viewName, Columns: synCols}
+	}
+
 	stmt, err := e.parser().Parse(viewSQL)
 	if err != nil {
 		return nil
@@ -133,7 +143,7 @@ func (e *Executor) syntheticTableDefFromViewSQL(viewName, viewSQL string) *catal
 						}
 					}
 				}
-				// For named column lists, synthesize from SELECT expressions
+				// For named column lists, synthesize from SELECT expressions (alias or ColName only).
 				var synCols []catalog.ColumnDef
 				for _, se := range sel.SelectExprs.Exprs {
 					switch s := se.(type) {
@@ -357,7 +367,12 @@ func (e *Executor) buildFromExpr(expr sqlparser.TableExpr) ([]storage.Row, error
 				if crossDB {
 					e.CurrentDB = lookupDB
 				}
+				// Mark that we're executing a re-serialized view SQL (from sqlparser.String()),
+				// so column name derivation can compact arithmetic operators (e.g. "b + 1" → "b+1").
+				savedExecutingViewSQL := e.executingViewSQL
+				e.executingViewSQL = true
 				viewResult, err := e.Execute(viewSQL)
+				e.executingViewSQL = savedExecutingViewSQL
 				if crossDB {
 					e.CurrentDB = savedCurrentDB
 				}
@@ -375,12 +390,25 @@ func (e *Executor) buildFromExpr(expr sqlparser.TableExpr) ([]storage.Row, error
 				}
 				// Convert view result to storage.Rows
 				rows := make([]storage.Row, 0, len(viewResult.Rows))
+				// If the view has an explicit column list (CREATE VIEW v (c1,c2,...) AS SELECT ...),
+				// rename output columns to the view's defined names.
+				effectiveCols := viewResult.Columns
+				if viewColNames := e.getViewColumnNames(lookupTable); len(viewColNames) > 0 {
+					renamed := make([]string, len(effectiveCols))
+					copy(renamed, effectiveCols)
+					for i, vn := range viewColNames {
+						if i < len(renamed) {
+							renamed[i] = vn
+						}
+					}
+					effectiveCols = renamed
+				}
 				// Store column order as a special metadata key for SELECT * resolution
-				colOrderStr := strings.Join(viewResult.Columns, "\x00")
+				colOrderStr := strings.Join(effectiveCols, "\x00")
 				for _, vrow := range viewResult.Rows {
 					row := make(storage.Row)
 					row["__column_order__"] = colOrderStr
-					for ci, col := range viewResult.Columns {
+					for ci, col := range effectiveCols {
 						if ci < len(vrow) {
 							row[col] = vrow[ci]
 							row[alias+"."+col] = vrow[ci]
@@ -392,10 +420,10 @@ func (e *Executor) buildFromExpr(expr sqlparser.TableExpr) ([]storage.Row, error
 				// in a metadata row. This allows SELECT * to resolve column names even
 				// when the view returns 0 data rows.
 				// The __view_columns__ key signals this is metadata, not a real row.
-				if len(rows) == 0 && len(viewResult.Columns) > 0 {
+				if len(rows) == 0 && len(effectiveCols) > 0 {
 					metaRow := make(storage.Row)
 					metaRow["__column_order__"] = colOrderStr
-					metaRow["__view_columns__"] = viewResult.Columns
+					metaRow["__view_columns__"] = effectiveCols
 					rows = append(rows, metaRow)
 				}
 				return rows, nil
@@ -4272,6 +4300,12 @@ func (e *Executor) execSelectGroupBy(stmt *sqlparser.Select, allRows []storage.R
 					}
 					// Normalize charset introducers (e.g. _utf8mb3 'x' → _utf8'x')
 					raw = normalizeCharsetIntroducers(raw)
+					// When executing a re-serialized view SQL (from sqlparser.String()), sqlparser
+					// adds spaces around arithmetic operators (e.g. "b+1" → "b + 1"). Compact
+					// them back so the column name matches what MySQL reports (e.g. "b+1").
+					if e.executingViewSQL {
+						raw = compactOperatorsInSubexpressions(raw)
+					}
 					// Preserve original query text for column name (MySQL behavior)
 					colNames = append(colNames, raw)
 				} else {
@@ -6135,6 +6169,12 @@ func (e *Executor) resolveSelectExprs(exprs []sqlparser.SelectExpr, rows []stora
 					}
 					// Normalize charset introducers (e.g. _utf8mb3 'x' → _utf8'x')
 					raw = normalizeCharsetIntroducers(raw)
+					// When executing a re-serialized view SQL (from sqlparser.String()), sqlparser
+					// adds spaces around arithmetic operators (e.g. "b+1" → "b + 1"). Compact
+					// them back so the column name matches what MySQL reports (e.g. "b+1").
+					if e.executingViewSQL {
+						raw = compactOperatorsInSubexpressions(raw)
+					}
 					name = raw
 				}
 				if name == "" {

--- a/executor/view_store.go
+++ b/executor/view_store.go
@@ -20,6 +20,11 @@ type ViewStore struct {
 	createSQL map[string]string
 	// security maps "db.viewname" -> "definer" or "invoker" (SQL SECURITY clause).
 	security map[string]string
+	// columnList maps "db.viewname" -> ordered list of view column alias names
+	// (from the CREATE VIEW v (...) column list). Empty list means no explicit column list.
+	columnList map[string][]string
+	// algorithm maps "db.viewname" -> view algorithm ("temptable", "merge", "undefined", or "").
+	algorithm map[string]string
 }
 
 // NewViewStore creates a new empty ViewStore.
@@ -30,6 +35,8 @@ func NewViewStore() *ViewStore {
 		checkOptions: make(map[string]string),
 		createSQL:    make(map[string]string),
 		security:     make(map[string]string),
+		columnList:   make(map[string][]string),
+		algorithm:    make(map[string]string),
 	}
 }
 
@@ -55,6 +62,67 @@ func (vs *ViewStore) Set(db, name, selectSQL, displaySQL, checkOption, createSQL
 	}
 }
 
+// SetColumnList stores the ordered list of view column alias names for a view.
+// This is the column list from CREATE VIEW v (col1, col2, ...) AS SELECT ...
+func (vs *ViewStore) SetColumnList(db, name string, cols []string) {
+	key := viewKey(db, name)
+	vs.mu.Lock()
+	defer vs.mu.Unlock()
+	vs.columnList[key] = cols
+}
+
+// SetAlgorithm stores the view algorithm (e.g. "temptable", "merge", "undefined").
+func (vs *ViewStore) SetAlgorithm(db, name, algo string) {
+	key := viewKey(db, name)
+	vs.mu.Lock()
+	defer vs.mu.Unlock()
+	vs.algorithm[key] = strings.ToLower(algo)
+}
+
+// LookupAlgorithm returns the view algorithm (lowercased), or "" if not set.
+func (vs *ViewStore) LookupAlgorithm(db, name string) string {
+	key := viewKey(db, name)
+	vs.mu.RLock()
+	defer vs.mu.RUnlock()
+	if algo, ok := vs.algorithm[key]; ok {
+		return algo
+	}
+	// Try case-insensitive name match
+	prefix := db + "."
+	for k, algo := range vs.algorithm {
+		if len(k) > len(prefix) && k[:len(prefix)] == prefix {
+			if equalFoldASCII(k[len(prefix):], name) {
+				return algo
+			}
+		} else if db == "" && equalFoldASCII(k, name) {
+			return algo
+		}
+	}
+	return ""
+}
+
+// LookupColumnList returns the column alias list for a view, or nil if not set.
+func (vs *ViewStore) LookupColumnList(db, name string) []string {
+	key := viewKey(db, name)
+	vs.mu.RLock()
+	defer vs.mu.RUnlock()
+	if cols, ok := vs.columnList[key]; ok {
+		return cols
+	}
+	// Try case-insensitive name match
+	prefix := db + "."
+	for k, cols := range vs.columnList {
+		if len(k) > len(prefix) && k[:len(prefix)] == prefix {
+			if equalFoldASCII(k[len(prefix):], name) {
+				return cols
+			}
+		} else if db == "" && equalFoldASCII(k, name) {
+			return cols
+		}
+	}
+	return nil
+}
+
 // IsInvokerSecurity returns true if the view uses SQL SECURITY INVOKER.
 func (vs *ViewStore) IsInvokerSecurity(db, name string) bool {
 	key := viewKey(db, name)
@@ -72,6 +140,8 @@ func (vs *ViewStore) Delete(db, name string) {
 	delete(vs.displaySQL, key)
 	delete(vs.checkOptions, key)
 	delete(vs.createSQL, key)
+	delete(vs.columnList, key)
+	delete(vs.algorithm, key)
 }
 
 // Lookup looks up a view by db+name (case-insensitive for the name part).
@@ -151,6 +221,14 @@ func (vs *ViewStore) Rename(db, oldName, newName string) bool {
 	if v, ok2 := vs.security[oldKey]; ok2 {
 		vs.security[newKey] = v
 		delete(vs.security, oldKey)
+	}
+	if v, ok2 := vs.columnList[oldKey]; ok2 {
+		vs.columnList[newKey] = v
+		delete(vs.columnList, oldKey)
+	}
+	if v, ok2 := vs.algorithm[oldKey]; ok2 {
+		vs.algorithm[newKey] = v
+		delete(vs.algorithm, oldKey)
 	}
 	return true
 }

--- a/mtrrunner/runner.go
+++ b/mtrrunner/runner.go
@@ -1843,7 +1843,7 @@ func (ctx *execContext) handleDirective(directive string) (handled bool, skip bo
 			// Check if this error was expected (--error before --reap)
 			if ctx.expectedError != "" {
 				if ctx.resultLogEnabled {
-					if strings.Contains(ctx.expectedError, ",") {
+					if countNonEmptyErrorCodes(ctx.expectedError) > 1 {
 						codes := strings.Split(ctx.expectedError, ",")
 						includesZero := false
 						for _, c := range codes {
@@ -2782,10 +2782,9 @@ func (ctx *execContext) executeQuery(stmt string) error {
 		if ctx.expectedError != "" {
 			// Output the error message (mysqltest format)
 			if ctx.resultLogEnabled {
-				if strings.Contains(ctx.expectedError, ",") {
-					// When expected error list includes 0 (success allowed),
-					// errors are silently absorbed with no output line.
-					// Otherwise, output "Got one of the listed errors".
+				if countNonEmptyErrorCodes(ctx.expectedError) > 1 {
+					// Multiple error codes: check if any is 0 (success allowed),
+					// otherwise output "Got one of the listed errors".
 					codes := strings.Split(ctx.expectedError, ",")
 					includesZero := false
 					for _, c := range codes {
@@ -2798,6 +2797,7 @@ func (ctx *execContext) executeQuery(stmt string) error {
 						ctx.output.WriteString("Got one of the listed errors\n")
 					}
 				} else {
+					// Single error code (possibly with trailing comma): output full error.
 					ctx.output.WriteString(formatMySQLError(err) + "\n")
 				}
 			}
@@ -3242,7 +3242,7 @@ func (ctx *execContext) executeQueryOrExec(stmt string) error {
 	if err != nil {
 		if ctx.expectedError != "" {
 			if ctx.resultLogEnabled {
-				if strings.Contains(ctx.expectedError, ",") {
+				if countNonEmptyErrorCodes(ctx.expectedError) > 1 {
 					codes := strings.Split(ctx.expectedError, ",")
 					includesZero := false
 					for _, c := range codes {
@@ -3544,7 +3544,7 @@ func (ctx *execContext) executeExecWithExpectedError(stmt string) error {
 			ctx.variables["$mysql_errname"] = strconv.Itoa(errCode)
 		}
 		if ctx.resultLogEnabled {
-			if strings.Contains(expectedCode, ",") {
+			if countNonEmptyErrorCodes(expectedCode) > 1 {
 				codes := strings.Split(expectedCode, ",")
 				includesZero := false
 				for _, c := range codes {
@@ -6232,6 +6232,19 @@ func normalizeDeprecationWarnings(s string) string {
 // 2. Lowercases charset/collation names in "Unknown character set/collation" errors
 var charsetErrRe = regexp.MustCompile(`(Unknown character set: ')([^']+)(')`)
 var collationErrRe = regexp.MustCompile(`(Unknown collation: ')([^']+)(')`)
+
+// countNonEmptyErrorCodes counts the number of non-empty error codes in a comma-separated
+// error code string (e.g. "ER_A,ER_B" → 2, "ER_A," → 1). Trailing commas from MySQL test
+// files are treated as single-code directives.
+func countNonEmptyErrorCodes(errCodes string) int {
+	n := 0
+	for _, c := range strings.Split(errCodes, ",") {
+		if strings.TrimSpace(c) != "" {
+			n++
+		}
+	}
+	return n
+}
 
 func normalizeCharsetErrors(s string) string {
 	s = charsetErrRe.ReplaceAllStringFunc(s, func(m string) string {


### PR DESCRIPTION
## Summary

- Add explicit column list tracking for `CREATE VIEW v (c1,c2,...)`: stored locally and in shared `ViewStore`, used for `SELECT *` column resolution and output column renaming
- Add view algorithm tracking (`MERGE`/`TEMPTABLE`/`UNDEFINED`) in executor and `ViewStore`
- Fix `EXPLAIN` output for non-merge views: use `PRIMARY` + `DERIVED` rows instead of `SIMPLE`
- Compute `IS_UPDATABLE` in `INFORMATION_SCHEMA.VIEWS` dynamically via `isViewUpdatable()`
- Reject `INSERT`/`UPDATE` through views targeting computed (non-updatable) columns with `ER_NONUPDATEABLE_COLUMN`
- Set `executingViewSQL` flag during view SQL re-execution so arithmetic operator spacing is compacted (e.g. `b + 1` → `b+1`) to match MySQL column display names, without affecting direct user queries
- Fix `countNonEmptyErrorCodes()` in mtrrunner to handle trailing comma in `--error` directives (e.g. `ER_NONUPDATEABLE_COLUMN,` should be treated as single error, not multi-error)
- Remove `gcol/gcol_view_innodb` from skiplist (test now passes)

## Test plan

- [ ] `go build ./... && go test ./... -count=1` passes
- [ ] `gcol/gcol_view_innodb` passes (was skipped before)
- [ ] `json/json_no_table` passes (no regression)
- [ ] Full `go run ./cmd/mtrrun` shows 1723 passing (+1 vs baseline 1722), 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #159