### PR TITLE
fix: setup_objects enum validation with correct Warning+Error ordering

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -428,6 +428,9 @@ type Executor struct {
 	queryTableDef *catalog.TableDef
 	// warnings stores the warnings from the last executed statement.
 	warnings []Warning
+	// postErrorWarnings stores warnings to be appended AFTER the main error is added
+	// to the warnings list by the Execute() defer. Use addPostErrorWarning() to stage them.
+	postErrorWarnings []Warning
 	// lastWarningCount / lastErrorCount hold the warning/error counts from the
 	// previous statement so that SELECT @@warning_count / @@error_count return
 	// the correct value (the counts are snapshotted before warnings are cleared).
@@ -694,6 +697,13 @@ func (e *Executor) addWarning(level string, code int, message string) {
 		return
 	}
 	e.warnings = append(e.warnings, Warning{Level: level, Code: code, Message: message})
+}
+
+// addPostErrorWarning stages a warning to be appended AFTER the main error is added
+// to the warnings list by the Execute() defer. This ensures correct ordering when
+// MySQL adds a warning after the error event (e.g., cleanup warnings).
+func (e *Executor) addPostErrorWarning(level string, code int, message string) {
+	e.postErrorWarnings = append(e.postErrorWarnings, Warning{Level: level, Code: code, Message: message})
 }
 
 // sqlNotesEnabled returns true if the sql_notes session variable is ON (default).
@@ -1843,6 +1853,11 @@ func (e *Executor) Execute(query string) (res *Result, retErr error) {
 					}
 				}
 				e.addWarning("Error", code, msg)
+				// Append any post-error warnings (staged via addPostErrorWarning).
+				for _, pw := range e.postErrorWarnings {
+					e.warnings = append(e.warnings, pw)
+				}
+				e.postErrorWarnings = nil
 			}
 			// Update ROW_COUNT() tracking (MySQL semantics):
 			// - After SELECT: -1

--- a/executor/information_schema.go
+++ b/executor/information_schema.go
@@ -4453,11 +4453,29 @@ func (e *Executor) execPerfSchemaInsert(stmt *sqlparser.Insert, tableName string
 					newRow["HISTORY"] = strings.ToUpper(history)
 				}
 			} else {
+				// Validate OBJECT_TYPE
 				if objType, ok := newRow["OBJECT_TYPE"].(string); ok {
 					if !validSetupObjectTypes[strings.ToUpper(objType)] {
+						e.addWarning("Warning", 1265, "Data truncated for column 'OBJECT_TYPE' at row 1")
 						return nil, mysqlError(1452, "23000", "Cannot add or update a child row: a foreign key constraint fails ()")
 					}
 					newRow["OBJECT_TYPE"] = strings.ToUpper(objType)
+				}
+				// Validate ENABLED
+				if enabled, ok := newRow["ENABLED"].(string); ok {
+					if !isPerfSchemaEnumValid(enabled) {
+						e.addWarning("Warning", 1265, "Data truncated for column 'ENABLED' at row 1")
+						return nil, mysqlError(1452, "23000", "Cannot add or update a child row: a foreign key constraint fails ()")
+					}
+					newRow["ENABLED"] = strings.ToUpper(enabled)
+				}
+				// Validate TIMED
+				if timed, ok := newRow["TIMED"].(string); ok {
+					if !isPerfSchemaEnumValid(timed) {
+						e.addWarning("Warning", 1265, "Data truncated for column 'TIMED' at row 1")
+						return nil, mysqlError(1452, "23000", "Cannot add or update a child row: a foreign key constraint fails ()")
+					}
+					newRow["TIMED"] = strings.ToUpper(timed)
 				}
 			}
 
