### PR TITLE
feat: add binlog/replication system variable definitions

### DIFF
--- a/cmd/mtrrun/skiplist.json
+++ b/cmd/mtrrun/skiplist.json
@@ -3009,10 +3009,6 @@
       "reason": "output mismatch or execution error"
     },
     {
-      "test": "sys_vars/log_statements_unsafe_for_binlog_basic",
-      "reason": "output mismatch or execution error"
-    },
-    {
       "test": "sys_vars/max_delayed_threads_basic",
       "reason": "output mismatch or execution error"
     },
@@ -3062,14 +3058,6 @@
     },
     {
       "test": "sys_vars/rpl_read_size_basic",
-      "reason": "output mismatch or execution error"
-    },
-    {
-      "test": "sys_vars/slave_parallel_type_basic",
-      "reason": "output mismatch or execution error"
-    },
-    {
-      "test": "sys_vars/slave_type_conversions_basic",
       "reason": "output mismatch or execution error"
     },
     {
@@ -3371,10 +3359,6 @@
     {
       "test": "sys_vars/insert_id_func",
       "reason": "output mismatch"
-    },
-    {
-      "test": "sys_vars/binlog_group_commit_sync_no_delay_count_basic",
-      "reason": "engine does not truncate out-of-range values for binlog_group_commit_sync_no_delay_count"
     },
     {
       "test": "sys_vars/binlog_encryption",
@@ -4503,10 +4487,6 @@
     {
       "test": "sys_vars/slave_pending_jobs_size_max_basic",
       "reason": "result file has literal $var from eval echo behavior"
-    },
-    {
-      "test": "sys_vars/slave_rows_search_algorithms_basic",
-      "reason": "needs SET value canonicalization and invalid value rejection"
     },
     {
       "test": "sys_vars/session_track_system_variables_basic",

--- a/executor/variables.go
+++ b/executor/variables.go
@@ -2708,6 +2708,25 @@ var sysVarEnumValues = map[string]map[string]string{
 		"STRICT":     "STRICT",
 		"IDEMPOTENT": "IDEMPOTENT",
 	},
+	"slave_parallel_type": {
+		"DATABASE":      "DATABASE",
+		"LOGICAL_CLOCK": "LOGICAL_CLOCK",
+	},
+	// slave_type_conversions is a SET type (comma-separated); empty string is valid (no conversions).
+	// Individual valid values: ALL_LOSSY, ALL_NON_LOSSY.
+	"slave_type_conversions": {
+		"":              "",
+		"ALL_LOSSY":     "ALL_LOSSY",
+		"ALL_NON_LOSSY": "ALL_NON_LOSSY",
+	},
+	// slave_rows_search_algorithms is a SET type (comma-separated).
+	// Valid values: TABLE_SCAN, INDEX_SCAN, HASH_SCAN.
+	// Canonical order: TABLE_SCAN, INDEX_SCAN, HASH_SCAN.
+	"slave_rows_search_algorithms": {
+		"TABLE_SCAN": "TABLE_SCAN",
+		"INDEX_SCAN": "INDEX_SCAN",
+		"HASH_SCAN":  "HASH_SCAN",
+	},
 	"log_output": {
 		"TABLE": "TABLE",
 		"FILE":  "FILE",
@@ -2862,6 +2881,7 @@ var sysVarBoolean = map[string]bool{
 	"log_queries_not_using_indexes": true, "log_slow_admin_statements": true,
 	"log_slow_extra": true, "log_slow_replica_statements": true,
 	"log_slow_slave_statements": true, "log_bin_trust_function_creators": true,
+	"log_statements_unsafe_for_binlog": true,
 	"binlog_order_commits": true, "binlog_rows_query_log_events": true,
 	"binlog_direct_non_transactional_updates": true, "binlog_encryption": true,
 	"binlog_transaction_compression": true,
@@ -2998,7 +3018,7 @@ var sysVarIntRange = map[string]intVarRange{
 	"binlog_stmt_cache_size":                     {Min: 4096, Max: 18446744073709547520, IsUnsigned: true, BlockSize: 4096},
 	"binlog_expire_logs_seconds":                 {Min: 0, Max: 4294967295, IsUnsigned: true},
 	"binlog_group_commit_sync_delay":             {Min: 0, Max: 1000000, IsUnsigned: true},
-	"binlog_group_commit_sync_no_delay_count":    {Min: 0, Max: 1000000, IsUnsigned: true},
+	"binlog_group_commit_sync_no_delay_count":    {Min: 0, Max: 100000, IsUnsigned: true},
 	"binlog_max_flush_queue_time":                {Min: 0, Max: 10000, IsUnsigned: true},
 	"binlog_transaction_dependency_history_size": {Min: 1, Max: 1000000, IsUnsigned: true},
 	"cte_max_recursion_depth":                    {Min: 0, Max: 4294967295, IsUnsigned: true},
@@ -3535,6 +3555,13 @@ func normalizeEnumSetValue(name string, expr sqlparser.Expr, evalVal interface{}
 				if name == "log_output" {
 					sort.Slice(normalized, func(i, j int) bool {
 						order := map[string]int{"NONE": 0, "FILE": 1, "TABLE": 2}
+						return order[normalized[i]] < order[normalized[j]]
+					})
+				}
+				// Sort in canonical order for slave_rows_search_algorithms: TABLE_SCAN, INDEX_SCAN, HASH_SCAN
+				if name == "slave_rows_search_algorithms" {
+					sort.Slice(normalized, func(i, j int) bool {
+						order := map[string]int{"TABLE_SCAN": 0, "INDEX_SCAN": 1, "HASH_SCAN": 2}
 						return order[normalized[i]] < order[normalized[j]]
 					})
 				}


### PR DESCRIPTION
## Summary
- Add enum validation for `slave_parallel_type` (DATABASE/LOGICAL_CLOCK), `slave_type_conversions` (empty/ALL_LOSSY/ALL_NON_LOSSY), and `slave_rows_search_algorithms` (TABLE_SCAN/INDEX_SCAN/HASH_SCAN) to `sysVarEnumValues`
- Add canonical ordering for `slave_rows_search_algorithms` SET values: TABLE_SCAN, INDEX_SCAN, HASH_SCAN
- Add `log_statements_unsafe_for_binlog` to `sysVarBoolean` to reject float values with ER_WRONG_TYPE_FOR_VAR
- Fix `binlog_group_commit_sync_no_delay_count` max value from 1000000 to 100000 per MySQL 8.0 spec
- Remove 5 tests from skiplist that now pass

## Results
- New passes: `binlog_group_commit_sync_no_delay_count_basic`, `log_statements_unsafe_for_binlog_basic`, `slave_parallel_type_basic`, `slave_rows_search_algorithms_basic`, `slave_type_conversions_basic`
- Total: 1734 passing (baseline: 1729) — +5 passes, 0 regressions
- binlog-related tests passing: 20+ (meets issue requirement)
- slave_*/replica_* tests passing: 14 (meets issue requirement of 10+)

## Test plan
- [x] `go build ./...` - passes
- [x] `go test ./... -count=1` - all unit tests pass
- [x] `go run ./cmd/mtrrun` - full suite: 1734 passed, 0 regressions vs baseline 1729
- [x] Zero regressions verified

Closes #266

🤖 Generated with [Claude Code](https://claude.com/claude-code)