### PR TITLE
fix: remove idx_persisted_variables from skiplist (Closes #253)

### DIFF
--- a/cmd/mtrrun/skiplist.json
+++ b/cmd/mtrrun/skiplist.json
@@ -3889,10 +3889,6 @@
       "reason": "output mismatch, timeout, or error"
     },
     {
-      "test": "perfschema/idx_persisted_variables",
-      "reason": "output mismatch, timeout, or error"
-    },
-    {
       "test": "perfschema/indexed_table_io",
       "reason": "output mismatch, timeout, or error"
     },


### PR DESCRIPTION
## Summary

- Removes `perfschema/idx_persisted_variables` from the skiplist since it already passes without any code changes
- The test only queries SHOW CREATE TABLE and INFORMATION_SCHEMA.STATISTICS for a perfschema table - no multi-connection required
- Related to #253 (P_S idx_* test group improvements)

## Test Results

- Baseline: 1734 pass
- After: 1735 pass (+1)
- Regressions: 0

## Analysis

Issue #253 asked for EXPLAIN perfschema improvements and SELECT INTO @var implementation. Investigation found:

1. **SELECT INTO @var** is already fully implemented in `executor/select.go` (`execSelectIntoUserVars`)
2. **EXPLAIN perfschema** already produces correct access types (ref/ALL/const) — confirmed by 82/105 idx_* tests passing
3. The 6 remaining skiplist idx_* tests (idx_events_stages_current etc.) require multi-connection support (they timeout) - cannot be unblocked
4. `idx_persisted_variables` was incorrectly in the skiplist

🤖 Generated with [Claude Code](https://claude.com/claude-code)