@@ -4600,9 +4618,26 @@ func (e *Executor) execPerfSchemaInsert(stmt *sqlparser.Insert, tableName string
 			// Validate OBJECT_TYPE
 			if objType, ok := newRow["OBJECT_TYPE"].(string); ok {
 				if !validSetupObjectTypes[strings.ToUpper(objType)] {
+					e.addWarning("Warning", 1265, "Data truncated for column 'OBJECT_TYPE' at row 1")
 					return nil, mysqlError(1452, "23000", "Cannot add or update a child row: a foreign key constraint fails ()")
 				}
 				newRow["OBJECT_TYPE"] = strings.ToUpper(objType)
+			}
+			// Validate ENABLED
+			if enabled, ok := newRow["ENABLED"].(string); ok {
+				if !isPerfSchemaEnumValid(enabled) {
+					e.addWarning("Warning", 1265, "Data truncated for column 'ENABLED' at row 1")
+					return nil, mysqlError(1452, "23000", "Cannot add or update a child row: a foreign key constraint fails ()")
+				}
+				newRow["ENABLED"] = strings.ToUpper(enabled)
+			}
+			// Validate TIMED
+			if timed, ok := newRow["TIMED"].(string); ok {
+				if !isPerfSchemaEnumValid(timed) {
+					e.addWarning("Warning", 1265, "Data truncated for column 'TIMED' at row 1")
+					return nil, mysqlError(1452, "23000", "Cannot add or update a child row: a foreign key constraint fails ()")
+				}
+				newRow["TIMED"] = strings.ToUpper(timed)
 			}
 		}
 
@@ -4725,6 +4760,11 @@ func (e *Executor) execPerfSchemaUpdate(stmt *sqlparser.Update, tableName string
 		}
 		strVal := fmt.Sprintf("%v", val)
 		if !isPerfSchemaEnumValid(strVal) {
+			// setup_objects uses foreign-key-style error (1452) with a preceding warning (1265)
+			if tableName == "setup_objects" {
+				e.addWarning("Warning", 1265, fmt.Sprintf("Data truncated for column '%s' at row 1", colName))
+				return nil, mysqlError(1452, "23000", "Cannot add or update a child row: a foreign key constraint fails ()")
+			}
 			return nil, mysqlError(1265, "01000", fmt.Sprintf("Data truncated for column '%s' at row 1", colName))
 		}
 	}

--- a/executor/preprocess.go
+++ b/executor/preprocess.go
@@ -292,6 +292,7 @@ func (e *Executor) preprocessQuery(query string) (string, *Result, error) {
 		}
 		e.lastErrorCount = errCnt
 		e.warnings = nil
+		e.postErrorWarnings = nil
 	}
 
 	// Handle SHOW COUNT(*) WARNINGS / SHOW COUNT(*) ERRORS before parser

--- a/executor/procedures.go
+++ b/executor/procedures.go
@@ -1719,9 +1719,10 @@ func (e *Executor) execDropProcedureAST(stmt *sqlparser.DropProcedure) (*Result,
 	}
 	// MySQL tries to revoke privileges from mysql.procs_priv when dropping a routine.
 	// If the table doesn't exist, return an error and a warning.
+	// Warning 1405 is added AFTER the error (post-error warning) to match MySQL's ordering.
 	if mysqlDB, err2 := e.Catalog.GetDatabase("mysql"); err2 == nil {
 		if _, tblErr := mysqlDB.GetTable("procs_priv"); tblErr != nil {
-			e.warnings = append(e.warnings, Warning{Level: "Warning", Code: 1405, Message: "Failed to revoke all privileges to dropped routine"})
+			e.addPostErrorWarning("Warning", 1405, "Failed to revoke all privileges to dropped routine")
 			return nil, mysqlError(1146, "42S02", "Table 'mysql.procs_priv' doesn't exist")
 		}
 	}
@@ -2507,9 +2508,10 @@ func (e *Executor) execDropFunction(query string) (*Result, error) {
 	}
 	// MySQL tries to revoke privileges from mysql.procs_priv when dropping a routine.
 	// If the table doesn't exist, return an error and a warning.
