### PR TITLE
feat: extend LOCK INSTANCE FOR BACKUP to block all DDL paths (#247)

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -2693,14 +2693,21 @@ func (e *Executor) Execute(query string) (res *Result, retErr error) {
 	case *sqlparser.Use:
 		return e.execUse(s)
 	case *sqlparser.CreateTable:
-		if err := e.waitForInstanceBackupLock(); err != nil {
-			return nil, err
+		// LOCK INSTANCE FOR BACKUP does not block CREATE TEMPORARY TABLE because
+		// temporary tables are session-local and not part of the on-disk backup.
+		if !s.Temp {
+			if err := e.waitForInstanceBackupLock(); err != nil {
+				return nil, err
+			}
 		}
 		e.ddlImplicitCommit()
 		return e.execCreateTable(s)
 	case *sqlparser.DropTable:
-		if err := e.waitForInstanceBackupLock(); err != nil {
-			return nil, err
+		// DROP TEMPORARY TABLE is also exempt from the backup lock for the same reason.
+		if !s.Temp {
+			if err := e.waitForInstanceBackupLock(); err != nil {
+				return nil, err
+			}
 		}
 		e.ddlImplicitCommit()
 		return e.execDropTable(s)
@@ -2999,6 +3006,10 @@ func (e *Executor) Execute(query string) (res *Result, retErr error) {
 		}
 		return &Result{}, nil
 	case *sqlparser.Analyze:
+		// ANALYZE TABLE is DDL-like: blocked while another connection holds LOCK INSTANCE FOR BACKUP.
+		if err := e.waitForInstanceBackupLock(); err != nil {
+			return nil, err
+		}
 		tableName := s.Table.Name.String()
 		msgText := "Table is already up to date"
 		if db, err := e.Catalog.GetDatabase(e.CurrentDB); err == nil {
@@ -3069,13 +3080,26 @@ func (e *Executor) Execute(query string) (res *Result, retErr error) {
 	case *sqlparser.DeallocateStmt:
 		return e.execDeallocate(s)
 	case *sqlparser.AlterDatabase:
+		if err := e.waitForInstanceBackupLock(); err != nil {
+			return nil, err
+		}
 		return e.execAlterDatabase(s)
 	case *sqlparser.DropProcedure:
+		if err := e.waitForInstanceBackupLock(); err != nil {
+			return nil, err
+		}
 		return e.execDropProcedureAST(s)
 	case *sqlparser.CreateProcedure:
+		if err := e.waitForInstanceBackupLock(); err != nil {
+			return nil, err
+		}
 		// Simple CREATE PROCEDURE without BEGIN...END body (already handled above for complex ones)
 		return &Result{}, nil
 	case *sqlparser.CreateView:
+		// CREATE VIEW is DDL: blocked while another connection holds LOCK INSTANCE FOR BACKUP.
+		if err := e.waitForInstanceBackupLock(); err != nil {
+			return nil, err
+		}
 		// Store view definition
 		viewName := s.ViewName.Name.String()
 		viewDB := e.CurrentDB
@@ -3144,6 +3168,10 @@ func (e *Executor) Execute(query string) (res *Result, retErr error) {
 		}
 		return &Result{}, nil
 	case *sqlparser.DropView:
+		// DROP VIEW is DDL: blocked while another connection holds LOCK INSTANCE FOR BACKUP.
+		if err := e.waitForInstanceBackupLock(); err != nil {
+			return nil, err
+		}
 		// DROP VIEW is not allowed when LOCK TABLES is active (ER_LOCK_OR_ACTIVE_TRANSACTION).
 		if e.tableLockManager != nil && e.tableLockManager.HasLocks(e.connectionID) {
 			return nil, mysqlError(1192, "HY000", "Can't execute the given command because you have active locked tables or an active transaction")
@@ -3271,6 +3299,10 @@ func (e *Executor) Execute(query string) (res *Result, retErr error) {
 	case *sqlparser.OtherAdmin:
 		return e.execOtherAdmin(query)
 	case *sqlparser.AlterView:
+		// ALTER VIEW is DDL: blocked while another connection holds LOCK INSTANCE FOR BACKUP.
+		if err := e.waitForInstanceBackupLock(); err != nil {
+			return nil, err
+		}
 		viewName := s.ViewName.Name.String()
 		viewDB := e.CurrentDB
 		if !s.ViewName.Qualifier.IsEmpty() {

--- a/executor/preprocess.go
+++ b/executor/preprocess.go
@@ -11,6 +11,50 @@ import (
 	"github.com/myuon/mylite/catalog"
 )
 
+// isPreprocessDDLForBackupLock reports whether a query (already uppercased and
+// with leading whitespace removed) is a DDL statement handled at the preprocess
+// layer that should be blocked while another connection holds LOCK INSTANCE FOR
+// BACKUP. Statements handled by the AST-level switch (CREATE/ALTER/DROP
+// TABLE/DATABASE/VIEW, TRUNCATE, RENAME TABLE) are guarded separately and are
+// intentionally not included here.
+func isPreprocessDDLForBackupLock(upper string) bool {
+	prefixes := []string{
+		"CREATE INDEX", "DROP INDEX",
+		"CREATE UNIQUE INDEX", "CREATE FULLTEXT INDEX", "CREATE SPATIAL INDEX",
+		"CREATE SERVER", "ALTER SERVER", "DROP SERVER",
+		"CREATE TRIGGER", "DROP TRIGGER",
+		"CREATE EVENT", "ALTER EVENT", "DROP EVENT",
+		"CREATE TABLESPACE", "ALTER TABLESPACE", "DROP TABLESPACE",
+		"CREATE PROCEDURE", "ALTER PROCEDURE", "DROP PROCEDURE",
+		"CREATE FUNCTION", "ALTER FUNCTION", "DROP FUNCTION",
+		"CREATE LOGFILE GROUP", "ALTER LOGFILE GROUP", "DROP LOGFILE GROUP",
+		"CREATE RESOURCE GROUP", "ALTER RESOURCE GROUP", "DROP RESOURCE GROUP",
+		// ALTER DATABASE / CREATE DATABASE with CHARACTER SET/COLLATE clauses are
+		// handled in preprocess (vitess can't parse them) and otherwise bypass
+		// the AST-level guard.
+		"ALTER DATABASE", "ALTER SCHEMA",
+		"ANALYZE TABLE",
+		"OPTIMIZE TABLE",
+		"REPAIR TABLE",
+		"INSTALL PLUGIN", "UNINSTALL PLUGIN",
+	}
+	// Handle CREATE DEFINER=... PROCEDURE/FUNCTION/EVENT/TRIGGER/VIEW
+	if strings.HasPrefix(upper, "CREATE DEFINER") {
+		if strings.Contains(upper, " PROCEDURE") ||
+			strings.Contains(upper, " FUNCTION") ||
+			strings.Contains(upper, " EVENT") ||
+			strings.Contains(upper, " TRIGGER") {
+			return true
+		}
+	}
+	for _, p := range prefixes {
+		if strings.HasPrefix(upper, p) {
+			return true
+		}
+	}
+	return false
+}
+
 // preprocessQuery performs pre-parse processing on the query string before
 // it is handed to the SQL parser. It handles three cases:
 //   - Query rewrite: returns (rewritten, nil, nil)
@@ -519,6 +563,20 @@ func (e *Executor) preprocessQuery(query string) (string, *Result, error) {
 		return "", &Result{}, nil
 	}
 
+	// Block DDL statements that go through preprocess-level handling
+	// (CREATE INDEX, CREATE SERVER, CREATE TRIGGER, CREATE EVENT, CREATE TABLESPACE,
+	//  CREATE PROCEDURE, CREATE FUNCTION, ALTER/DROP variants of the above, RENAME,
+	//  ANALYZE TABLE) when LOCK INSTANCE FOR BACKUP is held by another connection.
+	// CREATE/ALTER/DROP TABLE/DATABASE/VIEW are handled in the AST-level switch
+	// (executor.go) which has its own waitForInstanceBackupLock guards.
+	// CREATE TEMPORARY TABLE is exempted because temporary tables are session-local
+	// and not part of the on-disk backup.
+	if isPreprocessDDLForBackupLock(upper) {
+		if err := e.waitForInstanceBackupLock(); err != nil {
+			return "", nil, err
+		}
+	}
+
 	// Handle CREATE/ALTER/DROP/SET RESOURCE GROUP
 	if strings.HasPrefix(upper, "CREATE RESOURCE GROUP") {
 		// Extract group name (first word after "CREATE RESOURCE GROUP")
@@ -782,6 +840,16 @@ func (e *Executor) preprocessQuery(query string) (string, *Result, error) {
 	if strings.HasPrefix(upper, "CREATE TABLESPACE") ||
 		strings.HasPrefix(upper, "ALTER TABLESPACE") ||
 		strings.HasPrefix(upper, "DROP TABLESPACE") {
+		return "", &Result{}, nil
+	}
+
+	// Handle CREATE/ALTER/DROP SERVER as a silent no-op. mylite does not
+	// implement federated tables, but accepting the syntax keeps tests that
+	// touch CREATE SERVER as part of a larger flow (e.g. lock_backup_ddl)
+	// working.
+	if strings.HasPrefix(upper, "CREATE SERVER") ||
+		strings.HasPrefix(upper, "ALTER SERVER") ||
+		strings.HasPrefix(upper, "DROP SERVER") {
 		return "", &Result{}, nil
 	}
 


### PR DESCRIPTION
## Summary

Extends the existing `LOCK INSTANCE FOR BACKUP` / `UNLOCK INSTANCE` implementation so that the full range of DDL statements is blocked while the backup lock is held by another connection.

The base lock manager and parser support already existed (see `executor/lock_manager.go` `InstanceBackupLock`, and the `LOCK INSTANCE FOR BACKUP` / `UNLOCK INSTANCE` handlers in `executor/preprocess.go`). However, several DDL paths bypassed `waitForInstanceBackupLock()`:

- Statements that go through preprocess-level handling: CREATE/ALTER/DROP INDEX, SERVER, TRIGGER, EVENT, TABLESPACE, PROCEDURE, FUNCTION, LOGFILE GROUP, RESOURCE GROUP, ALTER DATABASE (with CHARACTER SET/COLLATE), ANALYZE/OPTIMIZE/REPAIR TABLE, INSTALL/UNINSTALL PLUGIN, and CREATE DEFINER=... variants.
- AST-level statements not previously guarded: `CreateView`, `DropView`, `AlterView`, `AlterDatabase`, `CreateProcedure` (no-body fallback), `DropProcedure`, and `Analyze`.

Changes:

- New `isPreprocessDDLForBackupLock` helper centralises the prefix list and is invoked at preprocess time before any of the DDL-specific handlers run.
- AST-level cases that were missing the guard now call `waitForInstanceBackupLock()`.
- `CREATE TEMPORARY TABLE` / `DROP TEMPORARY TABLE` are explicitly exempted (temporary tables are session-local and not part of the backup).
- `CREATE/ALTER/DROP SERVER` are accepted as silent no-ops so the syntax in `lock_backup_ddl` no longer trips the vitess parser.

## Test plan

- [x] `go build ./...`
- [x] `go test ./... -count=1`
- [x] `go run ./cmd/mtrrun -test other/lock_backup,other/lock_backup_ddl,other/lock_backup_sessions,other/lock_backup_ddl_myisam -force` — 4 / 4 pass
- [x] `go run ./cmd/mtrrun -suite other -j 1 -max 280 -force` — identical results vs main (104 pass / 112 fail / 53 skip / 33 error), no regressions

Closes #247