### PR TITLE
feat: implement ALTER TABLE ADD COLUMN ALGORITHM=INSTANT

### DIFF
--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -42,6 +42,8 @@ type ColumnDef struct {
 	Collation               string // column-level collation override; empty means inherit table default
 	CharsetExplicit         bool   // true when charset was explicitly specified by user (not inferred from collation or table default)
 	SRIDConstraint          *uint32 // SRID constraint for spatial columns; nil means no constraint
+	IsInstantAdded          bool    // true when this column was added by ALTER TABLE ... ADD COLUMN with INSTANT semantics
+	InstantDefault          string  // hex-encoded InnoDB row-format representation of the default for instant-added columns
 }
 
 // IndexDef represents an index definition.
@@ -87,6 +89,7 @@ type TableDef struct {
 	PartitionCount        int                 // PARTITIONS N (0 = unset/implicit)
 	PartitionSubpartition *PartitionSubpart   // subpartition definition (nil if none)
 	PartitionDefs         []PartitionDef      // individual PARTITION definitions
+	InstantCols           int                 // number of columns at the time the first INSTANT ADD COLUMN was applied (0 = no instant cols)
 }
 
 // PartitionSubpart holds the SUBPARTITION BY clause details.

--- a/executor/ddl.go
+++ b/executor/ddl.go
@@ -3079,6 +3079,69 @@ func implicitDefaultForType(colType string) interface{} {
 	}
 }
 
