### PR TITLE
fix: respect firstmatch switch for IN subqueries under DEPENDENT SUBQUERY

### DIFF
--- a/executor/explain.go
+++ b/executor/explain.go
@@ -4776,11 +4776,19 @@ func (e *Executor) walkForSubqueries(node sqlparser.SQLNode, idCounter *int64, r
 				} else if (correlated || innerHasNoSemijoin) && !existsCanDecorrelate && !inCanDecorrelate {
 					selectType = "DEPENDENT SUBQUERY"
 				} else if inContext || existsCanDecorrelate {
-					if inContext && outerSelectTypeOuter == "DEPENDENT SUBQUERY" && e.isSemijoinEnabled() {
-						// IN subquery inside a DEPENDENT SUBQUERY context: MySQL uses FirstMatch
-						// within the dependent context (the inner table is transitively dependent).
-						// Don't use MATERIALIZED here — produce a DEPENDENT SUBQUERY row merged
-						// at the outer id level instead of a new MATERIALIZED subquery.
+					// IN subquery inside a DEPENDENT SUBQUERY context: MySQL's strategy choice
+					// depends on optimizer_switch:
+					//   - firstmatch=on  → FirstMatch within the dependent context, so the inner
+					//                      table is shown as DEPENDENT SUBQUERY merged at the
+					//                      outer (dependent) id (no MATERIALIZED row).
+					//   - firstmatch=off → MySQL materializes the non-correlated inner subquery
+					//                      once and accesses it via a <subqueryN> placeholder
+					//                      from the dependent parent — falls through to the
+					//                      general MATERIALIZED branch below.
+					// The correlated case is already handled by the
+					// (correlated || innerHasNoSemijoin) branch above.
+					if inContext && outerSelectTypeOuter == "DEPENDENT SUBQUERY" && e.isSemijoinEnabled() &&
+						e.isOptimizerSwitchEnabled("firstmatch") {
 						selectType = "DEPENDENT SUBQUERY"
 					} else if e.isSemijoinEnabled() && outerCanSemijoin {
 						bigTables := false

--- a/executor/explain_select_type_test.go
+++ b/executor/explain_select_type_test.go
@@ -306,3 +306,75 @@ func collectSelectTypes(rows [][]interface{}) []string {
 	}
 	return types
 }
+
+// TestExplainSemijoinMaterialization_Deterministic verifies that the planner
+// produces a stable EXPLAIN strategy choice for non-correlated IN subqueries
+// nested inside a DEPENDENT SUBQUERY.
+//
+// Regression: previously the rule "IN subquery inside DEPENDENT SUBQUERY context
+// → DEPENDENT SUBQUERY" was applied unconditionally, which produced an output
+// missing the MATERIALIZED inner-subquery row when firstmatch=off and
+// materialization=on. See GitHub issue #261.
+func TestExplainSemijoinMaterialization_Deterministic(t *testing.T) {
+	cases := []struct {
+		name     string
+		switches string
+		// expected select_type strings (in id order)
+		want []string
+	}{
+		{
+			name:     "firstmatch_off_materialization_on",
+			switches: "firstmatch=off,materialization=on,subquery_materialization_cost_based=off",
+			want:     []string{"PRIMARY", "DEPENDENT SUBQUERY", "DEPENDENT SUBQUERY", "MATERIALIZED"},
+		},
+		{
+			name:     "firstmatch_on_materialization_on",
+			switches: "firstmatch=on,materialization=on,subquery_materialization_cost_based=off",
+			want:     []string{"PRIMARY", "DEPENDENT SUBQUERY", "DEPENDENT SUBQUERY"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			e := newTestExecutor(t)
+			if _, err := e.Execute("CREATE TABLE t_sjmat(a INT)"); err != nil {
+				t.Fatalf("create: %v", err)
+			}
+			if _, err := e.Execute("INSERT INTO t_sjmat VALUES (0),(1)"); err != nil {
+				t.Fatalf("insert: %v", err)
+			}
+			if _, err := e.Execute("SET optimizer_switch='" + tc.switches + "'"); err != nil {
+				t.Fatalf("set: %v", err)
+			}
+			query := "EXPLAIN SELECT (SELECT MAX(y.a) FROM t_sjmat y WHERE a IN (SELECT a FROM t_sjmat z) AND a < x.a) AS s FROM t_sjmat x"
+			// Run multiple times to detect non-determinism / AST-walk side effects.
+			var prev []string
+			for i := 0; i < 5; i++ {
+				res, err := e.Execute(query)
+				if err != nil {
+					t.Fatalf("explain (run %d): %v", i, err)
+				}
+				got := collectSelectTypes(res.Rows)
+				if i == 0 {
+					prev = got
+				} else if !equalStringSlice(prev, got) {
+					t.Fatalf("flaky EXPLAIN output: run0=%v run%d=%v", prev, i, got)
+				}
+				if !equalStringSlice(got, tc.want) {
+					t.Fatalf("run %d: expected select_type %v, got %v", i, tc.want, got)
+				}
+			}
+		})
+	}
+}
+
+func equalStringSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
Closes #261

## Summary

The semijoin planner in `executor/explain.go` unconditionally forced any IN subquery whose immediate parent is a `DEPENDENT SUBQUERY` to also become `DEPENDENT SUBQUERY`. That was correct only when `firstmatch=on` (FirstMatch keeps the inner table merged at the dependent parent id), but wrong for `firstmatch=off,materialization=on`: MySQL materializes the non-correlated inner subquery once and accesses it through a `<subqueryN>` placeholder at the dependent parent's id, producing an additional `MATERIALIZED` row at a new id.

Fix: gate the DEPENDENT-SUBQUERY override on `firstmatch=on`, so `firstmatch=off` falls through to the general MATERIALIZED / FirstMatch decision branch.

Canonical example (`other/subquery_sj_mat` setup, firstmatch=off + materialization=on):

```sql
EXPLAIN SELECT (SELECT max(y.a)
                FROM t1 y
                WHERE a IN (SELECT a FROM t1 z) AND a < x.a) AS s
FROM t1 x;
```

Before: 3 rows (`PRIMARY`, `DEPENDENT SUBQUERY` x2) — wrong.
After: 4 rows matching MySQL (`PRIMARY`, `DEPENDENT SUBQUERY`, `DEPENDENT SUBQUERY <subquery3>`, `MATERIALIZED z`).

## KPI / regression check

| test | first-diff-line before | after |
| --- | --- | --- |
| `other/subquery_sj_mat` | 3397 | 3586 |
| `other/subquery_sj_mat_bka` | 3398 | 3587 |
| `other/subquery_sj_mat_bka_nixbnl` | 3398 | 3521 |
| `other/subquery_sj_all` (firstmatch=on path) | 4084 | 4084 (no change) |
| `other/opt_hints_subquery` | 115 | 115 (no change) |

Full mtrrun before: passed=1737, failed=316, errors=131.
Full mtrrun after: passed=1737, failed=316, errors=130 (one error→timeout flake elsewhere).
**No pass→fail regressions.**

## Why this PR is draft (test not yet fully passing)

`other/subquery_sj_mat` still fails after this change, but at a much later line and for unrelated reasons:

1. **Line ~3586** — `EXPLAIN FORMAT=TREE` outputs `-> Index range scan on t1 using kp1, with index condition: #` while MySQL produces `-> Index range scan on t1 using kp1` (no condition suffix). This is in the tree formatter (`executor/explain.go:8908`-ish) and is independent of the semijoin/materialization decision.
2. **Line ~4135** — `where a1 IN (select b1 from t2_16 where b1 > '0')` should give `MATERIALIZED t2_16` but our planner picks inline FirstMatch SIMPLE rows. Likely a separate cost-based heuristic mismatch (longblob columns / `subquery_materialization_cost_based=off` interaction).

These are tracked under #261 follow-ups; this PR does not attempt them.

## Determinism

The test was reported as "flaky" but in practice failed at the same line on every run both before and after this change. The new unit test runs the EXPLAIN 5x and asserts the `select_type` sequence is identical across runs to guard against future AST-walk side effects.

## Test plan
- [x] `go build ./...`
- [x] `go test ./... -count=1`
- [x] New unit test `TestExplainSemijoinMaterialization_Deterministic` (firstmatch_off and firstmatch_on subcases)
- [x] `go run ./cmd/mtrrun -suite other` — no regressions
- [x] `go run ./cmd/mtrrun` — no regressions in full suite
- [x] `for i in 1..5; do go run ./cmd/mtrrun -test other/subquery_sj_mat -force; done` — all 5 runs fail at the exact same line (3586), confirming determinism

🤖 Generated with [Claude Code](https://claude.com/claude-code)