### PR TITLE
feat: block SELECT ... FOR UPDATE under read_only=ON

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -2654,6 +2654,21 @@ func (e *Executor) Execute(query string) (res *Result, retErr error) {
 					if !s.Temp {
 						return nil, mysqlError(1290, "HY000", "The MySQL server is running with the --read-only option so it cannot execute this statement")
 					}
+				case *sqlparser.Select:
+					// SELECT ... FOR UPDATE is treated as a write operation under read_only=ON.
+					// FOR SHARE is allowed since it only acquires shared locks.
+					hasExclusiveLock := s.Lock == sqlparser.ForUpdateLock
+					if !hasExclusiveLock {
+						for _, lc := range e.selectLockClauses {
+							if lc.exclusive {
+								hasExclusiveLock = true
+								break
+							}
+						}
+					}
+					if hasExclusiveLock {
+						return nil, mysqlError(1290, "HY000", "The MySQL server is running with the --read-only option so it cannot execute this statement")
+					}
 				}
 			}
 		}


### PR DESCRIPTION
## Summary

- Implements `SELECT ... FOR UPDATE` blocking under `read_only=ON` for non-SUPER users
- When `read_only=ON`, `SELECT ... FOR UPDATE` (exclusive lock) now returns `ER_OPTION_PREVENTS_STATEMENT` (error 1290) immediately, matching MySQL behavior
- `SELECT ... FOR SHARE` remains allowed (only acquires shared locks)
- Also handles dual-locking clauses (`FOR SHARE OF t1 FOR UPDATE OF t2`) — if any clause requests exclusive, the whole query is blocked

## Test plan

- [x] `other/flush_block_commit` — passes (was already passing in baseline)
- [x] `other/locking_readonly_db` — passes (was failing in baseline, now passes)
- [x] No regressions: 1735 passing vs 1734 baseline
- [x] `go test ./... -count=1` passes

Closes #249

🤖 Generated with [Claude Code](https://claude.com/claude-code)