+	// Warning 1405 is added AFTER the error (post-error warning) to match MySQL's ordering.
 	if mysqlDB, err2 := e.Catalog.GetDatabase("mysql"); err2 == nil {
 		if _, tblErr := mysqlDB.GetTable("procs_priv"); tblErr != nil {
-			e.warnings = append(e.warnings, Warning{Level: "Warning", Code: 1405, Message: "Failed to revoke all privileges to dropped routine"})
+			e.addPostErrorWarning("Warning", 1405, "Failed to revoke all privileges to dropped routine")
 			return nil, mysqlError(1146, "42S02", "Table 'mysql.procs_priv' doesn't exist")
 		}
 	}

--- a/executor/show.go
+++ b/executor/show.go
@@ -916,22 +916,10 @@ func (e *Executor) execShow(stmt *sqlparser.Show, query string) (*Result, error)
 
 	// SHOW WARNINGS
 	if strings.HasPrefix(upper, "SHOW WARNINGS") || strings.HasPrefix(upper, "SHOW COUNT(*) WARNINGS") {
-		// MySQL returns warnings in severity order: Errors first, Warnings second, Notes last.
+		// MySQL returns warnings in insertion order (the order they were added).
 		rows := make([][]interface{}, 0, len(e.warnings))
 		for _, w := range e.warnings {
-			if strings.EqualFold(w.Level, "Error") {
-				rows = append(rows, []interface{}{w.Level, int64(w.Code), w.Message})
-			}
-		}
-		for _, w := range e.warnings {
-			if strings.EqualFold(w.Level, "Warning") {
-				rows = append(rows, []interface{}{w.Level, int64(w.Code), w.Message})
-			}
-		}
-		for _, w := range e.warnings {
-			if strings.EqualFold(w.Level, "Note") {
-				rows = append(rows, []interface{}{w.Level, int64(w.Code), w.Message})
-			}
+			rows = append(rows, []interface{}{w.Level, int64(w.Code), w.Message})
 		}
 		return &Result{
 			Columns:     []string{"Level", "Code", "Message"},


### PR DESCRIPTION
## Summary

- Add `Warning(1265)` before `Error(1452)` for `setup_objects` INSERT with invalid `OBJECT_TYPE`, `ENABLED`, or `TIMED` enum values (both `INSERT VALUES` and `INSERT...SELECT` paths)
- Add `ENABLED` and `TIMED` column validation for `setup_objects` INSERT (previously only `OBJECT_TYPE` was checked)
- Fix `setup_objects` UPDATE to return `Error(1452)` with `Warning(1265)` for invalid `ENABLED`/`TIMED` values instead of just `Error(1265)`
- Fix `SHOW WARNINGS` to return entries in insertion order (matches real MySQL behavior) instead of severity-sorted order
- Add `postErrorWarning` mechanism for warnings that must appear *after* the main error in `SHOW WARNINGS`; use it for `DROP FUNCTION`/`PROCEDURE` procs_priv cleanup warning (1405) so `sp-destruct` continues to pass

### Result
`perfschema/setup_objects` first-diff-line improves from 34 → 168. Tests `dml_setup_actors` and `dml_setup_objects` already passed. Full `setup_objects` pass blocked by unimplemented `events_waits_history_long` I/O instrumentation (out of scope). No regressions (baseline 1728).

## Test plan
- [x] `go test ./... -count=1` passes
- [x] `perfschema/setup_objects` first-diff-line: 34 → 168
- [x] `perfschema/dml_setup_objects`, `perfschema/dml_setup_actors` still pass
- [x] `other/sp-destruct` still passes (SHOW WARNINGS order for DROP FUNCTION)
- [x] `perfschema` suite: 351 pass (no regression)
- [x] `sys_vars` suite: 497 pass (no regression)
- [x] `innodb` suite: 87 pass (no regression)

Closes #251

🤖 Generated with [Claude Code](https://claude.com/claude-code)