### PR TITLE
feat: persist setup_instruments and setup_threads UPDATE state in-memory (Closes #252)

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -524,6 +524,14 @@ type Executor struct {
 	psThreadInstrumented map[int64]string
 	// psThreadHistory tracks per-connection HISTORY column for threads table.
 	psThreadHistory map[int64]string
+	// psSetupInstrumentsOverride holds per-instrument column overrides for setup_instruments.
+	// Key is lowercase instrument name; value maps lowercase column name to new value.
+	// nil means no overrides have been applied.
+	psSetupInstrumentsOverride map[string]map[string]string
+	// psSetupThreadsOverride holds per-thread-type column overrides for setup_threads.
+	// Key is lowercase thread name; value maps lowercase column name to new value.
+	// nil means no overrides have been applied.
+	psSetupThreadsOverride map[string]map[string]string
 	// processList is a shared registry of active connections and their states.
 	// It is shared across all executor instances (connections).
 	processList *ProcessList

--- a/executor/information_schema.go
+++ b/executor/information_schema.go
@@ -4281,8 +4281,21 @@ func (e *Executor) perfSchemaSetupThreads() []storage.Row {
 
 	rows := make([]storage.Row, 0, len(threads))
 	for _, t := range threads {
+		enabled := "YES"
+		history := "YES"
+		// Apply any in-memory overrides from UPDATE statements
+		if e.psSetupThreadsOverride != nil {
+			if overrides, ok := e.psSetupThreadsOverride[strings.ToLower(t.name)]; ok {
+				if v, ok2 := overrides["enabled"]; ok2 {
+					enabled = v
+				}
+				if v, ok2 := overrides["history"]; ok2 {
+					history = v
+				}
+			}
+		}
 		rows = append(rows, storage.Row{
-			"NAME": t.name, "ENABLED": "YES", "HISTORY": "YES",
+			"NAME": t.name, "ENABLED": enabled, "HISTORY": history,
 			"PROPERTIES": t.properties, "VOLATILITY": int64(0), "DOCUMENTATION": nil,
 		})
 	}
@@ -4903,7 +4916,73 @@ func (e *Executor) execPerfSchemaUpdate(stmt *sqlparser.Update, tableName string
 		return &Result{AffectedRows: affected}, nil
 	}
 
-	// For setup_instruments, setup_threads - silently succeed
+	// For setup_instruments: persist column overrides in-memory
+	if tableName == "setup_instruments" {
+		if e.psSetupInstrumentsOverride == nil {
+			e.psSetupInstrumentsOverride = make(map[string]map[string]string)
+		}
+		// Apply to all instruments (no WHERE support needed for these tests;
+		// use wildcard key "" to represent "all rows updated").
+		// If WHERE is present, apply per-row; otherwise apply globally.
+		currentRows := e.perfSchemaSetupInstruments()
+		affected := uint64(0)
+		for _, row := range currentRows {
+			name := strings.ToLower(fmt.Sprintf("%v", row["NAME"]))
+			match := true
+			if stmt.Where != nil {
+				m, err := e.evalWhere(stmt.Where.Expr, row)
+				if err != nil {
+					return nil, err
+				}
+				match = m
+			}
+			if match {
+				if e.psSetupInstrumentsOverride[name] == nil {
+					e.psSetupInstrumentsOverride[name] = make(map[string]string)
+				}
+				for _, expr := range stmt.Exprs {
+					colName := strings.ToLower(expr.Name.Name.String())
+					val, _ := e.evalExpr(expr.Expr)
+					e.psSetupInstrumentsOverride[name][colName] = strings.ToUpper(fmt.Sprintf("%v", val))
+				}
+				affected++
+			}
+		}
+		return &Result{AffectedRows: affected}, nil
+	}
+
+	// For setup_threads: persist column overrides in-memory
+	if tableName == "setup_threads" {
+		if e.psSetupThreadsOverride == nil {
+			e.psSetupThreadsOverride = make(map[string]map[string]string)
+		}
+		currentRows := e.perfSchemaSetupThreads()
+		affected := uint64(0)
+		for _, row := range currentRows {
+			name := strings.ToLower(fmt.Sprintf("%v", row["NAME"]))
+			match := true
+			if stmt.Where != nil {
+				m, err := e.evalWhere(stmt.Where.Expr, row)
+				if err != nil {
+					return nil, err
+				}
+				match = m
+			}
+			if match {
+				if e.psSetupThreadsOverride[name] == nil {
+					e.psSetupThreadsOverride[name] = make(map[string]string)
+				}
+				for _, expr := range stmt.Exprs {
+					colName := strings.ToLower(expr.Name.Name.String())
+					val, _ := e.evalExpr(expr.Expr)
+					e.psSetupThreadsOverride[name][colName] = strings.ToUpper(fmt.Sprintf("%v", val))
+				}
+				affected++
+			}
+		}
+		return &Result{AffectedRows: affected}, nil
+	}
+
 	return &Result{AffectedRows: 0}, nil
 }
 
@@ -5094,6 +5173,17 @@ func (e *Executor) perfSchemaSetupInstruments() []storage.Row {
 		enabled, timed := inst.enabled, inst.timed
 		if patterns != "" {
 			enabled, timed = applyPsInstrumentPatterns(patterns, inst.name, enabled, timed)
+		}
+		// Apply any in-memory overrides from UPDATE statements
+		if e.psSetupInstrumentsOverride != nil {
+			if overrides, ok := e.psSetupInstrumentsOverride[strings.ToLower(inst.name)]; ok {
+				if v, ok2 := overrides["enabled"]; ok2 {
+					enabled = v
+				}
+				if v, ok2 := overrides["timed"]; ok2 {
+					timed = v
+				}
+			}
 		}
 		rows = append(rows, storage.Row{
 			"NAME": inst.name, "ENABLED": enabled, "TIMED": timed,


### PR DESCRIPTION
## Summary

- Add `psSetupInstrumentsOverride` and `psSetupThreadsOverride` maps to the `Executor` struct for in-memory persistence of UPDATE operations
- Apply per-instrument/per-thread overrides in `perfSchemaSetupInstruments()` and `perfSchemaSetupThreads()` so subsequent SELECTs reflect changes
- Replace the silent no-op UPDATE path for `setup_instruments`/`setup_threads` with proper WHERE-aware row iteration and override storage
- `ps_current_thread_id()` and `ps_thread_id()` were already implemented returning `connectionID + 1`; `threads.INSTRUMENTED` UPDATE persistence was also already in place

## Target tests (all pass)

- `perfschema/dml_setup_instruments` — enabled/timed UPDATE now persisted
- `perfschema/dml_setup_threads` — enabled/history UPDATE now persisted, ORDER BY name LIMIT 12 returns real data
- `perfschema/dml_threads` — threads.INSTRUMENTED UPDATE persistence (pre-existing)
- `perfschema/native_func_thread_id` — ps_current_thread_id() returns real thread ID (pre-existing)

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./... -count=1` passes
- [x] 4 target tests pass via `go run ./cmd/mtrrun -test perfschema/dml_setup_instruments,...`
- [x] Full perfschema suite: 351 pass, 0 fail, 196 skip (no regressions vs baseline)

Closes #252

🤖 Generated with [Claude Code](https://claude.com/claude-code)