### PR TITLE
feat: validate partition definition constraints at CREATE TABLE time (Closes #187)

### DIFF
--- a/cmd/mtrrun/skiplist.json
+++ b/cmd/mtrrun/skiplist.json
@@ -3429,14 +3429,6 @@
       "reason": "complex failures"
     },
     {
-      "test": "parts/partition_list_error",
-      "reason": "partition failures"
-    },
-    {
-      "test": "parts/partition_value_error",
-      "reason": "partition failures"
-    },
-    {
       "test": "parts/partition_syntax_innodb",
       "reason": "partition failures"
     },

--- a/executor/ddl.go
+++ b/executor/ddl.go
@@ -2493,6 +2493,57 @@ func (e *Executor) execCreateTable(stmt *sqlparser.CreateTable) (*Result, error)
 				seen[key] = true
 			}
 		}
+		// For RANGE partitions, validate that VALUES LESS THAN bounds are strictly increasing.
+		if po.Type == sqlparser.RangeType && len(def.PartitionDefs) > 1 {
+			prevBound := int64(-1 << 62) // sentinel: less than any real value
+			prevIsMaxvalue := false
+			for _, pd := range def.PartitionDefs {
+				vr := strings.TrimSpace(pd.ValueRange)
+				if strings.EqualFold(vr, "LESS THAN MAXVALUE") {
+					if prevIsMaxvalue {
+						return nil, mysqlError(1493, "HY000", "VALUES LESS THAN value must be strictly increasing for each partition")
+					}
+					prevIsMaxvalue = true
+				} else if strings.HasPrefix(strings.ToUpper(vr), "LESS THAN (") {
+					if prevIsMaxvalue {
+						return nil, mysqlError(1493, "HY000", "VALUES LESS THAN value must be strictly increasing for each partition")
+					}
+					inner := strings.TrimSpace(vr[len("LESS THAN (") : len(vr)-1])
+					bound, parseErr := strconv.ParseInt(inner, 10, 64)
+					if parseErr != nil {
+						if f, fErr := strconv.ParseFloat(inner, 64); fErr == nil {
+							bound = int64(f)
+						}
+						// If we can't parse, skip validation for this partition
+					} else if bound <= prevBound {
+						return nil, mysqlError(1493, "HY000", "VALUES LESS THAN value must be strictly increasing for each partition")
+					}
+					if parseErr == nil {
+						prevBound = bound
+					}
+				}
+			}
+		}
+		// For LIST partitions, validate that no constant value appears in more than one partition.
+		if po.Type == sqlparser.ListType && len(def.PartitionDefs) > 0 {
+			seenListVals := make(map[string]bool)
+			for _, pd := range def.PartitionDefs {
+				vr := strings.TrimSpace(pd.ValueRange)
+				if !strings.HasPrefix(strings.ToUpper(vr), "IN (") {
+					continue
+				}
+				inner := vr[len("IN (") : len(vr)-1]
+				values := splitListValues(inner)
+				for _, v := range values {
+					v = strings.TrimSpace(v)
+					key := strings.ToLower(v)
+					if seenListVals[key] {
+						return nil, mysqlError(1495, "HY000", "Multiple definition of same constant in list partitioning")
+					}
+					seenListVals[key] = true
+				}
+			}
+		}
 		// For KEY partitions, check for duplicate column names in the partition key.
 		if po.Type == sqlparser.KeyType && len(po.ColList) > 0 {
 			seenCols := make(map[string]bool, len(po.ColList))


### PR DESCRIPTION
## Summary

- Add **ER_RANGE_NOT_INCREASING_ERROR** (MySQL 1493): validates that `VALUES LESS THAN` bounds in RANGE partitions are strictly increasing
- Add **ER_MULTIPLE_DEF_CONST_IN_LIST_PART_ERROR** (MySQL 1495): validates that no constant value appears in more than one LIST partition
- Both validations fire at `CREATE TABLE` time, consistent with MySQL behavior
- Remove `parts/partition_list_error` and `parts/partition_value_error` from skiplist (+2 tests pass)

Closes #187

## Test plan

- [ ] `go build ./... && go test ./... -count=1` — all pass
- [ ] `parts/partition_list_error` — now passes
- [ ] `parts/partition_value_error` — now passes
- [ ] Full suite baseline 1724 pass maintained (engine_funcs, engine_iuds, innodb, other verified — no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)