### PR TITLE
feat(planner): plan-based EXPLAIN scaffolding for subqueries and DERIVED tables

### DIFF
--- a/executor/explain.go
+++ b/executor/explain.go
@@ -9745,6 +9745,9 @@ func (e *Executor) explainTreeText(query string) string {
 // Simple and JOIN queries are handled by the plan-based path (Phase 3).
 func (e *Executor) tryPlanBasedExplainTraditional(sel *sqlparser.Select) ([][]interface{}, bool) {
 	// Fall back for queries with complex parts (subqueries / derived tables).
+	// Phase 4 adds plan-based DerivedTableNode support, but the existing path
+	// has additional logic (empty-derived detection, multi-semijoin, etc.) we
+	// have not yet replicated, so we keep falling back to it.
 	if e.queryHasComplexParts(sel) {
 		return nil, false
 	}

--- a/executor/plan.go
+++ b/executor/plan.go
@@ -124,6 +124,8 @@ func (n *UnionNode) NodeType() string     { return "Union" }
 // ---- Subquery nodes ----
 
 // SubqueryNode wraps a subquery that appears in WHERE / SELECT etc.
+// SelectType describes how MySQL labels the subquery in EXPLAIN
+// ("SUBQUERY", "DEPENDENT SUBQUERY", "MATERIALIZED" etc.).
 type SubqueryNode struct {
 	Plan         PlanNode
 	SelectType   string
@@ -131,14 +133,42 @@ type SubqueryNode struct {
 	IsCorrelated bool
 }
 
+// QueryWithSubqueries pairs a main plan with the SUBQUERY / DEPENDENT
+// SUBQUERY plans referenced from the outer query's WHERE / SELECT-list /
+// HAVING / JOIN-ON clauses. Plan_explain emits the main rows first, then the
+// subquery rows in declared order.
+type QueryWithSubqueries struct {
+	Main       PlanNode
+	Subqueries []*SubqueryNode
+}
+
+func (n *QueryWithSubqueries) Children() []PlanNode {
+	out := []PlanNode{n.Main}
+	for _, s := range n.Subqueries {
+		out = append(out, s)
+	}
+	return out
+}
+func (n *QueryWithSubqueries) NodeType() string { return "QueryWithSubqueries" }
+
 func (n *SubqueryNode) Children() []PlanNode { return []PlanNode{n.Plan} }
 func (n *SubqueryNode) NodeType() string     { return "Subquery" }
 
 // DerivedTableNode wraps a derived table (subquery in FROM clause).
+// ParentID and ParentSelectType describe the outer query block that owns this
+// derived table; the EXPLAIN placeholder row uses those values, while the inner
+// plan rows use ID with selectType="DERIVED".
 type DerivedTableNode struct {
-	Alias string
-	Plan  PlanNode
-	ID    int64
+	Alias            string
+	Plan             PlanNode
+	ID               int64
+	ParentID         int64
+	ParentSelectType string
+	Extra            []string
+	// InnerSelect holds the original AST for the derived subquery, used by the
+	// optimizer pass to feed access-type detection for tables inside the derived
+	// query block. Nil for UNION-based derived tables.
+	InnerSelect *sqlparser.Select
 }
 
 func (n *DerivedTableNode) Children() []PlanNode { return []PlanNode{n.Plan} }

--- a/executor/plan_explain.go
+++ b/executor/plan_explain.go
@@ -1,5 +1,7 @@
 package executor
 
+import "fmt"
+
 // PlanExplainer converts a logical PlanNode tree to EXPLAIN output rows.
 // This is Phase 1 scaffolding; actual output still uses the existing explain path.
 type PlanExplainer struct {
@@ -113,11 +115,41 @@ func (pe *PlanExplainer) collectRows(node PlanNode, rows *[][]interface{}, extra
 			"Using temporary",
 		})
 
+	case *QueryWithSubqueries:
+		// Emit the main plan first, then each non-FROM subquery's rows.
+		// MySQL conventionally orders WHERE-clause subqueries before
+		// FROM-clause derived tables, but DerivedTableNode rows are already
+		// part of n.Main, so we just append SubqueryNode rows at the end.
+		pe.collectRows(n.Main, rows, extraAccum)
+		for _, sub := range n.Subqueries {
+			pe.collectRows(sub, rows, nil)
+		}
+
 	case *SubqueryNode:
 		pe.collectRows(n.Plan, rows, extraAccum)
 
 	case *DerivedTableNode:
-		pe.collectRows(n.Plan, rows, extraAccum)
+		// Emit a "<derivedN>" placeholder row at the parent's id/select_type level.
+		// This represents the materialized derived table seen by the outer query.
+		// When ParentSelectType is empty (e.g. derived table is nested inside a JOIN
+		// or another derived table), fall back to recursive emission only.
+		if n.ParentSelectType != "" {
+			placeholderExtra := buildExtraString(append([]string(nil), extraAccum...))
+			derivedRef := fmt.Sprintf("<derived%d>", n.ID)
+			*rows = append(*rows, []interface{}{
+				n.ParentID,
+				n.ParentSelectType,
+				derivedRef,
+				nil, // partitions
+				"ALL",
+				nil, nil, nil, nil,
+				int64(2), // rows estimate (MySQL default 2 unless materialized count known)
+				"100.00",
+				placeholderExtra,
+			})
+		}
+		// Recurse into the inner plan; it will emit DERIVED rows with the inner ID.
+		pe.collectRows(n.Plan, rows, nil)
 	}
 }
 

--- a/executor/plan_test.go
+++ b/executor/plan_test.go
@@ -113,9 +113,154 @@ func TestPlanBuilder_Subquery(t *testing.T) {
 	if plan == nil {
 		t.Fatal("expected non-nil plan")
 	}
-	// Plan should be non-trivial (at least Project wrapping something)
-	if plan.NodeType() == "" {
-		t.Error("expected non-empty node type")
+	// The top-level node should be QueryWithSubqueries with one Subquery child.
+	qws, ok := plan.(*QueryWithSubqueries)
+	if !ok {
+		t.Fatalf("expected QueryWithSubqueries top node, got %T", plan)
+	}
+	if len(qws.Subqueries) != 1 {
+		t.Fatalf("expected 1 subquery, got %d", len(qws.Subqueries))
+	}
+	if qws.Subqueries[0].SelectType != "SUBQUERY" {
+		t.Errorf("expected SUBQUERY label, got %q", qws.Subqueries[0].SelectType)
+	}
+}
+
+// TestPlanBuilder_DerivedTableIDs verifies that the derived table inner SELECT
+// reuses the placeholder id (so EXPLAIN emits "id=1 PRIMARY <derived2>" plus
+// "id=2 DERIVED ..." rather than allocating an extra id).
+func TestPlanBuilder_DerivedTableIDs(t *testing.T) {
+	e := newTestExecutor(t)
+	planner := newPlanner(e)
+
+	stmt := parsePlanStmt(t, e, "SELECT d.id FROM (SELECT id FROM t1) AS d")
+	plan, err := planner.BuildPlan(stmt)
+	if err != nil {
+		t.Fatalf("BuildPlan: %v", err)
+	}
+	var dt *DerivedTableNode
+	walkPlan(plan, func(n PlanNode) {
+		if d, ok := n.(*DerivedTableNode); ok && dt == nil {
+			dt = d
+		}
+	})
+	if dt == nil {
+		t.Fatal("expected DerivedTableNode")
+	}
+	if dt.ParentID != 1 {
+		t.Errorf("expected ParentID=1, got %d", dt.ParentID)
+	}
+	if dt.ID != 2 {
+		t.Errorf("expected DerivedTableNode.ID=2, got %d", dt.ID)
+	}
+	if dt.ParentSelectType != "PRIMARY" {
+		t.Errorf("expected ParentSelectType=PRIMARY, got %q", dt.ParentSelectType)
+	}
+	// The inner DERIVED rows must use the same id as the placeholder (2).
+	walkPlan(dt.Plan, func(n PlanNode) {
+		if ts, ok := n.(*TableScanNode); ok {
+			if ts.ID != 2 {
+				t.Errorf("expected inner TableScan ID=2, got %d", ts.ID)
+			}
+			if ts.SelectType != "DERIVED" {
+				t.Errorf("expected inner TableScan SelectType=DERIVED, got %q", ts.SelectType)
+			}
+		}
+	})
+}
+
+// TestPlanBuilder_SubqueryDependent verifies that a correlated subquery is
+// labelled "DEPENDENT SUBQUERY" by the planner.
+func TestPlanBuilder_SubqueryDependent(t *testing.T) {
+	e := newTestExecutor(t)
+	planner := newPlanner(e)
+
+	stmt := parsePlanStmt(t, e, "SELECT id FROM t1 WHERE EXISTS (SELECT 1 FROM t2 WHERE t2.t1_id = t1.id)")
+	plan, err := planner.BuildPlan(stmt)
+	if err != nil {
+		t.Fatalf("BuildPlan: %v", err)
+	}
+	qws, ok := plan.(*QueryWithSubqueries)
+	if !ok {
+		t.Fatalf("expected QueryWithSubqueries top node, got %T", plan)
+	}
+	if len(qws.Subqueries) != 1 {
+		t.Fatalf("expected 1 subquery, got %d", len(qws.Subqueries))
+	}
+	if !qws.Subqueries[0].IsCorrelated {
+		t.Error("expected correlated subquery")
+	}
+	if qws.Subqueries[0].SelectType != "DEPENDENT SUBQUERY" {
+		t.Errorf("expected DEPENDENT SUBQUERY label, got %q", qws.Subqueries[0].SelectType)
+	}
+}
+
+// TestPlanExplain_DerivedTablePlaceholder verifies that EXPLAIN output for a
+// query with a derived FROM table emits a "<derivedN>" placeholder row at the
+// parent's id/select_type, followed by the inner DERIVED rows.
+func TestPlanExplain_DerivedTablePlaceholder(t *testing.T) {
+	e := newTestExecutor(t)
+	planner := newPlanner(e)
+
+	stmt := parsePlanStmt(t, e, "SELECT d.id FROM (SELECT id FROM t1) AS d")
+	plan, err := planner.BuildPlan(stmt)
+	if err != nil {
+		t.Fatalf("BuildPlan: %v", err)
+	}
+	plan = planner.optimize(plan, stmt.(*sqlparser.Select))
+
+	pe := &PlanExplainer{executor: e, query: "SELECT d.id FROM (SELECT id FROM t1) AS d"}
+	rows := pe.ExplainTraditional(plan)
+	if len(rows) < 2 {
+		t.Fatalf("expected at least 2 rows, got %d (%v)", len(rows), rows)
+	}
+	// First row: id=1, select_type=PRIMARY, table=<derived2>.
+	if rows[0][0].(int64) != 1 {
+		t.Errorf("row 0 id: expected 1, got %v", rows[0][0])
+	}
+	if rows[0][1] != "PRIMARY" {
+		t.Errorf("row 0 select_type: expected PRIMARY, got %v", rows[0][1])
+	}
+	if rows[0][2] != "<derived2>" {
+		t.Errorf("row 0 table: expected <derived2>, got %v", rows[0][2])
+	}
+	// Second row: id=2, select_type=DERIVED, table=t1.
+	if rows[1][0].(int64) != 2 {
+		t.Errorf("row 1 id: expected 2, got %v", rows[1][0])
+	}
+	if rows[1][1] != "DERIVED" {
+		t.Errorf("row 1 select_type: expected DERIVED, got %v", rows[1][1])
+	}
+	if rows[1][2] != "t1" {
+		t.Errorf("row 1 table: expected t1, got %v", rows[1][2])
+	}
+}
+
+// TestPlanExplain_SubqueryRows verifies that a SUBQUERY in WHERE produces an
+// EXPLAIN row with select_type=SUBQUERY and a fresh id.
+func TestPlanExplain_SubqueryRows(t *testing.T) {
+	e := newTestExecutor(t)
+	planner := newPlanner(e)
+
+	stmt := parsePlanStmt(t, e, "SELECT id FROM t1 WHERE id IN (SELECT t1_id FROM t2)")
+	plan, err := planner.BuildPlan(stmt)
+	if err != nil {
+		t.Fatalf("BuildPlan: %v", err)
+	}
+	plan = planner.optimize(plan, stmt.(*sqlparser.Select))
+
+	pe := &PlanExplainer{executor: e, query: "SELECT id FROM t1 WHERE id IN (SELECT t1_id FROM t2)"}
+	rows := pe.ExplainTraditional(plan)
+	if len(rows) < 2 {
+		t.Fatalf("expected at least 2 rows, got %d (%v)", len(rows), rows)
+	}
+	// Last row should be the SUBQUERY one.
+	last := rows[len(rows)-1]
+	if last[1] != "SUBQUERY" {
+		t.Errorf("last row select_type: expected SUBQUERY, got %v", last[1])
+	}
+	if last[0].(int64) != 2 {
+		t.Errorf("last row id: expected 2, got %v", last[0])
 	}
 }
 

--- a/executor/planner.go
+++ b/executor/planner.go
@@ -38,8 +38,89 @@ func (p *Planner) BuildPlan(stmt sqlparser.Statement) (PlanNode, error) {
 
 // buildSelectPlan builds a logical plan for a SELECT statement.
 // The returned plan tree is (bottom-up): Source → Filter → Aggregate → Project → Sort → Limit
+//
+// When the SELECT references SUBQUERY-style nested SELECTs (e.g. inside
+// WHERE / SELECT list), the returned plan is wrapped in a
+// QueryWithSubqueries node. Subqueries are recorded in declared order with
+// their own child plans, so plan_explain can emit them as separate rows.
 func (p *Planner) buildSelectPlan(sel *sqlparser.Select, selectType string) (PlanNode, error) {
-	id := p.nextID()
+	main, err := p.buildSelectPlanWithID(sel, selectType, p.nextID())
+	if err != nil {
+		return nil, err
+	}
+	subs := p.collectSelectSubqueries(sel)
+	if len(subs) == 0 {
+		return main, nil
+	}
+	return &QueryWithSubqueries{Main: main, Subqueries: subs}, nil
+}
+
+// collectSelectSubqueries walks a SELECT's WHERE / SELECT-list / HAVING /
+// JOIN-ON clauses and builds SubqueryNode entries for each non-FROM
+// subquery encountered. Each subquery is given a fresh query-block id and a
+// SUBQUERY-or-DEPENDENT-SUBQUERY label depending on whether it references
+// an outer column.
+func (p *Planner) collectSelectSubqueries(sel *sqlparser.Select) []*SubqueryNode {
+	var subs []*SubqueryNode
+	outerTables := p.executor.extractTableNamesAndAliases(sel)
+	collect := func(node sqlparser.SQLNode) {
+		_ = sqlparser.Walk(func(n sqlparser.SQLNode) (bool, error) {
+			sq, ok := n.(*sqlparser.Subquery)
+			if !ok {
+				return true, nil
+			}
+			isCorrelated := p.executor.isCorrelatedSubquery(sq.Select, outerTables)
+			label := "SUBQUERY"
+			if isCorrelated {
+				label = "DEPENDENT SUBQUERY"
+			}
+			subID := p.nextID()
+			var inner PlanNode
+			var err error
+			switch s := sq.Select.(type) {
+			case *sqlparser.Select:
+				inner, err = p.buildSelectPlanWithID(s, label, subID)
+			case *sqlparser.Union:
+				inner, err = p.buildUnionPlan(s, false)
+			default:
+				return true, nil
+			}
+			if err != nil || inner == nil {
+				return true, nil
+			}
+			subs = append(subs, &SubqueryNode{
+				Plan:         inner,
+				SelectType:   label,
+				ID:           subID,
+				IsCorrelated: isCorrelated,
+			})
+			// Don't recurse into the subquery body — its own subqueries are
+			// emitted by its own buildSelectPlan invocation.
+			return false, nil
+		}, node)
+	}
+	collect(sel.SelectExprs)
+	if sel.Where != nil {
+		collect(sel.Where.Expr)
+	}
+	if sel.Having != nil {
+		collect(sel.Having.Expr)
+	}
+	for _, te := range sel.From {
+		var onNodes []sqlparser.SQLNode
+		p.executor.collectJoinOnConditions(te, &onNodes)
+		for _, on := range onNodes {
+			collect(on)
+		}
+	}
+	return subs
+}
+
+// buildSelectPlanWithID is like buildSelectPlan but uses an explicit id (used by
+// derived tables to share an id with their parent placeholder row). Note: the
+// caller is responsible for wrapping the result with QueryWithSubqueries if
+// SUBQUERY rows should be emitted alongside the main plan.
+func (p *Planner) buildSelectPlanWithID(sel *sqlparser.Select, selectType string, id int64) (PlanNode, error) {
 
 	// Promote selectType from SIMPLE to PRIMARY when query has complex parts
 	// (subqueries, derived tables, etc.)
@@ -145,12 +226,23 @@ func (p *Planner) buildTableExprPlan(te sqlparser.TableExpr, selectType string, 
 	case *sqlparser.AliasedTableExpr:
 		// Check if this is a derived table (subquery in FROM)
 		if dt, ok := t.Expr.(*sqlparser.DerivedTable); ok {
+			// Promote parent's selectType: the outer block becomes PRIMARY whenever
+			// it owns a DERIVED subquery (MySQL prints PRIMARY, not SIMPLE).
+			parentSelectType := selectType
+			if parentSelectType == "SIMPLE" {
+				parentSelectType = "PRIMARY"
+			}
+			// MySQL numbers derived tables sequentially starting from the next
+			// query block id. We reserve that id and pass it down so the inner
+			// SELECT's "DERIVED" row uses the same number.
 			derivedID := p.nextID()
 			var innerPlan PlanNode
+			var innerSel *sqlparser.Select
 			var err error
 			switch inner := dt.Select.(type) {
 			case *sqlparser.Select:
-				innerPlan, err = p.buildSelectPlan(inner, "DERIVED")
+				innerSel = inner
+				innerPlan, err = p.buildSelectPlanWithID(inner, "DERIVED", derivedID)
 			case *sqlparser.Union:
 				innerPlan, err = p.buildUnionPlan(inner, false)
 			default:
@@ -164,9 +256,12 @@ func (p *Planner) buildTableExprPlan(te sqlparser.TableExpr, selectType string, 
 				alias = t.As.String()
 			}
 			return &DerivedTableNode{
-				Alias: alias,
-				Plan:  innerPlan,
-				ID:    derivedID,
+				Alias:            alias,
+				Plan:             innerPlan,
+				ID:               derivedID,
+				ParentID:         id,
+				ParentSelectType: parentSelectType,
+				InnerSelect:      innerSel,
 			}, nil
 		}
 
@@ -409,9 +504,19 @@ func (p *Planner) optimizeNode(node PlanNode, sel *sqlparser.Select, hasSortAbov
 			p.optimizeNode(branch, nil, false, false, false)
 		}
 
+	case *QueryWithSubqueries:
+		// Optimize main plan with the outer SELECT context, then each
+		// subquery with its own context.
+		p.optimizeNode(n.Main, sel, hasSortAbove, hasAggAbove, hasFilterAbove)
+		for _, sub := range n.Subqueries {
+			p.optimizeNode(sub, nil, false, false, false)
+		}
+
 	case *DerivedTableNode:
-		// Derived table inner plan has its own SELECT context.
-		p.optimizeNode(n.Plan, nil, false, false, false)
+		// Derived table inner plan has its own SELECT context. Forward the
+		// inner SELECT so access-type detection works for tables inside the
+		// derived query block. UNION-based derived tables fall back to nil.
+		p.optimizeNode(n.Plan, n.InnerSelect, false, false, false)
 
 	case *SubqueryNode:
 		p.optimizeNode(n.Plan, nil, false, false, false)


### PR DESCRIPTION
## Summary
- Extends the new plan-based EXPLAIN path to be structurally capable of expressing FROM-clause derived tables (DerivedTableNode now carries ParentID/ParentSelectType so plan_explain can emit the \`<derivedN>\` placeholder at the parent block) and WHERE/SELECT/HAVING/JOIN-ON subqueries via a new \`QueryWithSubqueries\` wrapper that holds the main plan + a list of \`SubqueryNode\` children labelled SUBQUERY or DEPENDENT SUBQUERY.
- The live \`tryPlanBasedExplainTraditional\` keeps falling back to the existing \`explainMultiRows\` path for queries with derived tables / subqueries — the existing path covers edge cases (empty derived → "no matching row in const table", semijoin/materialization, view-derived) we have not yet replicated, so the change is architectural scaffolding plus unit tests rather than an immediate KPI bump.

## Test plan
- [x] \`go build ./...\`
- [x] \`go test ./... -count=1\` (executor + harness all pass)
- [x] \`go run ./cmd/mtrrun -test other/explain -force\` — first-diff-line stays at 310 (no regression vs main)
- [x] New unit tests:
  - TestPlanBuilder_DerivedTableIDs — derived inner SELECT shares the placeholder id (parent=1, derived=2)
  - TestPlanBuilder_SubqueryDependent — correlated EXISTS subquery is labelled DEPENDENT SUBQUERY
  - TestPlanExplain_DerivedTablePlaceholder — EXPLAIN row 0 = \`1 PRIMARY <derived2>\`, row 1 = \`2 DERIVED t1\`
  - TestPlanExplain_SubqueryRows — non-correlated IN subquery emits a trailing SUBQUERY row with id=2
- [x] Targeted regression spot-check: \`other/subquery_sj_mat\` first-diff at line 5969 (pre-existing failure, unchanged)

## Notes
- Refs #262. Issue is L-sized; this PR lands the planner/plan_explain scaffolding so a follow-up can flip the live path over once empty-derived detection and view-derived support are ported. The KPI-improvement portion of the issue (target +500 lines on \`other/explain\`) is blocked on those pieces and on a non-EXPLAIN correlated-IN-subquery execution bug at line ~310 that surfaces before any new EXPLAIN cases.