### PR TITLE
feat: tighten LOCK TABLES enforcement, fix VIEW/locking-clause semantics (refs #250)

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -3144,6 +3144,10 @@ func (e *Executor) Execute(query string) (res *Result, retErr error) {
 		}
 		return &Result{}, nil
 	case *sqlparser.DropView:
+		// DROP VIEW is not allowed when LOCK TABLES is active (ER_LOCK_OR_ACTIVE_TRANSACTION).
+		if e.tableLockManager != nil && e.tableLockManager.HasLocks(e.connectionID) {
+			return nil, mysqlError(1192, "HY000", "Can't execute the given command because you have active locked tables or an active transaction")
+		}
 		// Remove view definitions
 		for _, name := range s.FromTables {
 			viewName := name.Name.String()
@@ -3176,6 +3180,31 @@ func (e *Executor) Execute(query string) (res *Result, retErr error) {
 		}
 		return e.execRenameTable(s)
 	case *sqlparser.Flush:
+		// FLUSH TABLES WITH READ LOCK: always fails when LOCK TABLES is active (ER_LOCK_OR_ACTIVE_TRANSACTION)
+		if s.WithLock && e.tableLockManager != nil && e.tableLockManager.HasLocks(e.connectionID) {
+			return nil, mysqlError(1192, "HY000", "Can't execute the given command because you have active locked tables or an active transaction")
+		}
+		// FLUSH TABLES (no specific table names) when LOCK TABLES is active:
+		// all locked tables must have WRITE lock; READ-locked tables produce 1099.
+		if !s.WithLock && len(s.TableNames) == 0 && e.tableLockManager != nil && e.tableLockManager.HasLocks(e.connectionID) {
+			locks := e.tableLockManager.GetLocks(e.connectionID)
+			for _, mode := range locks {
+				if mode == "READ" {
+					// Find the table name for the error message
+					for lockedKey, m := range locks {
+						if m == "READ" {
+							parts := strings.SplitN(lockedKey, ".", 2)
+							tblName := lockedKey
+							if len(parts) == 2 {
+								tblName = parts[1]
+							}
+							return nil, mysqlError(1099, "HY000", fmt.Sprintf("Table '%s' was locked with a READ lock and can't be updated", tblName))
+						}
+					}
+					break
+				}
+			}
+		}
 		// FLUSH TABLES WITH READ LOCK: acquire global read lock
 		if s.WithLock && e.globalReadLock != nil {
 			// Implicitly commit any active transaction first (MySQL behavior)
@@ -3211,6 +3240,10 @@ func (e *Executor) Execute(query string) (res *Result, retErr error) {
 		// FLUSH PRIVILEGES: reload grant store from mysql.db and mysql.tables_priv
 		for _, opt := range s.FlushOptions {
 			if strings.HasPrefix(strings.ToUpper(strings.TrimSpace(opt)), "PRIVILEGES") {
+				// When LOCK TABLES is active, FLUSH PRIVILEGES fails because mysql.user is not locked.
+				if e.tableLockManager != nil && e.tableLockManager.HasLocks(e.connectionID) {
+					return nil, mysqlError(1100, "HY000", "Table 'user' was not locked with LOCK TABLES")
+				}
 				if e.grantStore != nil {
 					e.reloadGrantStoreFromStorage()
 				}
@@ -4034,6 +4067,15 @@ func (e *Executor) checkTableLockRestrictions(stmt sqlparser.Statement) error {
 			targetKey := targetDB + "." + targetName
 			introducedByChain[targetKey] = true
 		}
+	case *sqlparser.Select:
+		// When LOCK TABLES is active, every table referenced in FROM must be:
+		// (a) explicitly locked, (b) a temp table, (c) an IS/PS table, or
+		// (d) a base table of an explicitly locked view (implicit prelocking).
+		for _, te := range s.From {
+			if err := e.checkTableExprLocked(te); err != nil {
+				return err
+			}
+		}
 	case *sqlparser.CreateTable:
 		// CREATE TABLE when LOCK TABLES is active: the new table must be locked
 		tableName := s.Table.Name.String()
@@ -4084,6 +4126,72 @@ func (e *Executor) checkTableLockRestrictions(stmt sqlparser.Statement) error {
 				if !e.isTableImplicitlyLockedViaView(dbName, tableName) {
 					return mysqlError(1100, "HY000", fmt.Sprintf("Table '%s' was not locked with LOCK TABLES", tableName))
 				}
+			}
+		}
+	}
+	return nil
+}
+
+// checkTableExprLocked checks if a single TableExpr is accessible under LOCK TABLES.
+// Subqueries (derived tables) and JoinTableExpr are recursively checked.
+// Returns a MySQL error if the table is not accessible.
+func (e *Executor) checkTableExprLocked(te sqlparser.TableExpr) error {
+	switch t := te.(type) {
+	case *sqlparser.AliasedTableExpr:
+		switch inner := t.Expr.(type) {
+		case sqlparser.TableName:
+			tableName := inner.Name.String()
+			dbName := e.CurrentDB
+			if !inner.Qualifier.IsEmpty() {
+				dbName = inner.Qualifier.String()
+			}
+			// "dual" is a synthetic table inserted by the parser for SELECTs without
+			// a real FROM clause (e.g. SELECT @@var). It does not require a lock.
+			if strings.EqualFold(tableName, "dual") {
+				return nil
+			}
+			// Temp tables are always accessible under LOCK TABLES.
+			if e.tempTables != nil && (e.tempTables[tableName] || e.tempTables[strings.ToLower(tableName)]) {
+				return nil
+			}
+			// information_schema, performance_schema, and mysql metadata are always accessible.
+			if strings.EqualFold(dbName, "information_schema") || strings.EqualFold(dbName, "performance_schema") || strings.EqualFold(dbName, "mysql") || strings.EqualFold(dbName, "sys") {
+				return nil
+			}
+			// Check explicit lock (use alias name if present, else table name).
+			checkName := tableName
+			if !t.As.IsEmpty() {
+				checkName = t.As.String()
+			}
+			key := dbName + "." + checkName
+			locked, _ := e.tableLockManager.IsLocked(e.connectionID, key)
+			if locked {
+				return nil
+			}
+			// Also check by base table name (when alias was used for locking but table itself is referenced).
+			keyBase := dbName + "." + tableName
+			lockedBase, _ := e.tableLockManager.IsLocked(e.connectionID, keyBase)
+			if lockedBase {
+				return nil
+			}
+			// Check if the table is a base table of a locked view (implicit prelocking).
+			if e.isTableImplicitlyLockedViaView(dbName, tableName) {
+				return nil
+			}
+			return mysqlError(1100, "HY000", fmt.Sprintf("Table '%s' was not locked with LOCK TABLES", tableName))
+		case *sqlparser.DerivedTable:
+			// Derived tables (subqueries in FROM) don't require an explicit lock.
+			return nil
+		}
+	case *sqlparser.JoinTableExpr:
+		if err := e.checkTableExprLocked(t.LeftExpr); err != nil {
+			return err
+		}
+		return e.checkTableExprLocked(t.RightExpr)
+	case *sqlparser.ParenTableExpr:
+		for _, inner := range t.Exprs {
+			if err := e.checkTableExprLocked(inner); err != nil {
+				return err
 			}
 		}
 	}
@@ -4141,52 +4249,62 @@ func (e *Executor) isTableImplicitlyLockedViaView(dbName, tableName string) bool
 		lockedName := parts[1]
 
 		// Case 1: Locked entity is a view that directly or indirectly references target table.
+		// Look up the view SQL from local map first, then from the shared viewStore.
+		viewSQLForLocked := ""
 		if e.views != nil {
 			for vname, vsql := range e.views {
-				if !strings.EqualFold(vname, lockedName) {
-					continue
+				if strings.EqualFold(vname, lockedName) {
+					viewSQLForLocked = vsql
+					break
 				}
-				// Direct check: parse view SQL for table references
-				parsed, err := e.parser().Parse(vsql)
-				if err == nil {
-					found := false
-					_ = sqlparser.Walk(func(node sqlparser.SQLNode) (kontinue bool, err error) {
-						if tn, ok := node.(sqlparser.TableName); ok {
-							if strings.EqualFold(tn.Name.String(), target) {
-								found = true
-								return false, nil
-							}
+			}
+		}
+		if viewSQLForLocked == "" && e.viewStore != nil {
+			if sql, found := e.viewStore.Lookup(lockedDB, lockedName); found {
+				viewSQLForLocked = sql
+			}
+		}
+		if viewSQLForLocked != "" {
+			vsql := viewSQLForLocked
+			// Direct check: parse view SQL for table references
+			parsed, err := e.parser().Parse(vsql)
+			if err == nil {
+				found := false
+				_ = sqlparser.Walk(func(node sqlparser.SQLNode) (kontinue bool, err error) {
+					if tn, ok := node.(sqlparser.TableName); ok {
+						if strings.EqualFold(tn.Name.String(), target) {
+							found = true
+							return false, nil
 						}
-						return true, nil
-					}, parsed)
-					if found {
-						return true
 					}
-					// Indirect check: view calls a function that references target table.
-					// Collect function names from view SQL and check their bodies.
-					_ = sqlparser.Walk(func(node sqlparser.SQLNode) (kontinue bool, err error) {
-						if fc, ok := node.(*sqlparser.FuncExpr); ok {
-							fnName := fc.Name.Lowered()
-							db2, dbErr := e.Catalog.GetDatabase(lockedDB)
-							if dbErr != nil {
-								db2, _ = e.Catalog.GetDatabase(e.CurrentDB)
-							}
-							if db2 != nil {
-								if fn := db2.GetFunction(fnName); fn != nil {
-									if sqlContainsTable(fn.Body) {
-										found = true
-										return false, nil
-									}
+					return true, nil
+				}, parsed)
+				if found {
+					return true
+				}
+				// Indirect check: view calls a function that references target table.
+				// Collect function names from view SQL and check their bodies.
+				_ = sqlparser.Walk(func(node sqlparser.SQLNode) (kontinue bool, err error) {
+					if fc, ok := node.(*sqlparser.FuncExpr); ok {
+						fnName := fc.Name.Lowered()
+						db2, dbErr := e.Catalog.GetDatabase(lockedDB)
+						if dbErr != nil {
+							db2, _ = e.Catalog.GetDatabase(e.CurrentDB)
+						}
+						if db2 != nil {
+							if fn := db2.GetFunction(fnName); fn != nil {
+								if sqlContainsTable(fn.Body) {
+									found = true
+									return false, nil
 								}
 							}
 						}
-						return true, nil
-					}, parsed)
-					if found {
-						return true
 					}
+					return true, nil
+				}, parsed)
+				if found {
+					return true
 				}
-				break
 			}
 		}
 

--- a/executor/select.go
+++ b/executor/select.go
@@ -188,6 +188,47 @@ func extractJoinUsingCols(expr sqlparser.TableExpr) []string {
 	return nil
 }
 
+// extractNaturalJoinCols collects columns common to both sides of any
+// NATURAL JOIN in the given table expression. NATURAL JOIN merges these
+// columns just like JOIN ... USING(...), so star expansion should output
+// them only once.
+func (e *Executor) extractNaturalJoinCols(expr sqlparser.TableExpr) []string {
+	jt, ok := expr.(*sqlparser.JoinTableExpr)
+	if !ok {
+		return nil
+	}
+	var cols []string
+	// Recurse first so nested NATURAL JOINs are picked up.
+	cols = append(cols, e.extractNaturalJoinCols(jt.LeftExpr)...)
+	cols = append(cols, e.extractNaturalJoinCols(jt.RightExpr)...)
+	if jt.Join == sqlparser.NaturalJoinType || jt.Join == sqlparser.NaturalLeftJoinType {
+		leftDefs, _ := e.collectTableDefsWithAliases(jt.LeftExpr)
+		rightDefs, _ := e.collectTableDefsWithAliases(jt.RightExpr)
+		rightSet := make(map[string]bool)
+		for _, td := range rightDefs {
+			if td == nil {
+				continue
+			}
+			for _, c := range td.Columns {
+				rightSet[strings.ToLower(c.Name)] = true
+			}
+		}
+		seen := make(map[string]bool)
+		for _, td := range leftDefs {
+			if td == nil {
+				continue
+			}
+			for _, c := range td.Columns {
+				if rightSet[strings.ToLower(c.Name)] && !seen[strings.ToLower(c.Name)] {
+					cols = append(cols, c.Name)
+					seen[strings.ToLower(c.Name)] = true
+				}
+			}
+		}
+	}
+	return cols
+}
+
 func (e *Executor) buildFromExpr(expr sqlparser.TableExpr) ([]storage.Row, error) {
 	switch te := expr.(type) {
 	case *sqlparser.AliasedTableExpr:
@@ -380,10 +421,11 @@ func (e *Executor) buildFromExpr(expr sqlparser.TableExpr) ([]storage.Row, error
 				e.userVars["__active_roles"] = savedActiveRoles
 				e.currentQuery = savedCurrentQuery
 				if err != nil {
-					// For INVOKER and DEFINER views, wrap privilege errors into MySQL error 1356
-					// "View references invalid table(s) or column(s) or definer/invoker lacks rights"
-					// Only wrap privilege denial (1142) errors, not table-not-found or other errors.
-					if isMySQLError(err, 1142) || isMySQLError(err, 1356) {
+					// For INVOKER and DEFINER views, wrap privilege errors and missing-table/column
+					// errors into MySQL error 1356 "View references invalid table(s) or column(s) or
+					// definer/invoker lacks rights". This matches MySQL's behavior when a view's
+					// underlying objects are no longer reachable.
+					if isMySQLError(err, 1142) || isMySQLError(err, 1356) || isMySQLError(err, 1146) || isMySQLError(err, 1054) {
 						return nil, mysqlError(1356, "HY000", fmt.Sprintf("View '%s.%s' references invalid table(s) or column(s) or function(s) or definer/invoker of view lack rights to use them", lookupDB, lookupTable))
 					}
 					return nil, err
@@ -2549,7 +2591,15 @@ func (e *Executor) execSelect(stmt *sqlparser.Select) (*Result, error) {
 	// isExplicitLock is true for SELECT ... FOR UPDATE / FOR SHARE / LOCK IN SHARE MODE.
 	// In autocommit mode, explicit locks are released at statement end (MySQL auto-commit behavior).
 	isExplicitLock := stmt.Lock == sqlparser.ForUpdateLock || stmt.Lock == sqlparser.ShareModeLock || stmt.Lock == sqlparser.ForShareLock
-	if needsRowLock && e.rowLockManager != nil && len(allRows) > 0 {
+	// MySQL acquires gap locks for explicit FOR UPDATE / FOR SHARE in REPEATABLE READ
+	// even when the WHERE clause filters out all rows. We don't implement gap locks
+	// in general, but when another connection asks for NOWAIT / SKIP LOCKED we still
+	// need to surface the conflict. As a narrow approximation, when the result set is
+	// empty and the user explicitly asked for FOR UPDATE / FOR SHARE inside an active
+	// transaction, lock the entire scanned range so a subsequent NOWAIT statement
+	// from another connection observes the conflict and fails immediately.
+	emptyResultGapLock := len(allRows) == 0 && isExplicitLock && e.inTransaction && len(preWhereRows) > 0
+	if needsRowLock && e.rowLockManager != nil && (len(allRows) > 0 || emptyResultGapLock) {
 		filteredRows, err := e.acquireRowLocksForSelect(stmt, allRows, preWhereRows)
 		if err != nil {
 			return nil, err
@@ -2804,10 +2854,12 @@ func (e *Executor) execSelect(stmt *sqlparser.Select) (*Result, error) {
 	}
 
 	// Extract USING columns from JOIN for proper star expansion
-	// In MySQL, JOIN ... USING(col) merges the col and shows it only once in SELECT *
+	// In MySQL, JOIN ... USING(col) merges the col and shows it only once in SELECT *.
+	// NATURAL JOIN behaves the same way for columns common to both sides.
 	var joinUsingCols []string
 	if len(stmt.From) > 0 {
 		joinUsingCols = extractJoinUsingCols(stmt.From[0])
+		joinUsingCols = append(joinUsingCols, e.extractNaturalJoinCols(stmt.From[0])...)
 	}
 	// For column name resolution in SELECT *, use preWhereRows when allRows is empty
 	// and no tableDefs are available (e.g. derived tables like FROM (SELECT ...) AS d1).
@@ -6301,7 +6353,12 @@ func (e *Executor) execUnion(stmt *sqlparser.Union) (*Result, error) {
 	}
 
 	// Execute left side directly from AST so nested UNION semantics stay intact.
+	// Temporarily override currentQuery with just the left side's SQL so that
+	// column name extraction (extractRawSelectExprs) doesn't see the UNION clause.
+	savedCurrentQueryForUnion := e.currentQuery
+	e.currentQuery = sqlparser.String(stmt.Left)
 	leftResult, err := e.execTableStmtForUnion(stmt.Left)
+	e.currentQuery = savedCurrentQueryForUnion
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

Implements parts of #250 – LOCK TABLES interaction with VIEW / TRIGGER and the `FOR UPDATE / FOR SHARE` locking clause:

- Reject `FLUSH TABLES WITH READ LOCK` / `FLUSH PRIVILEGES` / `DROP VIEW` while the session already holds explicit `LOCK TABLES` (ER_LOCK_OR_ACTIVE_TRANSACTION / 1100).
- Bare `FLUSH TABLES` under `LOCK TABLES` now reports `ER_TABLE_NOT_LOCKED_FOR_WRITE` for any READ-locked entry.
- Every `SELECT … FROM` table reference is now validated against the active LOCK TABLES set when one is held, with carve-outs for temp tables, the parser-injected `dual`, `information_schema`/`performance_schema`/`mysql`/`sys` metadata, and base tables of an explicitly locked view (implicit prelocking).
- Resolve VIEW bodies through the shared `viewStore` so a `LOCK TABLES v_x WRITE` on a cross-database view still locks the underlying base tables.
- Wrap missing-table / missing-column errors raised while executing a view body into `ER_VIEW_INVALID` (1356), matching MySQL when the underlying object has been dropped.
- `NATURAL JOIN`'s `SELECT *` star expansion now collapses the join columns the same way `JOIN … USING(col)` does.
- `SELECT 1 UNION SELECT 2 FOR UPDATE` now reports a column header of `1` instead of `1 UNION SELECT 2`.
- Narrow gap-lock approximation for empty results: an explicit `FOR UPDATE` / `FOR SHARE` inside a transaction whose `WHERE` matches no rows now locks the scanned range so a concurrent `FOR UPDATE NOWAIT` correctly fails.

## KPI

- `other/locking_clause`: **PASS** (was FAIL, first-diff line 100).
- `other/lock`: still FAIL but first-diff-line moves 29 → 103 (FLUSH WITH READ LOCK + LOCK TABLES on view both fixed; remaining failure is `ER_VIEW_INVALID` after dropping a base table referenced by an explicitly locked view, which depends on more general view validation work).
- `other/tablelock`: continues to PASS.
- `other/archive_bitfield` and the rest of the first ~280 tests in `other` continue to PASS — verified head-to-head against `main`.
- Out-of-scope: full `other` suite cannot be validated end-to-end here because both `main` and this branch hang on a pre-existing test in the 302–320 range (independent of these changes).

## Test plan

- [x] `go build ./...`
- [x] `go test ./... -count=1`
- [x] `go run ./cmd/mtrrun -test other/lock,other/tablelock,other/locking_clause -force`
- [x] `go run ./cmd/mtrrun -test other/archive_bitfield -force`
- [x] `go run ./cmd/mtrrun -suite other -j 1 -max 280` head-to-head with `main` — same pass set, no regressions.
- [x] `go run ./cmd/mtrrun -suite innodb -force` — 88 pass / 1 fail / 187 skip, unchanged from baseline.
- [ ] Full `other` suite run — blocked by pre-existing hang at ~test 305 also reproducible on `main`.

Refs #250