### PR TITLE
feat: implement LOAD DATA INFILE warning generation and SELECT INTO DUMPFILE

### DIFF
--- a/executor/preprocess.go
+++ b/executor/preprocess.go
@@ -60,6 +60,15 @@ func (e *Executor) preprocessQuery(query string) (string, *Result, error) {
 		return "", &Result{}, nil
 	}
 
+	// When NO_BACKSLASH_ESCAPES is active, backslashes inside string literals are not
+	// escape characters. The vitess parser always treats '\' as escape, which causes it
+	// to misparse strings like ESCAPED BY '\' (TERMINATED BY appears outside the string).
+	// Rewrite single-quoted strings so that lone backslashes are doubled (\→\\), making
+	// the vitess parser interpret them correctly as literal backslash characters.
+	if e.isNoBackslashEscapes() {
+		query = rewriteStringsForNoBackslashEscapes(query)
+	}
+
 	// Handle ODBC escape syntax: {fn func(args)}, { date "value" }, {d 'value'}, {ts '...'}, {t '...'}.
 	// MySQL supports ODBC escape sequences for compatibility. We preprocess them to standard MySQL syntax.
 	// e.currentQuery is already set to the original for rawExprs column name extraction.
@@ -2357,4 +2366,100 @@ func rewriteInlineCheckConstraints(query string) string {
 	// Step 3: restore protected patterns
 	rewritten = strings.ReplaceAll(rewritten, inlineCheckPlaceholder, "CHECK (")
 	return rewritten
+}
+
+// isNoBackslashEscapes returns true when the current sql_mode includes NO_BACKSLASH_ESCAPES.
+func (e *Executor) isNoBackslashEscapes() bool {
+	mode := strings.ToUpper(e.sqlMode)
+	for _, part := range strings.Split(mode, ",") {
+		if strings.TrimSpace(part) == "NO_BACKSLASH_ESCAPES" {
+			return true
+		}
+	}
+	return false
+}
+
+// rewriteStringsForNoBackslashEscapes rewrites single-quoted string literals in a SQL query
+// so that lone backslashes (those not immediately followed by another backslash) are doubled.
+// This is necessary because the vitess parser always treats '\' as an escape character, but in
+// NO_BACKSLASH_ESCAPES mode backslashes are literal characters that don't escape the closing quote.
+// For example, ESCAPED BY '\' (where '\' is a single-backslash string in NO_BACKSLASH_ESCAPES mode)
+// would be rewritten to ESCAPED BY '\\' which the vitess parser correctly handles.
+func rewriteStringsForNoBackslashEscapes(query string) string {
+	var result strings.Builder
+	i := 0
+	n := len(query)
+	for i < n {
+		ch := query[i]
+		// Handle backtick-quoted identifiers — pass through unchanged.
+		if ch == '`' {
+			result.WriteByte('`')
+			i++
+			for i < n && query[i] != '`' {
+				result.WriteByte(query[i])
+				i++
+			}
+			if i < n {
+				result.WriteByte('`')
+				i++
+			}
+			continue
+		}
+		// Handle double-quoted strings — pass through unchanged (no backslash issue).
+		if ch == '"' {
+			result.WriteByte('"')
+			i++
+			for i < n {
+				c := query[i]
+				result.WriteByte(c)
+				i++
+				if c == '"' {
+					// Check for doubled quote (escape sequence "")
+					if i < n && query[i] == '"' {
+						result.WriteByte('"')
+						i++
+					} else {
+						break
+					}
+				}
+			}
+			continue
+		}
+		// Handle single-quoted strings.
+		if ch == '\'' {
+			result.WriteByte('\'')
+			i++
+			for i < n {
+				c := query[i]
+				if c == '\'' {
+					// Check for doubled quote '' (escape sequence)
+					if i+1 < n && query[i+1] == '\'' {
+						result.WriteByte('\'')
+						result.WriteByte('\'')
+						i += 2
+					} else {
+						// Closing quote
+						result.WriteByte('\'')
+						i++
+						break
+					}
+				} else if c == '\\' {
+					// In NO_BACKSLASH_ESCAPES mode, backslash is a literal character.
+					// Double it so the vitess parser treats it as a literal backslash,
+					// not as an escape character.
+					result.WriteByte('\\')
+					result.WriteByte('\\')
+					i++
+				} else {
+					result.WriteByte(c)
+					i++
+				}
+			}
+			continue
+		}
+		// Regular character outside of string literal.
+		result.WriteByte(ch)
+		i++
+	}
+	return result.String()
 }

