### PR TITLE
fix: coerce DATETIME columns to numeric in boolean context

### DIFF
--- a/executor/datetime_boolean_test.go
+++ b/executor/datetime_boolean_test.go
@@ -1,0 +1,83 @@
+package executor
+
+import (
+	"testing"
+
+	"github.com/myuon/mylite/catalog"
+	"github.com/myuon/mylite/storage"
+)
+
+// TestDatetimeColumnInBooleanContext exercises MySQL's coercion rule for
+// DATETIME values used directly as boolean predicates (e.g. JOIN ... ON dt_col,
+// WHERE dt_col). The numeric form of a datetime is its YYYYMMDDhhmmss value,
+// so '0000-00-00 00:00:00' is falsy and any real datetime is truthy.
+//
+// Regression for BUG#38075 / GH-285: a LEFT JOIN ... ON it2.datetime_key
+// previously matched every row because the bare column reference was treated
+// as truthy regardless of its value, producing a Cartesian product.
+func TestDatetimeColumnInBooleanContext(t *testing.T) {
+	cat := catalog.New()
+	store := storage.NewEngine()
+	e := New(cat, store)
+	if _, err := e.Execute("CREATE DATABASE IF NOT EXISTS test"); err != nil {
+		t.Fatalf("create db: %v", err)
+	}
+	e.CurrentDB = "test"
+	// Permissive SQL mode so '0000-00-00 00:00:00' inserts.
+	e.sqlMode = ""
+	if _, err := e.Execute("CREATE TABLE it2 (int_key int NOT NULL, datetime_key datetime NOT NULL)"); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	if _, err := e.Execute(`INSERT INTO it2 VALUES
+        (5,'2002-04-10 14:25:30'),
+        (0,'0000-00-00 00:00:00'),
+        (4,'0000-00-00 00:00:00'),
+        (3,'2006-02-14 18:06:35')`); err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+
+	rs, err := e.Execute("SELECT int_key FROM it2 WHERE datetime_key ORDER BY int_key")
+	if err != nil {
+		t.Fatalf("select: %v", err)
+	}
+	got := []string{}
+	for _, row := range rs.Rows {
+		got = append(got, formatVal(row[0]))
+	}
+	want := []string{"3", "5"}
+	if len(got) != len(want) {
+		t.Fatalf("expected %v rows, got %v: %v", len(want), len(got), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("row %d: got %q want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func formatVal(v interface{}) string {
+	switch x := v.(type) {
+	case int64:
+		if x < 0 {
+			return "-" + formatPositiveInt(uint64(-x))
+		}
+		return formatPositiveInt(uint64(x))
+	case string:
+		return x
+	}
+	return ""
+}
+
+func formatPositiveInt(u uint64) string {
+	if u == 0 {
+		return "0"
+	}
+	var b [20]byte
+	i := len(b)
+	for u > 0 {
+		i--
+		b[i] = byte('0' + u%10)
+		u /= 10
+	}
+	return string(b[i:])
+}

--- a/executor/expr_eval.go
+++ b/executor/expr_eval.go
@@ -7780,7 +7780,19 @@ func (e *Executor) evalWhere(expr sqlparser.Expr, row storage.Row) (bool, error)
 	case DivisionResult:
 		return x.Value != 0, nil
 	case string:
-		return strings.TrimSpace(x) != "" && x != "0", nil
+		s := strings.TrimSpace(x)
+		if s == "" || s == "0" {
+			return false, nil
+		}
+		// DATETIME/DATE/TIME values are stored as strings in mylite.
+		// In MySQL, when a typed temporal value is used in a boolean context
+		// (e.g. JOIN ... ON it2.datetime_key, WHERE date_col), it is coerced
+		// to its numeric representation: '2002-04-10 14:25:30' -> 20020410142530,
+		// '0000-00-00 00:00:00' -> 0 (falsy).
+		if isTemporalLikeString(s) {
+			return toDateTimeStringAsFloat(s) != 0, nil
+		}
+		return true, nil
 	default:
 		return toInt64(val) != 0, nil
 	}

--- a/executor/typeutil.go
+++ b/executor/typeutil.go
@@ -551,7 +551,73 @@ func isTruthy(v interface{}) bool {
 	case AvgResult:
 		return val.Value != 0
 	case string:
-		return val != "" && val != "0"
+		if val == "" || val == "0" {
+			return false
+		}
+		// DATETIME/DATE/TIME values are stored as strings in mylite.
+		// In MySQL, when a typed temporal value is used in a boolean context,
+		// it is coerced to its numeric representation (e.g.,
+		// '2002-04-10 14:25:30' -> 20020410142530, '0000-00-00 00:00:00' -> 0).
+		// Detect the temporal string format and treat zero values as falsy.
+		if isTemporalLikeString(val) {
+			return toDateTimeStringAsFloat(val) != 0
+		}
+		return true
+	}
+	return false
+}
+
+// isTemporalLikeString reports whether s looks like a DATE, DATETIME or TIME literal.
+// Used by isTruthy to detect when string values that originate from temporal
+// columns should be coerced to their numeric form for boolean evaluation.
+func isTemporalLikeString(s string) bool {
+	// TIME format: [-]HH:MM:SS[.frac]
+	if strings.Count(s, ":") == 2 {
+		// strip optional leading '-' and optional fractional part
+		t := s
+		if strings.HasPrefix(t, "-") {
+			t = t[1:]
+		}
+		if dot := strings.IndexByte(t, '.'); dot >= 0 {
+			t = t[:dot]
+		}
+		parts := strings.Split(t, ":")
+		if len(parts) == 3 && len(parts[0]) > 0 && len(parts[1]) > 0 && len(parts[2]) > 0 {
+			if _, err := strconv.Atoi(parts[0]); err == nil {
+				if _, err := strconv.Atoi(parts[1]); err == nil {
+					if _, err := strconv.Atoi(parts[2]); err == nil {
+						return true
+					}
+				}
+			}
+		}
+	}
+	// DATE: YYYY-MM-DD ; DATETIME: YYYY-MM-DD HH:MM:SS[.frac]
+	if len(s) >= 10 && s[4] == '-' && s[7] == '-' {
+		if _, err := strconv.Atoi(s[0:4]); err != nil {
+			return false
+		}
+		if _, err := strconv.Atoi(s[5:7]); err != nil {
+			return false
+		}
+		if _, err := strconv.Atoi(s[8:10]); err != nil {
+			return false
+		}
+		if len(s) == 10 {
+			return true
+		}
+		if len(s) >= 19 && s[10] == ' ' && s[13] == ':' && s[16] == ':' {
+			if _, err := strconv.Atoi(s[11:13]); err != nil {
+				return false
+			}
+			if _, err := strconv.Atoi(s[14:16]); err != nil {
+				return false
+			}
+			if _, err := strconv.Atoi(s[17:19]); err != nil {
+				return false
+			}
+			return true
+		}
 	}
 	return false
 }


### PR DESCRIPTION
Closes #285

## Summary
A bare temporal column reference used as a boolean predicate (e.g. `JOIN ... ON it2.datetime_key`, `WHERE date_col`) was always treated as truthy because `isTruthy()` and the `evalWhere()` default fallback only filtered out `""` and `"0"` strings. MySQL coerces a typed temporal value to its numeric form before evaluating boolean truthiness:

- `'2002-04-10 14:25:30'` -> `20020410142530` (truthy)
- `'0000-00-00 00:00:00'` -> `0` (falsy)

`other/subquery_sj_mat` line 5932 (BUG#38075's reproducer) hits this path:
```sql
SELECT int_key FROM ot1
WHERE int_nokey IN (SELECT it2.int_key
                    FROM it1 LEFT JOIN it2 ON it2.datetime_key);
```
The zero-datetime rows of `it2` should drop the right side to NULL via LEFT JOIN no-match handling, but mylite produced a full Cartesian product, returning extra `3` and `4` values that should not match `it1.int_nokey`.

## Fix
- New `isTemporalLikeString(s)` helper detects `YYYY-MM-DD`, `YYYY-MM-DD HH:MM:SS[.frac]`, and `[-]HH:MM:SS[.frac]` formats.
- `isTruthy()` (used by `IS TRUE` / `IS FALSE` / `NOT`) coerces temporal-looking strings via `toDateTimeStringAsFloat()` before comparing against zero.
- The default-case branch of `evalWhere()` (used for raw column refs in `JOIN ON` / `WHERE` predicates) does the same coercion.

Non-temporal strings (`"abc"`, `"1.5"`, etc.) fall through unchanged, so the existing string truthiness rule (`s != "" && s != "0"`) is preserved.

## KPI / regression check (mtrrun -test, first-diff-line)

| test | first-diff-line before | after |
| --- | --- | --- |
| `other/subquery_sj_mat` | 5932 | 5969 (+37) |
| `other/subquery_sj_mat_bka` | 5933 | 5970 (+37) |
| `other/subquery_sj_mat_bka_nixbnl` | 3521 | 3521 (separate earlier diff) |
| `other/subquery_sj_all` | 4084 | 4084 (no regression) |
| `other/opt_hints_subquery` | 115 | 115 (no regression) |

## Full mtrrun head-to-head
- Main: `passed=1735, failed=319, skipped=1161, errors=130`
- This branch: `passed=1735, failed=319, skipped=1161, errors=130`
- `diff` of `(status, name)` sets is empty — **no pass->fail/error regressions**.

The remaining failures in `subquery_sj_mat` after this PR are unrelated EXPLAIN row-ordering issues (SIMPLE vs MATERIALIZED order at line 5969); they are tracked separately under #285's outstanding work.

## Test plan
- [x] `go build ./...`
- [x] `go test ./... -count=1`
- [x] New unit test `TestDatetimeColumnInBooleanContext`
- [x] `go run ./cmd/mtrrun -test other/subquery_sj_mat,other/subquery_sj_mat_bka,other/subquery_sj_mat_bka_nixbnl,other/subquery_sj_all,other/opt_hints_subquery -force` — KPI improvements above, no regressions
- [x] `go run ./cmd/mtrrun -force` (full suite) — pass/fail set identical to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)