### PR TITLE
feat: implement SHOW VARIABLES completeness and sys_vars/all_vars test

### DIFF
--- a/cmd/mtrrun/skiplist.json
+++ b/cmd/mtrrun/skiplist.json
@@ -3137,10 +3137,6 @@
       "reason": "fails"
     },
     {
-      "test": "sys_vars/all_vars",
-      "reason": "LOAD DATA not fully supported"
-    },
-    {
       "test": "sys_vars/autocommit_func2",
       "reason": "still failing"
     },

--- a/executor/show.go
+++ b/executor/show.go
@@ -1249,6 +1249,10 @@ func (e *Executor) populatePerfSchemaTable(tbl *storage.Table, tableName string)
 		// Sort by name for deterministic output
 		names := make([]string, 0, len(vars))
 		for name := range vars {
+			// Exclude session-only variables from global_variables
+			if sysVarSessionOnly[name] {
+				continue
+			}
 			names = append(names, name)
 		}
 		sort.Strings(names)

--- a/executor/variables.go
+++ b/executor/variables.go
@@ -1282,9 +1282,14 @@ func (e *Executor) handleRawSet(raw string) error {
 					val = mapped
 				}
 			}
-			// Store directly in both globalScopeVars and startupVars.
-			e.setGlobalVar(varName, val)
+			// Store in startupVars regardless (for getSysVarSession fallback).
+			// Only propagate to globalScopeVars if this is a known system variable
+			// (i.e., has a compiled default). Unknown startup options like --loose-skip-ndbinfo
+			// should not pollute the SHOW VARIABLES / performance_schema output.
 			e.startupVars[varName] = val
+			if _, isKnownVar := e.getCompiledDefault(varName); isKnownVar {
+				e.setGlobalVar(varName, val)
+			}
 			// When character_set_server is set and collation_server was not explicitly
 			// set in startup options, update collation_server to the default collation
 			// for that charset (MySQL behavior).
@@ -2794,6 +2799,8 @@ var sysVarSessionOnly = map[string]bool{
 	"immediate_server_version":   true,
 	"timestamp":                  true,
 	"rbr_exec_mode":              true,
+	"resultset_metadata":         true, // session-only in MySQL 8.0
+	"use_secondary_engine":       true, // session-only in MySQL 8.0
 }
 
 // sysVarBothScope contains system variables that exist at both SESSION and GLOBAL scope.
@@ -4120,6 +4127,14 @@ func (e *Executor) buildVariablesMapScoped(globalOnly bool) map[string]string {
 		"ft_query_expansion_limit": "20",
 		"ft_stopword_file":         "(built-in)",
 
+		// MySQL 8.0 variables added for completeness
+		"activate_all_roles_on_login":   "OFF",
+		"group_replication_consistency": "EVENTUAL",
+		"keyring_operations":            "ON",
+		"mandatory_roles":               "",
+		"resultset_metadata":            "FULL",
+		"sql_require_primary_key":       "OFF",
+
 		// Misc variables
 		"big_tables":                        "OFF",
 		"block_encryption_mode":             "aes-128-ecb",
@@ -4423,6 +4438,12 @@ func (e *Executor) buildVariablesMapScoped(globalOnly bool) map[string]string {
 			name == "performance_schema_instrument" {
 			continue
 		}
+		// Only apply startup vars that are known system variables (already in the
+		// compiled defaults map). Unknown startup options like --loose-skip-ndbinfo
+		// should not appear in SHOW VARIABLES / performance_schema.global_variables.
+		if _, isKnown := vars[name]; !isKnown {
+			continue
+		}
 		// Apply minimum/maximum constraints for known variables
 		if name == "innodb_stats_transient_sample_pages" || name == "innodb_stats_persistent_sample_pages" {
 			if n, err := strconv.ParseInt(val, 10, 64); err == nil && n < 1 {
@@ -4473,6 +4494,11 @@ func (e *Executor) buildVariablesMapScoped(globalOnly bool) map[string]string {
 		// performance_schema_consumer_* are startup-only, not system variables
 		if strings.HasPrefix(name, "performance_schema_consumer_") ||
 			name == "performance_schema_instrument" {
+			continue
+		}
+		// Skip variables not in the compiled defaults (e.g. unknown startup options
+		// like skip_ndbinfo that should not appear in SHOW VARIABLES output).
+		if _, isKnown := vars[name]; !isKnown {
 			continue
 		}
 		if !globalOnly && !sysVarGlobalOnly[name] && !sysVarBothScope[name] {

--- a/mtrrunner/runner.go
+++ b/mtrrunner/runner.go
@@ -241,6 +241,7 @@ func (r *Runner) RunFile(testPath string) TestResult {
 				"$MYSQL_DUMP":         mysqldumpCmd,
 				"$MYSQL":              mysqlCmd,
 				"$MYSQLADMIN":         mysqladminCmd,
+				"$MYSQLTEST_FILE":     testPath,
 			}
 		}(),
 	}


### PR DESCRIPTION
## Summary

- Add `$MYSQLTEST_FILE` env var to mtrrunner so Perl blocks in test files can locate the test directory via `dirname()`
- Add 6 missing MySQL 8.0 system variables: `activate_all_roles_on_login`, `group_replication_consistency`, `keyring_operations`, `mandatory_roles`, `resultset_metadata`, `sql_require_primary_key`
- Mark `resultset_metadata` and `use_secondary_engine` as session-only variables, excluding them from `performance_schema.global_variables`
- Fix `SET STARTUP` handler: unknown startup options (e.g. `--loose-skip-ndbinfo` from master.opt) no longer pollute `globalScopeVars` / `SHOW VARIABLES` output
- Filter unknown startup options in both loops of `buildVariablesMapScoped`
- Remove `sys_vars/all_vars` from skiplist; update expected result file

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./... -count=1` passes
- [x] `go run ./cmd/mtrrun -test sys_vars/all_vars -force` → Passed: 1, Failed: 0

Closes #268

🤖 Generated with [Claude Code](https://claude.com/claude-code)