+// encodeInstantDefault encodes the DEFAULT value of an instant-added column
+// in InnoDB's on-disk byte format and returns it as a lowercase hex string.
+// Returns "" when no default is meaningful (e.g. nullable column with no
+// explicit default — InnoDB stores NULL as the default, surfaced as the
+// string "NULL" in INFORMATION_SCHEMA.INNODB_COLUMNS.DEFAULT_VALUE).
+func encodeInstantDefault(col catalog.ColumnDef) string {
+	if col.Default == nil {
+		// Nullable column without explicit default: caller treats as NULL.
+		return ""
+	}
+	defStr := *col.Default
+	upper := strings.ToUpper(strings.TrimSpace(col.Type))
+	base := upper
+	if i := strings.IndexByte(base, '('); i >= 0 {
+		base = strings.TrimSpace(base[:i])
+	}
+	isUnsigned := strings.Contains(upper, "UNSIGNED")
+	switch base {
+	case "TINYINT", "SMALLINT", "MEDIUMINT", "INT", "INTEGER", "BIGINT":
+		var width int
+		switch base {
+		case "TINYINT":
+			width = 1
+		case "SMALLINT":
+			width = 2
+		case "MEDIUMINT":
+			width = 3
+		case "INT", "INTEGER":
+			width = 4
+		case "BIGINT":
+			width = 8
+		}
+		var n uint64
+		if isUnsigned {
+			v, err := strconv.ParseUint(strings.TrimSpace(defStr), 10, 64)
+			if err != nil {
+				return ""
+			}
+			n = v
+		} else {
+			v, err := strconv.ParseInt(strings.TrimSpace(defStr), 10, 64)
+			if err != nil {
+				return ""
+			}
+			// InnoDB flips the sign bit of signed integers for big-endian sortability.
+			signBit := uint64(1) << (uint(width)*8 - 1)
+			n = uint64(v) ^ signBit
+			// Mask to width
+			if width < 8 {
+				n &= (uint64(1) << (uint(width) * 8)) - 1
+			}
+		}
+		buf := make([]byte, width)
+		for i := width - 1; i >= 0; i-- {
+			buf[i] = byte(n & 0xff)
+			n >>= 8
+		}
+		return fmt.Sprintf("%x", buf)
+	}
+	// For non-integer types we don't yet produce the InnoDB hex encoding.
+	return ""
+}
+
 func columnDefFromAST(col *sqlparser.ColumnDefinition) catalog.ColumnDef {
 	colDef := catalog.ColumnDef{
 		Name:     col.Name.String(),
@@ -3456,17 +3519,29 @@ func (e *Executor) execAlterTable(stmt *sqlparser.AlterTable) (*Result, error) {
 
 	// Pre-check: ALGORITHM=INPLACE rejection for operations that require COPY
 	alterIsInplace := false
+	alterIsInstant := false
 	{
 		isInplace := false
+		isInstant := false
 		hasStoredGcolAdd := false
+		hasNonAddOp := false   // any op other than ADD COLUMN (rejects INSTANT)
+		hasPKChange := false   // PK alteration (rejects INSTANT)
+		hasFirstOrAfter := false // ADD COLUMN with FIRST/AFTER position (INSTANT requires last)
 		for _, opt := range stmt.AlterOptions {
 			switch av := opt.(type) {
 			case sqlparser.AlgorithmValue:
-				if strings.EqualFold(string(av), "INPLACE") {
+				switch strings.ToUpper(string(av)) {
+				case "INPLACE":
 					isInplace = true
 					alterIsInplace = true
+				case "INSTANT":
+					isInstant = true
+					alterIsInstant = true
 				}
 			case *sqlparser.AddColumns:
+				if av.First || av.After != nil {
+					hasFirstOrAfter = true
+				}
 				for _, col := range av.Columns {
 					if col.Type.Options != nil && col.Type.Options.As != nil {
 						colTypeStr := strings.ToUpper(sqlparser.String(col.Type))
@@ -3474,7 +3549,26 @@ func (e *Executor) execAlterTable(stmt *sqlparser.AlterTable) (*Result, error) {
 							hasStoredGcolAdd = true
 						}
 					}
+					// ADD COLUMN that is itself a primary key inhibits INSTANT.
+					if col.Type.Options != nil && col.Type.Options.KeyOpt == sqlparser.ColKeyPrimary {
+						hasPKChange = true
+					}
 				}
+			case *sqlparser.DropColumn, *sqlparser.ModifyColumn, *sqlparser.ChangeColumn,
+				*sqlparser.RenameColumn, *sqlparser.AlterColumn:
+				hasNonAddOp = true
+			case *sqlparser.AddIndexDefinition:
+				// ADD PRIMARY KEY blocks INSTANT.
+				if av.IndexDefinition != nil && av.IndexDefinition.Info != nil &&
+					av.IndexDefinition.Info.Type == sqlparser.IndexTypePrimary {
+					hasPKChange = true
+				}
+				hasNonAddOp = true
+			case *sqlparser.DropKey:
+				if av.Type == sqlparser.PrimaryKeyType {
+					hasPKChange = true
+				}
+				hasNonAddOp = true
 			}
 		}
 		if isInplace && hasStoredGcolAdd {
@@ -3485,7 +3579,21 @@ func (e *Executor) execAlterTable(stmt *sqlparser.AlterTable) (*Result, error) {
 		if isInplace && withValidation {
 			return nil, mysqlError(1846, "0A000", "ALGORITHM=INPLACE is not supported for this operation. Try ALGORITHM=COPY.")
 		}
+		// ALGORITHM=INSTANT only supports ADD COLUMN (at the end of the table) and a few other ops.
+		// Reject when accompanied by DROP/MODIFY/CHANGE/PK alteration.
+		if isInstant {
+			if hasNonAddOp || hasPKChange {
+				return nil, mysqlError(1845, "0A000", "ALGORITHM=INSTANT is not supported for this operation. Try ALGORITHM=INPLACE.")
+			}
+			if hasFirstOrAfter {
+				return nil, mysqlError(1845, "0A000", "ALGORITHM=INSTANT is not supported. Reason: Cannot add a column at this position. Try ALGORITHM=INPLACE.")
+			}
+			if hasStoredGcolAdd {
+				return nil, mysqlError(1845, "0A000", "ALGORITHM=INSTANT is not supported. Reason: Cannot add a stored generated column. Try ALGORITHM=INPLACE.")
+			}
+		}
 	}
+	_ = alterIsInstant
 
 	// Pre-check: CSV engine requires all columns to be NOT NULL (ER_CHECK_NOT_IMPLEMENTED = 1178)
 	// This applies to ADD COLUMN, MODIFY COLUMN, and CHANGE COLUMN on CSV tables.
@@ -3820,11 +3928,49 @@ func (e *Executor) execAlterTable(stmt *sqlparser.AlterTable) (*Result, error) {
 						}
 					}
 				}
+				// Determine whether this ADD COLUMN should be treated as INSTANT.
+				// MySQL 8.0.29+ defaults to INSTANT when possible. We treat it as
+				// INSTANT either when ALGORITHM=INSTANT was explicitly requested,
+				// or by default for plain ADD COLUMN at the end of the table on
+				// non-MyISAM/CSV tables (mirrors MySQL's "instant by default").
+				if !alterIsInplace {
+					instantEligible := position == "" && !colDef.PrimaryKey
+					if instantEligible {
+						genExprPre := generatedColumnExpr(colDef.Type)
+						if genExprPre != "" && strings.Contains(strings.ToUpper(colDef.Type), "STORED") {
+							instantEligible = false
+						}
+						if colDef.AutoIncrement {
+							instantEligible = false
+						}
+					}
+					if instantEligible {
+						colDef.IsInstantAdded = true
+						colDef.InstantDefault = encodeInstantDefault(colDef)
+					}
+				}
 				if addErr := db.AddColumnAt(tableName, colDef, position, afterCol); addErr != nil {
 					if strings.Contains(addErr.Error(), "already exists") {
 						return nil, mysqlError(1060, "42S21", fmt.Sprintf("Duplicate column name '%s'", colDef.Name))
 					}
 					return nil, addErr
+				}
+				// Update InstantCols on the table when the first INSTANT-added
+				// column is recorded (snapshot of column count before this add).
+				if colDef.IsInstantAdded {
+					if tableDef, tdErr := db.GetTable(tableName); tdErr == nil && tableDef != nil {
+						if tableDef.InstantCols == 0 {
+							// Set to the number of "regular" columns just before this add
+							// (i.e. columns that existed prior to this INSTANT).
+							n := 0
+							for _, c := range tableDef.Columns {
+								if !c.IsInstantAdded {
+									n++
+								}
+							}
+							tableDef.InstantCols = n
+						}
+					}
 				}
 				// If the new column is a primary key (inline KEY or PRIMARY KEY), set it
 				if colDef.PrimaryKey {
@@ -3913,6 +4059,35 @@ func (e *Executor) execAlterTable(stmt *sqlparser.AlterTable) (*Result, error) {
 
 		case *sqlparser.ModifyColumn:
 			colDef := columnDefFromAST(op.NewColDefinition)
+			// MODIFY COLUMN cannot make a primary-key column explicitly nullable.
+			// Only reject when NULL was explicitly written in the definition; if
+			// the user omitted it, MySQL silently keeps the column NOT NULL.
+			// MySQL: ER_PRIMARY_CANT_HAVE_NULL (1171, SQLSTATE 42000).
+			if op.NewColDefinition.Type.Options != nil &&
+				op.NewColDefinition.Type.Options.Null != nil &&
+				*op.NewColDefinition.Type.Options.Null {
+				if modDef, _ := db.GetTable(tableName); modDef != nil {
+					targetName := strings.ToLower(op.NewColDefinition.Name.String())
+					for _, pk := range modDef.PrimaryKey {
+						if strings.ToLower(stripPrefixLengthFromCol(pk)) == targetName {
+							return nil, mysqlError(1171, "42000", "All parts of a PRIMARY KEY must be NOT NULL; if you need NULL in a key, use UNIQUE instead")
+						}
+					}
+				}
+			}
+			// If the target column is part of the primary key and NULL was not
+			// explicitly requested, silently keep it NOT NULL (MySQL behavior).
+			if colDef.Nullable {
+				if modDef, _ := db.GetTable(tableName); modDef != nil {
+					targetName := strings.ToLower(op.NewColDefinition.Name.String())
+					for _, pk := range modDef.PrimaryKey {
+						if strings.ToLower(stripPrefixLengthFromCol(pk)) == targetName {
+							colDef.Nullable = false
+							break
+						}
+					}
+				}
+			}
 			// Extract and validate SRID constraint for MODIFY COLUMN.
 			if sridErr := e.alterApplySRID(op.NewColDefinition, &colDef); sridErr != nil {
 				return nil, sridErr
@@ -4048,6 +4223,34 @@ func (e *Executor) execAlterTable(stmt *sqlparser.AlterTable) (*Result, error) {
 		case *sqlparser.ChangeColumn:
 			oldName := op.OldColumn.Name.String()
 			colDef := columnDefFromAST(op.NewColDefinition)
+			// CHANGE COLUMN cannot make a primary-key column explicitly nullable.
+			// Only reject when NULL was explicitly written in the definition; if
+			// the user omitted it, MySQL silently keeps the column NOT NULL.
+			if op.NewColDefinition.Type.Options != nil &&
+				op.NewColDefinition.Type.Options.Null != nil &&
+				*op.NewColDefinition.Type.Options.Null {
+				if chgDef, _ := db.GetTable(tableName); chgDef != nil {
+					targetName := strings.ToLower(oldName)
+					for _, pk := range chgDef.PrimaryKey {
+						if strings.ToLower(stripPrefixLengthFromCol(pk)) == targetName {
+							return nil, mysqlError(1171, "42000", "All parts of a PRIMARY KEY must be NOT NULL; if you need NULL in a key, use UNIQUE instead")
+						}
+					}
+				}
+			}
+			// If the target column is part of the primary key and NULL was not
+			// explicitly requested, silently keep it NOT NULL (MySQL behavior).
+			if colDef.Nullable {
+				if chgDef, _ := db.GetTable(tableName); chgDef != nil {
+					targetName := strings.ToLower(oldName)
+					for _, pk := range chgDef.PrimaryKey {
+						if strings.ToLower(stripPrefixLengthFromCol(pk)) == targetName {
+							colDef.Nullable = false
+							break
+						}
+					}
+				}
+			}
 			// Extract and validate SRID constraint for CHANGE COLUMN.
 			if sridErr := e.alterApplySRID(op.NewColDefinition, &colDef); sridErr != nil {
 				return nil, sridErr

--- a/executor/information_schema.go
+++ b/executor/information_schema.go
@@ -87,10 +87,10 @@ var infoSchemaColumnOrder = map[string][]string{
 	"statistics":               {"TABLE_CATALOG", "TABLE_SCHEMA", "TABLE_NAME", "NON_UNIQUE", "INDEX_SCHEMA", "INDEX_NAME", "SEQ_IN_INDEX", "COLUMN_NAME", "COLLATION", "CARDINALITY", "SUB_PART", "PACKED", "NULLABLE", "INDEX_TYPE", "COMMENT", "INDEX_COMMENT", "IS_VISIBLE", "EXPRESSION"},
 	"column_statistics":        {"SCHEMA_NAME", "TABLE_NAME", "COLUMN_NAME", "HISTOGRAM"},
 	"engines":                  {"ENGINE", "SUPPORT", "COMMENT", "TRANSACTIONS", "XA", "SAVEPOINTS"},
-	"innodb_tables":            {"TABLE_ID", "NAME", "SPACE", "FLAG", "N_COLS", "ROW_FORMAT", "ZIP_PAGE_SIZE", "SPACE_TYPE"},
+	"innodb_tables":            {"TABLE_ID", "NAME", "FLAG", "N_COLS", "SPACE", "ROW_FORMAT", "ZIP_PAGE_SIZE", "SPACE_TYPE", "INSTANT_COLS"},
 	"innodb_tablespaces":       {"SPACE", "NAME", "ROW_FORMAT", "PAGE_SIZE", "ZIP_PAGE_SIZE", "SPACE_TYPE"},
 	"innodb_datafiles":         {"SPACE", "PATH"},
-	"innodb_columns":           {"TABLE_ID", "NAME", "POS", "MTYPE", "PRTYPE", "LEN"},
+	"innodb_columns":           {"TABLE_ID", "NAME", "POS", "MTYPE", "PRTYPE", "LEN", "HAS_DEFAULT", "DEFAULT_VALUE"},
 	"innodb_virtual":           {"TABLE_ID", "POS", "BASE_POS"},
 	"innodb_foreign":           {"ID", "FOR_NAME", "REF_NAME", "N_COLS", "TYPE"},
 	"innodb_metrics":           {"NAME", "COUNT", "TYPE", "STATUS", "SUBSYSTEM", "COMMENT"},
@@ -546,7 +546,6 @@ var emptyStubTables = map[string]bool{
 // singleRowStubTables maps table names to their single stub row definition.
 // These are InnoDB metadata tables that return one row of zero/empty values.
 var singleRowStubTables = map[string]storage.Row{
-	"innodb_columns":        {"TABLE_ID": int64(0), "NAME": "", "POS": int64(0), "MTYPE": int64(0), "PRTYPE": int64(0), "LEN": int64(0)},
 	"innodb_virtual":        {"TABLE_ID": int64(0), "POS": int64(0), "BASE_POS": int64(0)},
 	"innodb_buffer_page_lru": {"POOL_ID": int64(0), "LRU_POSITION": int64(0), "SPACE": int64(0), "PAGE_NUMBER": int64(0)},
 	"innodb_buffer_pool_stats": {"POOL_ID": int64(0), "POOL_SIZE": int64(0)},
@@ -776,6 +775,8 @@ func (e *Executor) buildInformationSchemaRows(tableName, alias string) ([]storag
 		rawRows = e.infoSchemaInnoDBMetrics()
 	case "innodb_indexes":
 		rawRows = e.infoSchemaInnoDBIndexes()
+	case "innodb_columns":
+		rawRows = e.infoSchemaInnoDBColumns()
 	case "innodb_cached_indexes":
 		rawRows = e.infoSchemaInnoDBCachedIndexes()
 	case "innodb_foreign":
@@ -1284,6 +1285,7 @@ func (e *Executor) infoSchemaInnoDBTables() []storage.Row {
 				"ROW_FORMAT":    "Dynamic",
 				"ZIP_PAGE_SIZE": int64(0),
 				"SPACE_TYPE":    "Single",
+				"INSTANT_COLS":  int64(0),
 			})
 			tableID++
 			space++
@@ -1312,6 +1314,10 @@ func (e *Executor) infoSchemaInnoDBTables() []storage.Row {
 			// For partitioned tables, emit one entry per partition (MySQL behavior).
 			// Partition names follow the pattern: db/table#p#partname
 			// Subpartition names: db/table#p#partname#sp#subpartname
+			instantCols := int64(0)
+			if def != nil {
+				instantCols = int64(def.InstantCols)
+			}
 			if def != nil && def.PartitionType != "" {
 				partNames := innodbPartitionNames(def)
 				for _, partName := range partNames {
@@ -1324,6 +1330,7 @@ func (e *Executor) infoSchemaInnoDBTables() []storage.Row {
 						"ROW_FORMAT":    rowFmt,
 						"ZIP_PAGE_SIZE": zipPageSize,
 						"SPACE_TYPE":    "Single",
+						"INSTANT_COLS":  instantCols,
 					})
 					tableID++
 					space++
@@ -1338,6 +1345,7 @@ func (e *Executor) infoSchemaInnoDBTables() []storage.Row {
 					"ROW_FORMAT":    rowFmt,
 					"ZIP_PAGE_SIZE": zipPageSize,
 					"SPACE_TYPE":    "Single",
+					"INSTANT_COLS":  instantCols,
 				})
 				tableID++
 				space++
@@ -1345,7 +1353,7 @@ func (e *Executor) infoSchemaInnoDBTables() []storage.Row {
 		}
 	}
 	if len(rows) == 0 {
-		return []storage.Row{{"TABLE_ID": int64(0), "NAME": "", "SPACE": int64(0), "FLAG": int64(33), "N_COLS": int64(0), "ROW_FORMAT": "Dynamic", "ZIP_PAGE_SIZE": int64(0), "SPACE_TYPE": "Single"}}
+		return []storage.Row{{"TABLE_ID": int64(0), "NAME": "", "SPACE": int64(0), "FLAG": int64(33), "N_COLS": int64(0), "ROW_FORMAT": "Dynamic", "ZIP_PAGE_SIZE": int64(0), "SPACE_TYPE": "Single", "INSTANT_COLS": int64(0)}}
 	}
 	return rows
 }
@@ -1446,6 +1454,219 @@ func (e *Executor) infoSchemaInnoDBIndexes() []storage.Row {
 			tableID++
 			space++
 		}
+	}
+	return rows
+}
+
+// innodbColumnMTYPE maps a MySQL column type to the InnoDB internal mtype enum.
+// See dict0types.h: DATA_VARCHAR=1, DATA_CHAR=2, DATA_FIXBINARY=3, DATA_BINARY=4,
+// DATA_INT=6, DATA_FLOAT=10, DATA_DOUBLE=11, DATA_DECIMAL=12, DATA_VARMYSQL=13, DATA_MYSQL=14, DATA_GEOMETRY=15.
+func innodbColumnMTYPE(colType string) int64 {
+	t := strings.ToLower(strings.TrimSpace(colType))
+	// strip type length/precision suffix
+	if i := strings.Index(t, "("); i > 0 {
+		t = t[:i]
+	}
+	t = strings.TrimSpace(t)
+	switch t {
+	case "tinyint", "smallint", "mediumint", "int", "integer", "bigint", "year", "bool", "boolean", "bit":
+		return 6
+	case "float":
+		return 10
+	case "double", "real":
+		return 11
+	case "decimal", "numeric":
+		return 12
+	case "char":
+		return 2
+	case "varchar":
+		return 13
+	case "text", "tinytext", "mediumtext", "longtext":
+		return 13
+	case "binary":
+		return 3
+	case "varbinary":
+		return 4
+	case "blob", "tinyblob", "mediumblob", "longblob":
+		return 4
+	case "date", "time", "datetime", "timestamp":
+		return 6
+	case "json":
+		return 13
+	case "geometry", "point", "linestring", "polygon", "multipoint", "multilinestring", "multipolygon", "geometrycollection":
+		return 15
+	case "enum", "set":
+		return 6
+	}
+	return 6
+}
+
+// innodbColumnPRTYPE encodes the InnoDB precise-type bit-field for a column.
+// Layout (low to high): 8 bits MySQL type, 1 bit NOT NULL, 1 bit UNSIGNED, charset/collation in upper bits.
+// We follow MySQL's convention: NOT NULL = bit 8 (0x100), UNSIGNED = bit 9 (0x200) for integer types.
+func innodbColumnPRTYPE(col catalogPkg.ColumnDef) int64 {
+	t := strings.ToLower(strings.TrimSpace(col.Type))
+	upper := strings.ToUpper(t)
+	prtype := int64(0)
+	if !col.Nullable {
+		prtype |= 0x100
+	}
+	if strings.Contains(upper, "UNSIGNED") {
+		prtype |= 0x200
+	}
+	return prtype
+}
+
+// innodbColumnLEN returns the byte-length InnoDB stores for a column type.
+func innodbColumnLEN(colType string) int64 {
+	t := strings.ToLower(strings.TrimSpace(colType))
+	base := t
+	if i := strings.Index(base, "("); i > 0 {
+		base = strings.TrimSpace(base[:i])
+	}
+	switch base {
+	case "tinyint", "bool", "boolean":
+		return 1
+	case "smallint":
+		return 2
+	case "mediumint":
+		return 3
+	case "int", "integer", "year", "float":
+		return 4
+	case "bigint", "double", "real":
+		return 8
+	case "date":
+		return 3
+	case "time":
+		return 3
+	case "datetime", "timestamp":
+		return 5
+	}
+	// Try to extract (N) for char/varchar/binary/varbinary/bit
+	if i := strings.Index(t, "("); i > 0 {
+		var n int
+		if _, err := fmt.Sscanf(t[i:], "(%d)", &n); err == nil {
+			switch base {
+			case "char", "binary":
+				return int64(n)
+			case "varchar", "varbinary":
+				return int64(n)
+			case "bit":
+				return int64((n + 7) / 8)
+			case "decimal", "numeric":
+				// decimal(M,D) packed length depends on M and D; approximate
+				return int64((n / 9) * 4)
+			}
+		}
+	}
+	return 0
+}
+
+// innodbInstantDefaultHex returns the hex-encoded InnoDB row representation of
+// the column's DEFAULT value, used for INSTANT-added columns. Returns "" when
+// the column is not INSTANT-added or has no default that needs encoding.
+func innodbInstantDefaultHex(col catalogPkg.ColumnDef) string {
+	if !col.IsInstantAdded {
+		return ""
+	}
+	if col.InstantDefault != "" {
+		return col.InstantDefault
+	}
+	return ""
+}
+
+// infoSchemaInnoDBColumns returns rows for information_schema.INNODB_COLUMNS.
+// Columns: TABLE_ID, NAME, POS, MTYPE, PRTYPE, LEN, HAS_DEFAULT, DEFAULT_VALUE.
+func (e *Executor) infoSchemaInnoDBColumns() []storage.Row {
+	rows := make([]storage.Row, 0)
+	dbNames := e.Catalog.ListDatabases()
+	sort.Strings(dbNames)
+	tableID := int64(1)
+	for _, dbName := range dbNames {
+		switch strings.ToLower(dbName) {
+		case "information_schema", "mysql", "performance_schema":
+			continue
+		case "sys":
+			// Emit the columns of sys.sys_config (variable, value, set_time, set_by).
+			sysCols := []struct {
+				name    string
+				mtype   int64
+				prtype  int64
+				lenByte int64
+			}{
+				{"variable", 13, 0x100, 128},
+				{"value", 13, 0, 128},
+				{"set_time", 6, 0x100, 5},
+				{"set_by", 13, 0, 128},
+			}
+			for i, c := range sysCols {
+				rows = append(rows, storage.Row{
+					"TABLE_ID":      tableID,
+					"NAME":          c.name,
+					"POS":           int64(i),
+					"MTYPE":         c.mtype,
+					"PRTYPE":        c.prtype,
+					"LEN":           c.lenByte,
+					"HAS_DEFAULT":   int64(0),
+					"DEFAULT_VALUE": nil,
+				})
+			}
+			tableID++
+			continue
+		}
+		db, err := e.Catalog.GetDatabase(dbName)
+		if err != nil {
+			continue
+		}
+		tableNames := db.ListTables()
+		sort.Strings(tableNames)
+		for _, tblName := range tableNames {
+			def, err := db.GetTable(tblName)
+			if err != nil || def == nil {
+				tableID++
+				continue
+			}
+			// Determine partition fan-out (one TABLE_ID per partition entry, mirroring innodb_tables).
+			partCount := 1
+			if def.PartitionType != "" {
+				partCount = len(innodbPartitionNames(def))
+				if partCount == 0 {
+					partCount = 1
+				}
+			}
+			for p := 0; p < partCount; p++ {
+				for i, col := range def.Columns {
+					hasDefault := int64(0)
+					var defaultValue interface{} = nil
+					// Only INSTANT-added columns have their default tracked in INNODB_COLUMNS.
+					if col.IsInstantAdded {
+						hasDefault = 1
+						if col.Nullable && col.Default == nil {
+							// Nullable column without explicit default: default is SQL NULL.
+							defaultValue = "NULL"
+						} else if hex := innodbInstantDefaultHex(col); hex != "" {
+							defaultValue = hex
+						} else {
+							defaultValue = "NULL"
+						}
+					}
+					rows = append(rows, storage.Row{
+						"TABLE_ID":      tableID,
+						"NAME":          col.Name,
+						"POS":           int64(i),
+						"MTYPE":         innodbColumnMTYPE(col.Type),
+						"PRTYPE":        innodbColumnPRTYPE(col),
+						"LEN":           innodbColumnLEN(col.Type),
+						"HAS_DEFAULT":   hasDefault,
+						"DEFAULT_VALUE": defaultValue,
+					})
+				}
+				tableID++
+			}
+		}
+	}
+	if len(rows) == 0 {
+		return []storage.Row{{"TABLE_ID": int64(0), "NAME": "", "POS": int64(0), "MTYPE": int64(0), "PRTYPE": int64(0), "LEN": int64(0), "HAS_DEFAULT": int64(0), "DEFAULT_VALUE": nil}}
 	}
 	return rows
 }


### PR DESCRIPTION
## Summary
Implements MySQL 8.0 InnoDB INSTANT ADD COLUMN at the catalog and information_schema layer, addressing #256.

- Adds `ColumnDef.IsInstantAdded` / `InstantDefault` and `TableDef.InstantCols` to record per-column INSTANT metadata without rewriting existing rows.
- `ALTER TABLE ... ADD COLUMN ALGORITHM=INSTANT` is accepted; unsupported combinations (DROP/MODIFY/CHANGE, primary-key changes, FIRST/AFTER position, stored generated columns) raise `ER_ALTER_OPERATION_NOT_SUPPORTED` (1845).
- Plain end-of-table `ADD COLUMN` is implicitly INSTANT (matches MySQL 8.0.29+ default).
- `information_schema.INNODB_TABLES` exposes `INSTANT_COLS`; `INNODB_COLUMNS` is now a real per-column view including `HAS_DEFAULT` / `DEFAULT_VALUE` (hex-encoded for INSTANT integer columns).
- `MODIFY` / `CHANGE COLUMN` reject explicitly making a primary-key column nullable with `ER_PRIMARY_CANT_HAVE_NULL` (1171); omitting NULL/NOT NULL keeps the PK column NOT NULL silently.

## KPI delta (innodb suite, j=1)
- Before / after pass count: 88 / 88 (no regressions, no new fully-passing tests).
- `innodb/instant_add_column_basic` first-diff-line: line 5 -> line 210 (large improvement; remaining diff is FLOAT/DECIMAL hex encoding, out of scope).
- `innodb/innodb-alter-nullable` first-diff-line: line 4 -> line 6 (PK NULL detection now works; remaining diff is unrelated MODIFY-INPLACE affected-rows accounting).
- `innodb/instant_add_column_autoinc` continues to pass.

## Test plan
- [x] `go build ./...`
- [x] `go test ./... -count=1`
- [x] `go run ./cmd/mtrrun -test innodb/instant_add_column_basic,innodb/instant_add_column_autoinc,innodb/innodb-alter-nullable -skipped-only -force`
- [x] `go run ./cmd/mtrrun -suite innodb -j 1 -force` (head-to-head vs main: 88 pass / 1 fail on both)

Refs #256