--- a/executor/select.go
+++ b/executor/select.go
@@ -3177,6 +3177,11 @@ func (e *Executor) execSelect(stmt *sqlparser.Select) (*Result, error) {
 		return e.execSelectIntoOutfile(stmt.Into, colNames, resultRows)
 	}
 
+	// Handle SELECT ... INTO DUMPFILE
+	if stmt.Into != nil && stmt.Into.Type == sqlparser.IntoDumpfile {
+		return e.execSelectIntoDumpfile(stmt.Into, resultRows)
+	}
+
 	// Handle SELECT ... INTO @var1, @var2, ...
 	if stmt.Into != nil && stmt.Into.Type == sqlparser.IntoVariables {
 		return e.execSelectIntoUserVars(stmt.Into, colNames, resultRows)
@@ -4799,6 +4804,11 @@ func (e *Executor) execSelectGroupBy(stmt *sqlparser.Select, allRows []storage.R
 	// Handle SELECT ... INTO OUTFILE (GROUP BY path)
 	if stmt.Into != nil && stmt.Into.Type == sqlparser.IntoOutfile {
 		return e.execSelectIntoOutfile(stmt.Into, colNames, resultRows)
+	}
+
+	// Handle SELECT ... INTO DUMPFILE (GROUP BY path)
+	if stmt.Into != nil && stmt.Into.Type == sqlparser.IntoDumpfile {
+		return e.execSelectIntoDumpfile(stmt.Into, resultRows)
 	}
 
 	// Handle SELECT ... INTO @var1, @var2, ... (GROUP BY path)
@@ -8509,15 +8519,23 @@ func (e *Executor) execLoadData(query string) (*Result, error) {
 				}
 			}
 			// Coerce date/time values and pad BINARY columns, emitting warnings as appropriate.
-			if v, exists := row[colDef.Name]; exists && v != nil {
-				if padLen := binaryPadLength(colDef.Type); padLen > 0 {
-					v = padBinaryValue(v, padLen)
+			if v, exists := row[colDef.Name]; exists {
+				if v == nil {
+					// NULL value: warn if column is NOT NULL.
+					// MySQL emits Warning 1263 in this case.
+					if !colDef.Nullable && !colDef.AutoIncrement {
+						e.addWarning("Warning", 1263, fmt.Sprintf("Column set to default value; NULL supplied to NOT NULL column '%s' at row %d", colDef.Name, rowNum))
+					}
+				} else {
+					if padLen := binaryPadLength(colDef.Type); padLen > 0 {
+						v = padBinaryValue(v, padLen)
+					}
+					// Emit type-conversion warnings before coercing (only for string values).
+					if sv, isStr := v.(string); isStr {
+						e.emitLoadDataColumnWarning(colDef, sv, rowNum)
+					}
+					row[colDef.Name] = coerceDateTimeValue(colDef.Type, v)
 				}
-				// Emit type-conversion warnings before coercing (only for string values).
-				if sv, isStr := v.(string); isStr {
-					e.emitLoadDataColumnWarning(colDef, sv, rowNum)
-				}
-				row[colDef.Name] = coerceDateTimeValue(colDef.Type, v)
 			}
 		}
 
@@ -8604,6 +8622,33 @@ func (e *Executor) emitLoadDataColumnWarning(colDef catalog.ColumnDef, sv string
 		return
 	}
 
+	// --- VARCHAR / CHAR types ---
+	// Emit 1265 when the value exceeds the column's declared length.
+	isVarcharType := strings.HasPrefix(upper, "VARCHAR") || strings.HasPrefix(upper, "CHAR") ||
+		strings.HasPrefix(upper, "VARBINARY") || strings.HasPrefix(upper, "BINARY")
+	if isVarcharType {
+		// Extract the length from the type, e.g. VARCHAR(5) → 5
+		if parenIdx := strings.Index(upper, "("); parenIdx >= 0 {
+			closeIdx := strings.Index(upper, ")")
+			if closeIdx > parenIdx {
+				lenStr := upper[parenIdx+1 : closeIdx]
+				if maxLen, err := strconv.Atoi(strings.TrimSpace(lenStr)); err == nil {
+					// Use rune count for character types, byte count for binary types
+					var actualLen int
+					if strings.HasPrefix(upper, "VARBINARY") || strings.HasPrefix(upper, "BINARY") {
+						actualLen = len(sv)
+					} else {
+						actualLen = len([]rune(sv))
+					}
+					if actualLen > maxLen {
+						e.addWarning("Warning", 1265, fmt.Sprintf("Data truncated for column '%s' at row %d", colDef.Name, rowNum))
+					}
+				}
+			}
+		}
+		return
+	}
+
 	// --- INT types ---
 	isIntType := strings.Contains(upper, "INT") || strings.Contains(upper, "INTEGER")
 	if isIntType {
@@ -8613,7 +8658,7 @@ func (e *Executor) emitLoadDataColumnWarning(colDef catalog.ColumnDef, sv string
 			if strings.Contains(errMsg, "ERROR 1366") {
 				e.addWarning("Warning", 1366, fmt.Sprintf("Incorrect integer value: '%s' for column '%s' at row %d", sv, colDef.Name, rowNum))
 			} else if strings.Contains(errMsg, "ERROR 1265") {
-				e.addWarning("Note", 1265, fmt.Sprintf("Data truncated for column '%s' at row %d", colDef.Name, rowNum))
+				e.addWarning("Warning", 1265, fmt.Sprintf("Data truncated for column '%s' at row %d", colDef.Name, rowNum))
 			} else if strings.Contains(errMsg, "ERROR 1264") {
 				e.addWarning("Warning", 1264, fmt.Sprintf("Out of range value for column '%s' at row %d", colDef.Name, rowNum))
 			}
@@ -8878,6 +8923,44 @@ func (e *Executor) execSelectIntoOutfile(into *sqlparser.SelectInto, colNames []
 	}
 	if err := os.WriteFile(fileName, []byte(sb.String()), 0644); err != nil {
 		return nil, fmt.Errorf("cannot write outfile: %v", err)
+	}
+
+	return &Result{AffectedRows: uint64(len(rows))}, nil
+}
+
+// execSelectIntoDumpfile implements SELECT ... INTO DUMPFILE.
+// DUMPFILE writes a single row to a file as raw bytes with no field/line terminators
+// and no escape processing. If the result has multiple rows, only the first row is written.
+func (e *Executor) execSelectIntoDumpfile(into *sqlparser.SelectInto, rows [][]interface{}) (*Result, error) {
+	fileName := into.FileName
+	if len(fileName) >= 2 && fileName[0] == '\'' && fileName[len(fileName)-1] == '\'' {
+		fileName = fileName[1 : len(fileName)-1]
+	}
+	if !filepath.IsAbs(fileName) && e.DataDir != "" {
+		fileName = filepath.Join(e.DataDir, fileName)
+	}
+
+	// Enforce secure_file_priv before writing the file.
+	if err := e.checkSecureFilePriv(fileName); err != nil {
+		return nil, err
+	}
+
+	var content strings.Builder
+	if len(rows) > 0 {
+		row := rows[0]
+		for _, val := range row {
+			if val != nil {
+				content.WriteString(fmt.Sprintf("%v", val))
+			}
+		}
+	}
+
+	dir := filepath.Dir(fileName)
+	if errDir := os.MkdirAll(dir, 0755); errDir != nil {
+		return nil, fmt.Errorf("cannot create directory for dumpfile: %v", errDir)
+	}
+	if err := os.WriteFile(fileName, []byte(content.String()), 0644); err != nil {
+		return nil, fmt.Errorf("cannot write dumpfile: %v", err)
 	}
 
 	return &Result{AffectedRows: uint64(len(rows))}, nil


### PR DESCRIPTION
## Summary

- **Warning 1263**: NULL supplied to NOT NULL column in LOAD DATA now emits `Warning 1263 Column set to default value; NULL supplied to NOT NULL column '%s' at row %d`
- **Warning 1265 (INT)**: Fixed severity level from `Note` to `Warning` for integer type truncation (e.g. "67 abc" → 67)
- **Warning 1265 (VARCHAR/CHAR)**: Added truncation warning when loaded string exceeds column's declared max length (e.g. `char(5)` receiving a 30-char string)
- **SELECT INTO DUMPFILE**: Implemented `execSelectIntoDumpfile()` which writes first row values as raw bytes (no field/line terminators), following MySQL semantics
- **NO_BACKSLASH_ESCAPES preprocessing**: Added `rewriteStringsForNoBackslashEscapes()` preprocessor that doubles backslashes in single-quoted string literals when the `NO_BACKSLASH_ESCAPES` SQL mode is active, working around the vitess parser's always-on backslash escape handling

## Test plan

- `other/warnings` LOAD DATA block: `@@warning_count` now correctly equals 7 (was 5 before; all 7 expected warning types are generated)
- `other/loaddata` test: progresses past DUMPFILE and NO_BACKSLASH_ESCAPES lines; stops later at infrastructure dependency (`--copy_file $EXE_MYSQL`) which is expected infra-skip behavior
- Full MTR suite: **1723 passed** (matches baseline, 0 regressions)
- Unit tests: `go test ./... -count=1` all pass

Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)