### PR TITLE
fix: respect ICP switch and allow BLOB materialization for IN subqueries (#282)

### DIFF
--- a/executor/explain.go
+++ b/executor/explain.go
@@ -289,13 +289,15 @@ func (e *Executor) explainMultiRows(query string) [][]interface{} {
 														if len(idx.Columns) > 0 && strings.EqualFold(idx.Columns[0], outerJoinColForRef) {
 															// Change range → ref with <subquery>.col as ref
 															// Change range to ref with <subquery>.col as ref.
-															// Also clear "Using index condition" if present: when the ref is
-															// via a materialized subquery, range conditions are applied at the
-															// <subqueryN> placeholder level, not as ICP on this table.
+															// Also clear "Using index condition" / "Using where" if present:
+															// when the ref is via a materialized subquery, range conditions
+															// are applied at the <subqueryN> placeholder level, not as ICP
+															// or attached_condition on this table.
 															simpleRows[i].accessType = "ref"
 															simpleRows[i].ref = subqueryRef + "." + outerJoinColForRef
 															if simpleRows[i].extra != nil {
-																if extraStr := fmt.Sprintf("%v", simpleRows[i].extra); extraStr == "Using index condition" {
+																extraStr := fmt.Sprintf("%v", simpleRows[i].extra)
+																if extraStr == "Using index condition" || extraStr == "Using where" {
 																	simpleRows[i].extra = nil
 																}
 															}
@@ -2056,13 +2058,26 @@ func (e *Executor) explainSelect(sel *sqlparser.Select, idCounter *int64, select
 				}
 			}
 			if extra == nil && !refViaSubquery && (accessInfo.accessType == "ref" || accessInfo.accessType == "range") {
-				if sel.Where != nil {
+				if sel.Where != nil && e.isOptimizerSwitchEnabled("index_condition_pushdown") {
 					wcs := explainExtractWhereConditions(sel.Where.Expr, tblName)
 					for _, wc := range wcs {
 						if wc.isNull || wc.isRange {
 							extra = "Using index condition"
 							break
 						}
+					}
+				}
+			}
+
+			// When ICP is off, range access on indexed column with a WHERE filter
+			// should produce "Using where" instead of "Using index condition".
+			if extra == nil && !refViaSubquery && accessInfo.accessType == "range" &&
+				sel.Where != nil && !e.isOptimizerSwitchEnabled("index_condition_pushdown") {
+				wcs := explainExtractWhereConditions(sel.Where.Expr, tblName)
+				for _, wc := range wcs {
+					if wc.isNull || wc.isRange {
+						extra = "Using where"
+						break
 					}
 				}
 			}
@@ -3062,8 +3077,11 @@ func hasNonINRangeConditionOnCol(expr sqlparser.Expr, colName string) bool {
 // inSubqueryTypesCompatibleForMat returns true if the outer join column type
 // and inner select column type are compatible for materialization (same type class).
 // When types are incompatible (e.g., INT vs DATE), MySQL falls back to DuplicateWeedout.
-// Also returns false when BLOB/TEXT columns are involved, since materialization requires
-// indexing the temp table and BLOBs/TEXTs cannot be indexed.
+//
+// BLOB/TEXT columns: MySQL materializes BLOB/TEXT IN-subqueries (via a hash-based
+// <auto_key> on the temp table) when firstmatch is OFF. When firstmatch is ON,
+// MySQL prefers the inline FirstMatch strategy for BLOB/TEXT columns. So we
+// exclude BLOB/TEXT here only when firstmatch is enabled.
 func (e *Executor) inSubqueryTypesCompatibleForMat(outerSel *sqlparser.Select, inner *sqlparser.Select, subNode *sqlparser.Subquery) bool {
 	if e.Storage == nil || e.Catalog == nil {
 		return true // assume compatible if we can't check
@@ -3112,8 +3130,13 @@ func (e *Executor) inSubqueryTypesCompatibleForMat(outerSel *sqlparser.Select, i
 		}, outerSel.Where.Expr)
 	}
 
-	// For tuple IN, check if any tuple column is BLOB/TEXT → not materializable
+	// For tuple IN: BLOB/TEXT columns are materializable in MySQL when firstmatch is off.
+	// When firstmatch is on, MySQL prefers inline FirstMatch for BLOB/TEXT columns.
 	if len(outerColNames) > 0 {
+		if !e.isOptimizerSwitchEnabled("firstmatch") {
+			return true
+		}
+		// firstmatch=on: exclude tuple IN where any column is BLOB/TEXT.
 		db, err := e.Catalog.GetDatabase(e.CurrentDB)
 		if err != nil {
 			return true
@@ -3133,14 +3156,14 @@ func (e *Executor) inSubqueryTypesCompatibleForMat(outerSel *sqlparser.Select, i
 					for _, outerCol := range outerColNames {
 						if strings.EqualFold(col.Name, outerCol) {
 							if matTypeClass(col.Type) == "blob" {
-								return false // BLOB/TEXT cannot be materialized
+								return false
 							}
 						}
 					}
 				}
 			}
 		}
-		return true // tuple columns are not BLOBs → compatible
+		return true
 	}
 
 	if outerColName == "" {
@@ -3222,11 +3245,12 @@ func (e *Executor) inSubqueryTypesCompatibleForMat(outerSel *sqlparser.Select, i
 		return true // can't determine type, assume compatible
 	}
 
-	// Check if type classes are the same
+	// Check if type classes are the same.
+	// BLOB/TEXT columns: materializable when firstmatch is off; otherwise MySQL
+	// prefers FirstMatch over materialization for BLOB/TEXT IN-subqueries.
 	outerClass := matTypeClass(outerColType)
 	innerClass := matTypeClass(innerColType)
-	// BLOB/TEXT columns cannot be indexed → materialization is not possible
-	if outerClass == "blob" || innerClass == "blob" {
+	if (outerClass == "blob" || innerClass == "blob") && e.isOptimizerSwitchEnabled("firstmatch") {
 		return false
 	}
 	return outerClass == innerClass || outerClass == "other" || innerClass == "other"

--- a/executor/test_longblob_mat_test.go
+++ b/executor/test_longblob_mat_test.go
@@ -1,0 +1,67 @@
+package executor
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/myuon/mylite/catalog"
+	"github.com/myuon/mylite/storage"
+)
+
+// TestLongblobMaterialized tests subquery_sj_mat line ~4135 case:
+// where a1 IN (select b1 from t2_16 where b1 > '0')
+// Expected: MATERIALIZED t2_16 (1 row)
+// Actual (bug): inline FirstMatch SIMPLE rows
+func TestLongblobMaterialized(t *testing.T) {
+	cat := catalog.New()
+	store := storage.NewEngine()
+	e := New(cat, store)
+	if _, err := e.Execute("CREATE DATABASE IF NOT EXISTS test"); err != nil {
+		t.Fatalf("create db: %v", err)
+	}
+	e.CurrentDB = "test"
+
+	cmds := []string{
+		"SET optimizer_switch='semijoin=on,materialization=on'",
+		"SET optimizer_switch='loosescan=off'",
+		"SET optimizer_switch='firstmatch=off'",
+		"SET optimizer_switch='duplicateweedout=off'",
+		"SET optimizer_switch='index_condition_pushdown=off'",
+		"SET optimizer_switch='mrr=off'",
+		"CREATE TABLE t1_16 (a1 blob(16), a2 blob(16))",
+		"CREATE TABLE t2_16 (b1 blob(16), b2 blob(16))",
+		"INSERT INTO t1_16 VALUES ('1 - 00xxxxxxxxxxxx', '2 - 00xxxxxxxxxxxx')",
+		"INSERT INTO t1_16 VALUES ('1 - 01xxxxxxxxxxxx', '2 - 01xxxxxxxxxxxx')",
+		"INSERT INTO t1_16 VALUES ('1 - 02xxxxxxxxxxxx', '2 - 02xxxxxxxxxxxx')",
+		"INSERT INTO t2_16 VALUES ('1 - 01xxxxxxxxxxxx', '2 - 01xxxxxxxxxxxx')",
+		"INSERT INTO t2_16 VALUES ('1 - 02xxxxxxxxxxxx', '2 - 02xxxxxxxxxxxx')",
+		"INSERT INTO t2_16 VALUES ('1 - 03xxxxxxxxxxxx', '2 - 03xxxxxxxxxxxx')",
+	}
+	for _, cmd := range cmds {
+		if _, err := e.Execute(cmd); err != nil {
+			t.Fatalf("Setup %q failed: %v", cmd, err)
+		}
+	}
+
+	fmt.Println("=== explain select left(a1,7), left(a2,7) from t1_16 where a1 in (select b1 from t2_16 where b1 > '0') ===")
+	res, err := e.Execute("EXPLAIN SELECT LEFT(a1,7), LEFT(a2,7) FROM t1_16 WHERE a1 IN (SELECT b1 FROM t2_16 WHERE b1 > '0')")
+	if err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+	for _, row := range res.Rows {
+		fmt.Printf("  id=%v, selectType=%v, table=%v, type=%v, extra=%v\n", row[0], row[1], row[2], row[4], row[11])
+	}
+	// Expected: 3 rows: <subquery2> (ALL), t1_16 (ALL), t2_16 (MATERIALIZED ALL)
+	if len(res.Rows) != 3 {
+		t.Errorf("Expected 3 rows, got %d", len(res.Rows))
+	}
+	mat := false
+	for _, row := range res.Rows {
+		if fmt.Sprintf("%v", row[1]) == "MATERIALIZED" {
+			mat = true
+		}
+	}
+	if !mat {
+		t.Errorf("Expected t2_16 to be MATERIALIZED, got rows above")
+	}
+}


### PR DESCRIPTION
## Summary
Two independent fixes for `other/subquery_sj_mat` (and sister tests), addressing the bugs flagged in #282 / PR #281's "draft" notes.

### Bug 1: EXPLAIN respects `index_condition_pushdown=off`
When the optimizer switch `index_condition_pushdown=off` was set, the engine still emitted `Using index condition` (and the matching `with index condition: ...` suffix in TREE / `index_condition` in JSON). Now the ICP branch is gated on the switch, and for range access without ICP we surface the filter as plain `Using where`. The post-process that rewrites range -> ref via `<subqueryN>` also clears the leftover `Using where` so the JSON formatter does not append a stray `attached_condition` for the probe table.

### Bug 2: BLOB/TEXT IN-subqueries with firstmatch=off can materialize
`inSubqueryTypesCompatibleForMat` previously rejected any IN whose join column was BLOB/TEXT, forcing the planner into FirstMatch even when `firstmatch=off`. MySQL actually materializes BLOB IN-subqueries via a hash-based `<auto_key>` when only materialization is enabled, so we now allow materialization for BLOB columns when `firstmatch=off` and keep the BLOB exclusion only when `firstmatch=on` (sister test `subquery_sj_all` keeps preferring inline FirstMatch).

## KPI / regression check (mtrrun head-to-head vs main, full suite)

| test | first-diff-line before | after |
| --- | --- | --- |
| `other/subquery_sj_mat` | 3586 | 5932 |
| `other/subquery_sj_mat_bka` | 3587 | 5933 |
| `other/subquery_sj_mat_bka_nixbnl` | 3521 | 3521 (no change) |
| `other/subquery_sj_all` (firstmatch=on path) | 4084 | 4084 (no change) |
| `other/opt_hints_subquery` | 115 | 115 (no change) |

- Full mtrrun before: passed=1735, failed=319, errors=130.
- Full mtrrun after: passed=1735, failed=318, errors=131 (one fail->error flake on `sp-threads`, unrelated).
- **No pass -> fail/error regressions.**

## Why the test still does not fully pass
After both fixes the failure shifts to a result-data mismatch around line 5932 (different ordering of `int_key`/`int_nokey` rows in a later subquery) which is outside the scope of #282. This PR closes the two bugs called out in the issue; remaining failures are tracked separately.

## Test plan
- [x] `go build ./...`
- [x] `go test ./... -count=1`
- [x] New unit test `TestLongblobMaterialized` exercises Bug 2.
- [x] `go run ./cmd/mtrrun -force` (full suite) - no pass->fail regressions.
- [x] `go run ./cmd/mtrrun -test other/subquery_sj_mat,other/subquery_sj_mat_bka,other/subquery_sj_mat_bka_nixbnl,other/subquery_sj_all,other/opt_hints_subquery -force` - sister tests unaffected.

Closes #282

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>