### PR TITLE
feat(storage): IndexAccessSpec / ScanByIndex scaffolding (Phase 5 base)

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -659,6 +659,18 @@ type Executor struct {
 	// "Row N was cut by GROUP_CONCAT()" where N is the position of the value that triggered
 	// the truncation. Reset at the start of each SELECT execution.
 	groupConcatRowCount int
+	// indexAccessSpecs holds per-table storage.IndexAccessSpec entries for the
+	// current top-level SELECT, keyed by lowercase table alias / table name.
+	// When buildFromExpr scans a regular base table whose alias appears here,
+	// it routes the read through Table.ScanByIndex instead of Table.Scan().
+	//
+	// Phase 5 (issue #263) scaffolding: the map is only populated when
+	// useIndexAccessSpecs is true. The map is reset between top-level queries.
+	indexAccessSpecs map[string]storage.IndexAccessSpec
+	// useIndexAccessSpecs gates the new index-based execution path. Default
+	// false (legacy full scan + filter). Tests / EXPLAIN integration can
+	// flip this on per-query.
+	useIndexAccessSpecs bool
 }
 
 // Warning represents a MySQL warning.

--- a/executor/index_access.go
+++ b/executor/index_access.go
@@ -1,0 +1,420 @@
+package executor
+
+import (
+	"strconv"
+	"strings"
+
+	"github.com/myuon/mylite/catalog"
+	"github.com/myuon/mylite/storage"
+	"vitess.io/vitess/go/vt/sqlparser"
+)
+
+// buildIndexAccessSpec derives a storage.IndexAccessSpec for tableName
+// from the given SELECT's WHERE clause. The returned spec mirrors the
+// AccessPath that explainDetectAccessType would compute, but with the
+// concrete key VALUES extracted from WHERE so the storage layer can
+// perform the actual lookup.
+//
+// The second return is false when no usable index was found (caller
+// should fall back to a full Scan). A returned spec with Type=="ALL"
+// likewise signals the fallback path.
+//
+// This function is intentionally conservative — it only handles cases
+// the existing planner already classifies as const / ref / range.
+// Anything more elaborate (ref_or_null, index_merge, ICP, etc.)
+// returns ok=false so the caller stays on the legacy scan-and-filter
+// path until those cases are integrated end-to-end.
+func (e *Executor) buildIndexAccessSpec(sel *sqlparser.Select, tableName string) (storage.IndexAccessSpec, bool) {
+	if sel == nil || sel.Where == nil {
+		return storage.IndexAccessSpec{}, false
+	}
+	td := e.explainGetTableDef(tableName)
+	if td == nil {
+		return storage.IndexAccessSpec{}, false
+	}
+
+	ai := e.explainDetectAccessType(sel, tableName)
+	at := strings.ToLower(ai.accessType)
+	keyName := stringify(ai.key)
+	if keyName == "" || at == "" || at == "all" || at == "index" {
+		return storage.IndexAccessSpec{}, false
+	}
+
+	// Resolve which catalog index was chosen.
+	var idxCols []string
+	if strings.EqualFold(keyName, "PRIMARY") {
+		if len(td.PrimaryKey) == 0 {
+			return storage.IndexAccessSpec{}, false
+		}
+		idxCols = append([]string(nil), td.PrimaryKey...)
+	} else {
+		var found catalog.IndexDef
+		ok := false
+		for _, idx := range td.Indexes {
+			if strings.EqualFold(idx.Name, keyName) {
+				found = idx
+				ok = true
+				break
+			}
+		}
+		if !ok {
+			return storage.IndexAccessSpec{}, false
+		}
+		idxCols = append([]string(nil), found.Columns...)
+	}
+
+	// Map column → list of binding expressions for this column from the WHERE clause.
+	eqValues := map[string][]sqlparser.Expr{}
+	rangeValues := map[string]struct{ lower, upper sqlparser.Expr }{}
+	betweenValues := map[string]struct{ lower, upper sqlparser.Expr }{}
+	inLists := map[string][]sqlparser.Expr{}
+
+	collectBindings(sel.Where.Expr, tableName, eqValues, rangeValues, betweenValues, inLists)
+
+	// Try to assemble per-column equality values for all idxCols.
+	values := make([]interface{}, len(idxCols))
+	allHaveEq := true
+	for i, col := range idxCols {
+		bare := stripIndexPrefixLength(col)
+		bindings := eqValues[strings.ToLower(bare)]
+		if len(bindings) == 0 {
+			allHaveEq = false
+			break
+		}
+		v, ok := evalLiteralExpr(bindings[0])
+		if !ok {
+			allHaveEq = false
+			break
+		}
+		values[i] = v
+	}
+
+	switch at {
+	case "const", "eq_ref":
+		if !allHaveEq {
+			return storage.IndexAccessSpec{}, false
+		}
+		return storage.IndexAccessSpec{
+			Type:           ai.accessType,
+			IndexName:      keyName,
+			EqualityValues: values,
+		}, true
+
+	case "ref":
+		// For ref access, we need at least the leading equality column(s)
+		// to be matched. Build whatever prefix is available.
+		eqPrefix := []interface{}{}
+		for _, col := range idxCols {
+			bare := stripIndexPrefixLength(col)
+			bindings := eqValues[strings.ToLower(bare)]
+			if len(bindings) == 0 {
+				break
+			}
+			v, ok := evalLiteralExpr(bindings[0])
+			if !ok {
+				break
+			}
+			eqPrefix = append(eqPrefix, v)
+		}
+		if len(eqPrefix) == 0 {
+			return storage.IndexAccessSpec{}, false
+		}
+		return storage.IndexAccessSpec{
+			Type:           "ref",
+			IndexName:      keyName,
+			EqualityValues: eqPrefix,
+		}, true
+
+	case "range":
+		// Equality prefix + final-column range (or IN list).
+		// IN-list range: build full-tuple lookups.
+		firstIdxCol := stripIndexPrefixLength(idxCols[0])
+		if inExprs, ok := inLists[strings.ToLower(firstIdxCol)]; ok && len(inExprs) > 0 && len(idxCols) == 1 {
+			tuples := make([][]interface{}, 0, len(inExprs))
+			allOK := true
+			for _, ex := range inExprs {
+				v, ok := evalLiteralExpr(ex)
+				if !ok {
+					allOK = false
+					break
+				}
+				tuples = append(tuples, []interface{}{v})
+			}
+			if allOK {
+				return storage.IndexAccessSpec{
+					Type:      "range",
+					IndexName: keyName,
+					InValues:  tuples,
+				}, true
+			}
+		}
+
+		eqPrefix := []interface{}{}
+		var rangeIdxPos int
+		for i, col := range idxCols {
+			bare := strings.ToLower(stripIndexPrefixLength(col))
+			bindings := eqValues[bare]
+			if len(bindings) == 0 {
+				rangeIdxPos = i
+				break
+			}
+			v, ok := evalLiteralExpr(bindings[0])
+			if !ok {
+				return storage.IndexAccessSpec{}, false
+			}
+			eqPrefix = append(eqPrefix, v)
+			rangeIdxPos = i + 1
+		}
+		if rangeIdxPos >= len(idxCols) {
+			// No range column left — treat as ref.
+			return storage.IndexAccessSpec{
+				Type:           "ref",
+				IndexName:      keyName,
+				EqualityValues: eqPrefix,
+			}, true
+		}
+		rangeCol := strings.ToLower(stripIndexPrefixLength(idxCols[rangeIdxPos]))
+
+		// BETWEEN takes precedence over individual >= / <= bindings.
+		lower := make([]interface{}, len(idxCols))
+		upper := make([]interface{}, len(idxCols))
+		lowerInclusive, upperInclusive := true, true
+		if bt, ok := betweenValues[rangeCol]; ok {
+			lv, lok := evalLiteralExpr(bt.lower)
+			uv, uok := evalLiteralExpr(bt.upper)
+			if lok && uok {
+				lower[rangeIdxPos] = lv
+				upper[rangeIdxPos] = uv
+				return storage.IndexAccessSpec{
+					Type:                "range",
+					IndexName:           keyName,
+					EqualityValues:      eqPrefix,
+					RangeLower:          lower,
+					RangeUpper:          upper,
+					RangeLowerInclusive: true,
+					RangeUpperInclusive: true,
+				}, true
+			}
+		}
+		if rg, ok := rangeValues[rangeCol]; ok {
+			haveAny := false
+			if rg.lower != nil {
+				if v, ok := evalLiteralExpr(rg.lower); ok {
+					lower[rangeIdxPos] = v
+					haveAny = true
+				}
+			}
+			if rg.upper != nil {
+				if v, ok := evalLiteralExpr(rg.upper); ok {
+					upper[rangeIdxPos] = v
+					haveAny = true
+				}
+			}
+			if haveAny {
+				return storage.IndexAccessSpec{
+					Type:                "range",
+					IndexName:           keyName,
+					EqualityValues:      eqPrefix,
+					RangeLower:          lower,
+					RangeUpper:          upper,
+					RangeLowerInclusive: lowerInclusive,
+					RangeUpperInclusive: upperInclusive,
+				}, true
+			}
+		}
+	}
+
+	return storage.IndexAccessSpec{}, false
+}
+
+// stripIndexPrefixLength strips the prefix-length suffix from an index
+// column name (e.g., "name(20)" -> "name"). Mirrors storage's helper
+// so the executor doesn't need to import the storage internal helper.
+func stripIndexPrefixLength(col string) string {
+	if i := strings.Index(col, "("); i >= 0 {
+		return col[:i]
+	}
+	return col
+}
+
+// collectBindings walks a WHERE expression and records, for each column
+// belonging to tableName, the literal expressions bound by =, IN,
+// BETWEEN, and range comparisons. Used by buildIndexAccessSpec to plumb
+// concrete values through to storage.IndexAccessSpec.
+func collectBindings(
+	expr sqlparser.Expr,
+	tableName string,
+	eq map[string][]sqlparser.Expr,
+	rng map[string]struct{ lower, upper sqlparser.Expr },
+	bt map[string]struct{ lower, upper sqlparser.Expr },
+	inL map[string][]sqlparser.Expr,
+) {
+	if expr == nil {
+		return
+	}
+	switch x := expr.(type) {
+	case *sqlparser.AndExpr:
+		collectBindings(x.Left, tableName, eq, rng, bt, inL)
+		collectBindings(x.Right, tableName, eq, rng, bt, inL)
+	case *sqlparser.ComparisonExpr:
+		colName, valExpr, swapped := extractColAndValue(x.Left, x.Right, tableName)
+		if colName == "" {
+			return
+		}
+		key := strings.ToLower(colName)
+		switch x.Operator {
+		case sqlparser.EqualOp, sqlparser.NullSafeEqualOp:
+			eq[key] = append(eq[key], valExpr)
+		case sqlparser.InOp:
+			if vt, ok := x.Right.(sqlparser.ValTuple); ok {
+				for _, ve := range vt {
+					inL[key] = append(inL[key], ve)
+				}
+			}
+		case sqlparser.GreaterThanOp, sqlparser.GreaterEqualOp:
+			cur := rng[key]
+			if !swapped {
+				cur.lower = valExpr
+			} else {
+				cur.upper = valExpr
+			}
+			rng[key] = cur
+		case sqlparser.LessThanOp, sqlparser.LessEqualOp:
+			cur := rng[key]
+			if !swapped {
+				cur.upper = valExpr
+			} else {
+				cur.lower = valExpr
+			}
+			rng[key] = cur
+		}
+	case *sqlparser.BetweenExpr:
+		col, ok := x.Left.(*sqlparser.ColName)
+		if !ok {
+			return
+		}
+		qual := col.Qualifier.Name.String()
+		if qual != "" && !strings.EqualFold(qual, tableName) {
+			return
+		}
+		key := strings.ToLower(col.Name.String())
+		bt[key] = struct{ lower, upper sqlparser.Expr }{lower: x.From, upper: x.To}
+	}
+}
+
+// extractColAndValue returns the column-name + literal-expr pair from a
+// binary comparison's two sides, plus a "swapped" bool that's true when
+// the column was on the right (so range comparators can be flipped).
+func extractColAndValue(left, right sqlparser.Expr, tableName string) (string, sqlparser.Expr, bool) {
+	if col, ok := left.(*sqlparser.ColName); ok {
+		qual := col.Qualifier.Name.String()
+		if qual == "" || strings.EqualFold(qual, tableName) {
+			return col.Name.String(), right, false
+		}
+	}
+	if col, ok := right.(*sqlparser.ColName); ok {
+		qual := col.Qualifier.Name.String()
+		if qual == "" || strings.EqualFold(qual, tableName) {
+			return col.Name.String(), left, true
+		}
+	}
+	return "", nil, false
+}
+
+// evalLiteralExpr extracts the Go-typed value of a literal expression
+// (Literal, NullVal, BoolVal). Returns ok=false for anything else
+// (column refs, expressions, subqueries) so the optimizer drops back
+// to the full-scan path.
+func evalLiteralExpr(expr sqlparser.Expr) (interface{}, bool) {
+	switch x := expr.(type) {
+	case *sqlparser.Literal:
+		return literalGoValue(x), true
+	case *sqlparser.NullVal:
+		return nil, true
+	case sqlparser.BoolVal:
+		if bool(x) {
+			return int64(1), true
+		}
+		return int64(0), true
+	case *sqlparser.UnaryExpr:
+		// Handle negative literals: -42, -3.14
+		if x.Operator == sqlparser.UMinusOp {
+			if inner, ok := evalLiteralExpr(x.Expr); ok {
+				switch v := inner.(type) {
+				case int64:
+					return -v, true
+				case float64:
+					return -v, true
+				case string:
+					// keep as-is; storage compares numerically when possible
+					return "-" + v, true
+				}
+			}
+		}
+	}
+	return nil, false
+}
+
+// scanTableForFrom is the entry point used by buildFromExpr to read all
+// rows for a base table. When the executor has registered an
+// IndexAccessSpec for the given alias / table, this routes through
+// Table.ScanByIndex (so the read mirrors the planner's chosen access
+// path); otherwise it falls back to Table.Scan() — preserving the
+// pre-#263 behaviour bit-for-bit.
+//
+// Lookup precedence:
+//  1. spec keyed by lowercased alias
+//  2. spec keyed by lowercased table name
+//
+// Falls back to Scan() if the executor has no access specs registered
+// or the spec describes a full scan.
+func (e *Executor) scanTableForFrom(tbl *storage.Table, alias, tableName string) []storage.Row {
+	if !e.useIndexAccessSpecs || len(e.indexAccessSpecs) == 0 || tbl == nil {
+		return tbl.Scan()
+	}
+	var spec storage.IndexAccessSpec
+	found := false
+	if alias != "" {
+		if s, ok := e.indexAccessSpecs[strings.ToLower(alias)]; ok {
+			spec = s
+			found = true
+		}
+	}
+	if !found && tableName != "" {
+		if s, ok := e.indexAccessSpecs[strings.ToLower(tableName)]; ok {
+			spec = s
+			found = true
+		}
+	}
+	if !found {
+		return tbl.Scan()
+	}
+	rows, err := tbl.ScanByIndex(spec)
+	if err != nil {
+		return tbl.Scan()
+	}
+	return rows
+}
+
+// literalGoValue converts a sqlparser.Literal into an int64/float64/string
+// matching the broad semantics of how rows store values.
+func literalGoValue(lit *sqlparser.Literal) interface{} {
+	if lit == nil {
+		return nil
+	}
+	switch lit.Type {
+	case sqlparser.IntVal:
+		// Best-effort int64 parse, fall back to string.
+		if v, err := strconv.ParseInt(string(lit.Val), 10, 64); err == nil {
+			return v
+		}
+		return string(lit.Val)
+	case sqlparser.FloatVal, sqlparser.DecimalVal:
+		if v, err := strconv.ParseFloat(string(lit.Val), 64); err == nil {
+			return v
+		}
+		return string(lit.Val)
+	default:
+		return string(lit.Val)
+	}
+}

--- a/executor/index_access_test.go
+++ b/executor/index_access_test.go
@@ -1,0 +1,217 @@
+package executor
+
+import (
+	"testing"
+
+	"github.com/myuon/mylite/catalog"
+	"github.com/myuon/mylite/storage"
+	"vitess.io/vitess/go/vt/sqlparser"
+)
+
+func parseSelectIA(t *testing.T, sql string) *sqlparser.Select {
+	t.Helper()
+	parser, err := sqlparser.New(sqlparser.Options{})
+	if err != nil {
+		t.Fatalf("sqlparser.New: %v", err)
+	}
+	stmt, err := parser.Parse(sql)
+	if err != nil {
+		t.Fatalf("Parse(%q): %v", sql, err)
+	}
+	sel, ok := stmt.(*sqlparser.Select)
+	if !ok {
+		t.Fatalf("expected SELECT, got %T", stmt)
+	}
+	return sel
+}
+
+func setupIATestExecutor(t *testing.T) *Executor {
+	t.Helper()
+	cat := catalog.New()
+	store := storage.NewEngine()
+	e := New(cat, store)
+	if _, err := e.Execute("CREATE DATABASE IF NOT EXISTS test"); err != nil {
+		t.Fatalf("CREATE DATABASE: %v", err)
+	}
+	e.CurrentDB = "test"
+	if _, err := e.Execute("CREATE TABLE t1 (id INT PRIMARY KEY, v INT, KEY idx_v (v))"); err != nil {
+		t.Fatalf("CREATE TABLE: %v", err)
+	}
+	if _, err := e.Execute("INSERT INTO t1 VALUES (1, 10), (2, 20), (3, 20), (4, 30)"); err != nil {
+		t.Fatalf("INSERT: %v", err)
+	}
+	return e
+}
+
+func TestBuildIndexAccessSpec_ConstPK(t *testing.T) {
+	e := setupIATestExecutor(t)
+	sel := parseSelectIA(t, "SELECT * FROM t1 WHERE id = 2")
+	spec, ok := e.buildIndexAccessSpec(sel, "t1")
+	if !ok {
+		t.Fatalf("expected spec for PK lookup")
+	}
+	if spec.Type != "const" || spec.IndexName != "PRIMARY" {
+		t.Fatalf("unexpected spec: %+v", spec)
+	}
+	if len(spec.EqualityValues) != 1 {
+		t.Fatalf("expected 1 EqualityValue, got %d", len(spec.EqualityValues))
+	}
+}
+
+func TestBuildIndexAccessSpec_RefSecondary(t *testing.T) {
+	e := setupIATestExecutor(t)
+	sel := parseSelectIA(t, "SELECT * FROM t1 WHERE v = 20")
+	spec, ok := e.buildIndexAccessSpec(sel, "t1")
+	if !ok {
+		t.Fatalf("expected spec for ref lookup")
+	}
+	if spec.Type != "ref" {
+		t.Fatalf("expected ref type, got %s", spec.Type)
+	}
+	if spec.IndexName != "idx_v" {
+		t.Fatalf("expected idx_v, got %s", spec.IndexName)
+	}
+}
+
+func TestBuildIndexAccessSpec_RangeBetween(t *testing.T) {
+	e := setupIATestExecutor(t)
+	sel := parseSelectIA(t, "SELECT * FROM t1 WHERE id BETWEEN 2 AND 3")
+	spec, ok := e.buildIndexAccessSpec(sel, "t1")
+	if !ok {
+		t.Fatalf("expected spec for range BETWEEN")
+	}
+	if spec.Type != "range" || spec.IndexName != "PRIMARY" {
+		t.Fatalf("unexpected spec: %+v", spec)
+	}
+	if spec.RangeLower[0] == nil || spec.RangeUpper[0] == nil {
+		t.Fatalf("expected lower & upper bounds, got %+v", spec)
+	}
+}
+
+func TestBuildIndexAccessSpec_RangeIN(t *testing.T) {
+	e := setupIATestExecutor(t)
+	// Use a non-unique index to avoid the "const collapses single-IN" path,
+	// then verify the range/IN spec is built when the access type is "range".
+	if _, err := e.Execute("CREATE TABLE t2 (id INT, v INT, KEY idx_id (id))"); err != nil {
+		t.Fatalf("CREATE t2: %v", err)
+	}
+	if _, err := e.Execute("INSERT INTO t2 VALUES (1,1),(2,2),(3,3),(4,4)"); err != nil {
+		t.Fatalf("INSERT t2: %v", err)
+	}
+	sel := parseSelectIA(t, "SELECT * FROM t2 WHERE id IN (1, 3)")
+	spec, ok := e.buildIndexAccessSpec(sel, "t2")
+	if !ok {
+		// IN-list access types depend on the planner's classification;
+		// ref/range both produce a usable spec. ok=false means the planner
+		// didn't pick this index — accept that as a valid no-op.
+		return
+	}
+	if spec.Type != "range" && spec.Type != "ref" {
+		t.Fatalf("expected range or ref type, got %s", spec.Type)
+	}
+}
+
+func TestBuildIndexAccessSpec_FullScan(t *testing.T) {
+	e := setupIATestExecutor(t)
+	sel := parseSelectIA(t, "SELECT * FROM t1")
+	if _, ok := e.buildIndexAccessSpec(sel, "t1"); ok {
+		t.Fatalf("expected ok=false for full scan")
+	}
+}
+
+func TestBuildIndexAccessSpec_NonIndexedCol(t *testing.T) {
+	e := setupIATestExecutor(t)
+	if _, err := e.Execute("ALTER TABLE t1 ADD COLUMN extra INT"); err != nil {
+		t.Fatalf("ALTER: %v", err)
+	}
+	sel := parseSelectIA(t, "SELECT * FROM t1 WHERE extra = 5")
+	if _, ok := e.buildIndexAccessSpec(sel, "t1"); ok {
+		t.Fatalf("expected ok=false for non-indexed column")
+	}
+}
+
+// TestScanTableForFrom_OptIn proves that when useIndexAccessSpecs is true
+// and a spec is registered for a table, buildFromExpr routes the read
+// through Table.ScanByIndex. The resulting query result must still
+// match the legacy full-scan path bit-for-bit.
+func TestScanTableForFrom_OptIn(t *testing.T) {
+	cat := catalog.New()
+	store := storage.NewEngine()
+	e := New(cat, store)
+	if _, err := e.Execute("CREATE DATABASE IF NOT EXISTS test"); err != nil {
+		t.Fatalf("CREATE DATABASE: %v", err)
+	}
+	e.CurrentDB = "test"
+	if _, err := e.Execute("CREATE TABLE t1 (id INT PRIMARY KEY, v INT)"); err != nil {
+		t.Fatalf("CREATE TABLE: %v", err)
+	}
+	if _, err := e.Execute("INSERT INTO t1 VALUES (1,10),(2,20),(3,30),(4,40)"); err != nil {
+		t.Fatalf("INSERT: %v", err)
+	}
+
+	// Without opt-in: full result.
+	resBefore, err := e.Execute("SELECT * FROM t1 WHERE id = 2")
+	if err != nil {
+		t.Fatalf("SELECT (off): %v", err)
+	}
+	if len(resBefore.Rows) != 1 {
+		t.Fatalf("expected 1 row pre-opt-in, got %d", len(resBefore.Rows))
+	}
+
+	// Register a const spec on alias t1 and enable the new path.
+	e.indexAccessSpecs = map[string]storage.IndexAccessSpec{
+		"t1": {
+			Type:           "const",
+			IndexName:      "PRIMARY",
+			EqualityValues: []interface{}{int64(2)},
+		},
+	}
+	e.useIndexAccessSpecs = true
+	defer func() {
+		e.useIndexAccessSpecs = false
+		e.indexAccessSpecs = nil
+	}()
+
+	resAfter, err := e.Execute("SELECT * FROM t1")
+	if err != nil {
+		t.Fatalf("SELECT (on): %v", err)
+	}
+	// New path should restrict the scan to the spec's single row, even
+	// though no WHERE clause is present.
+	if len(resAfter.Rows) != 1 {
+		t.Fatalf("expected 1 row post-opt-in, got %d (%+v)", len(resAfter.Rows), resAfter.Rows)
+	}
+	if id, _ := resAfter.Rows[0][0].(int64); id != 2 {
+		t.Fatalf("expected id=2, got %v", resAfter.Rows[0][0])
+	}
+}
+
+func TestEvalLiteralExpr(t *testing.T) {
+	cases := []struct {
+		sql  string
+		want interface{}
+	}{
+		{"SELECT 1", int64(1)},
+		{"SELECT -42", int64(-42)},
+		{"SELECT 3.14", float64(3.14)},
+		{"SELECT NULL", nil},
+		{"SELECT 'hello'", "hello"},
+	}
+	parser, _ := sqlparser.New(sqlparser.Options{})
+	for _, c := range cases {
+		stmt, err := parser.Parse(c.sql)
+		if err != nil {
+			t.Fatalf("parse(%q): %v", c.sql, err)
+		}
+		sel := stmt.(*sqlparser.Select)
+		ae := sel.SelectExprs.Exprs[0].(*sqlparser.AliasedExpr)
+		got, ok := evalLiteralExpr(ae.Expr)
+		if !ok {
+			t.Errorf("evalLiteralExpr(%q): ok=false", c.sql)
+			continue
+		}
+		if got != c.want {
+			t.Errorf("evalLiteralExpr(%q) = %v (%T), want %v (%T)", c.sql, got, got, c.want, c.want)
+		}
+	}
+}

--- a/executor/select.go
+++ b/executor/select.go
@@ -580,7 +580,11 @@ func (e *Executor) buildFromExpr(expr sqlparser.TableExpr) ([]storage.Row, error
 			})
 			return result, nil
 		}
-		rawAll := tbl.Scan()
+		// Default to a full scan; if the optimizer registered an
+		// IndexAccessSpec for this table alias, route the read through
+		// the new index-based path. Falls back to Scan() automatically
+		// when the spec describes a full scan or the index is unknown.
+		rawAll := e.scanTableForFrom(tbl, alias, lookupTable)
 		// MySQL's InnoDB stores mysql.engine_cost in clustered PK order (cost_name, engine_name, device_type).
 		// Sort here to match MySQL's natural row ordering when no ORDER BY is specified.
 		// MySQL uses latin1_swedish_ci collation for these columns, which is case-insensitive.

--- a/storage/index_access.go
+++ b/storage/index_access.go
@@ -1,0 +1,324 @@
+package storage
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/myuon/mylite/catalog"
+)
+
+// IndexAccessSpec describes how a table should be accessed via an index.
+//
+// This struct is the contract between the optimizer (which produces
+// AccessPath information when planning a query) and the executor (which
+// can use it to skip the full table scan and read only the rows the
+// access path identifies).
+//
+// The zero value (Type="" or Type="ALL") means "fall back to the full
+// table scan". Callers should detect AccessType and route to the
+// appropriate Table method.
+//
+// Phase 5 scaffolding: this type is the public API surface for the new
+// index-based execution path. Real call sites are still gated behind a
+// feature flag while the executor is migrated.
+type IndexAccessSpec struct {
+	// Type mirrors AccessPath.Type from the planner — one of "const",
+	// "eq_ref", "ref", "range", "index", "ALL".
+	Type string
+
+	// IndexName is the index used for the lookup. "PRIMARY" denotes the
+	// primary key; otherwise the name matches a catalog.IndexDef.Name.
+	// Empty when Type=="ALL".
+	IndexName string
+
+	// EqualityValues holds the per-column equality values for const /
+	// eq_ref / ref lookups. The slice is indexed by column position in
+	// the index definition (so EqualityValues[0] is the value for the
+	// first column of the index). Values may be of any concrete Go type
+	// stored in Row maps.
+	//
+	// For ref-or-null access, NULL is represented as a nil interface{}.
+	EqualityValues []interface{}
+
+	// RangeLower and RangeUpper hold the prefix-equality + final-range
+	// bounds used by range-style access. RangeLower[i] / RangeUpper[i]
+	// correspond to the i-th column of IndexName. A nil entry on either
+	// bound means "unbounded on that side". RangeLowerInclusive /
+	// RangeUpperInclusive govern the boundary semantics for the final
+	// (range-typed) column; intermediate equality columns are always
+	// inclusive.
+	RangeLower          []interface{}
+	RangeUpper          []interface{}
+	RangeLowerInclusive bool
+	RangeUpperInclusive bool
+
+	// InValues is set when the optimizer chose an IN-list driven range
+	// scan. Each element is one full key tuple to look up.
+	InValues [][]interface{}
+}
+
+// rowMatchesEquality reports whether the given row's values for the
+// columns named in idxCols equal the supplied values, using string
+// formatting for comparison (matches existing PK lookup semantics).
+func rowMatchesEquality(row Row, idxCols []string, values []interface{}) bool {
+	if len(values) > len(idxCols) {
+		return false
+	}
+	for i, v := range values {
+		col := stripPrefixLength(idxCols[i])
+		got := rowGetCI(row, col)
+		if !valuesEqualLoose(got, v) {
+			return false
+		}
+	}
+	return true
+}
+
+// valuesEqualLoose compares two interface{} values with the same
+// "stringify and compare" behavior as bulkPKKey / bulkUniqueKey, so that
+// optimizer-built IndexAccessSpec values match rows the same way the
+// existing in-memory hash indexes already do.
+func valuesEqualLoose(a, b interface{}) bool {
+	if a == nil && b == nil {
+		return true
+	}
+	if a == nil || b == nil {
+		return false
+	}
+	// Try numeric comparison first to avoid 1 vs "1" mismatches caused
+	// by literal-vs-stored type differences.
+	if af, ok := toComparableFloat(a); ok {
+		if bf, ok := toComparableFloat(b); ok {
+			return af == bf
+		}
+	}
+	return fmt.Sprintf("%v", a) == fmt.Sprintf("%v", b)
+}
+
+// resolveIndexColumns returns the column list for the given index name,
+// or nil + false if the index isn't known. "PRIMARY" resolves to the
+// table's primary key.
+func (t *Table) resolveIndexColumns(indexName string) ([]string, bool) {
+	if t.Def == nil {
+		return nil, false
+	}
+	if strings.EqualFold(indexName, "PRIMARY") {
+		if len(t.Def.PrimaryKey) == 0 {
+			return nil, false
+		}
+		return append([]string(nil), t.Def.PrimaryKey...), true
+	}
+	for _, idx := range t.Def.Indexes {
+		if strings.EqualFold(idx.Name, indexName) {
+			return append([]string(nil), idx.Columns...), true
+		}
+	}
+	return nil, false
+}
+
+// GetByPK returns the row whose primary key columns match the supplied
+// values (in PrimaryKey-declaration order). The boolean return mirrors
+// the standard map-lookup idiom: false when no row matches or the table
+// has no primary key.
+//
+// This is the "const" access type: a single direct lookup.
+func (t *Table) GetByPK(pkValues []interface{}) (Row, bool) {
+	if t == nil || t.Def == nil || len(t.Def.PrimaryKey) == 0 {
+		return nil, false
+	}
+	if len(pkValues) != len(t.Def.PrimaryKey) {
+		return nil, false
+	}
+	t.Mu.RLock()
+	defer t.Mu.RUnlock()
+	pkCols := t.Def.PrimaryKey
+	for _, row := range t.Rows {
+		match := true
+		for i, pk := range pkCols {
+			col := stripPrefixLength(pk)
+			if !valuesEqualLoose(rowGetCI(row, col), pkValues[i]) {
+				match = false
+				break
+			}
+		}
+		if match {
+			return cloneRowSnapshot(row), true
+		}
+	}
+	return nil, false
+}
+
+// ScanByIndex returns the rows that match the supplied IndexAccessSpec.
+// The behavior depends on spec.Type:
+//
+//   - "const", "eq_ref": single-row PK / unique-index lookup using
+//     EqualityValues. Returns at most one row.
+//   - "ref": equality lookup on a (potentially non-unique) index. May
+//     return multiple rows.
+//   - "range": prefix-equality + final-range scan. EqualityValues holds
+//     the leading equality prefix; RangeLower/RangeUpper bound the next
+//     column. When InValues is non-empty it is used instead.
+//   - "index": full index scan (currently equivalent to a sorted full
+//     scan of the table; index-only access is simulated by reading all
+//     rows in PK order, matching the existing Scan() behaviour).
+//   - "ALL" or empty: callers should fall back to Scan(); ScanByIndex
+//     also handles this case by returning Scan() to keep the call site
+//     simple.
+//
+// Returned rows are deep-copied (same semantics as Scan()).
+//
+// This is intentionally conservative: it scans the in-memory rows and
+// filters them using the specified key columns. It does NOT yet build
+// or use any sorted index data structure — the win at this stage is
+// correctness of the shape (single-row for const, filtered subset for
+// ref) rather than algorithmic speed-up. Future PRs can specialize the
+// hot paths once the executor reliably plumbs AccessPath through.
+func (t *Table) ScanByIndex(spec IndexAccessSpec) ([]Row, error) {
+	if t == nil {
+		return nil, fmt.Errorf("ScanByIndex: nil table")
+	}
+	switch strings.ToLower(spec.Type) {
+	case "", "all", "index":
+		return t.Scan(), nil
+	}
+
+	idxCols, ok := t.resolveIndexColumns(spec.IndexName)
+	if !ok {
+		// Index not found — fall back to a full scan rather than error
+		// out. The optimizer may have selected an index that does not
+		// (yet) materialize as a real catalog index.
+		return t.Scan(), nil
+	}
+
+	switch strings.ToLower(spec.Type) {
+	case "const", "eq_ref":
+		if len(spec.EqualityValues) != len(idxCols) {
+			return t.Scan(), nil
+		}
+		t.Mu.RLock()
+		defer t.Mu.RUnlock()
+		for _, row := range t.Rows {
+			if rowMatchesEquality(row, idxCols, spec.EqualityValues) {
+				return []Row{cloneRowSnapshot(row)}, nil
+			}
+		}
+		return nil, nil
+
+	case "ref":
+		// Equality lookup on a (possibly non-unique) prefix of the index.
+		t.Mu.RLock()
+		defer t.Mu.RUnlock()
+		var out []Row
+		for _, row := range t.Rows {
+			if rowMatchesEquality(row, idxCols, spec.EqualityValues) {
+				out = append(out, cloneRowSnapshot(row))
+			}
+		}
+		return out, nil
+
+	case "range":
+		t.Mu.RLock()
+		defer t.Mu.RUnlock()
+		// IN-list driven range: equality on each tuple, OR'd together.
+		if len(spec.InValues) > 0 {
+			seen := make(map[int]bool, len(spec.InValues))
+			var out []Row
+			for i, row := range t.Rows {
+				if seen[i] {
+					continue
+				}
+				for _, tup := range spec.InValues {
+					if rowMatchesEquality(row, idxCols, tup) {
+						out = append(out, cloneRowSnapshot(row))
+						seen[i] = true
+						break
+					}
+				}
+			}
+			return out, nil
+		}
+		// Prefix equality + final-column range comparison.
+		eqLen := len(spec.EqualityValues)
+		var out []Row
+		for _, row := range t.Rows {
+			if eqLen > 0 && !rowMatchesEquality(row, idxCols, spec.EqualityValues) {
+				continue
+			}
+			if eqLen >= len(idxCols) {
+				// No range column left; treat as ref.
+				out = append(out, cloneRowSnapshot(row))
+				continue
+			}
+			rangeCol := stripPrefixLength(idxCols[eqLen])
+			v := rowGetCI(row, rangeCol)
+			if !inRange(v, spec.RangeLower, spec.RangeUpper, eqLen,
+				spec.RangeLowerInclusive, spec.RangeUpperInclusive) {
+				continue
+			}
+			out = append(out, cloneRowSnapshot(row))
+		}
+		return out, nil
+	}
+
+	return t.Scan(), nil
+}
+
+// inRange reports whether v lies within the lower/upper bounds for the
+// range column at idxPos. nil bounds mean unbounded on that side.
+func inRange(v interface{}, lower, upper []interface{}, idxPos int, lowerInclusive, upperInclusive bool) bool {
+	if idxPos < len(lower) && lower[idxPos] != nil {
+		cmp := compareRowValue(v, lower[idxPos])
+		if cmp < 0 {
+			return false
+		}
+		if cmp == 0 && !lowerInclusive {
+			return false
+		}
+	}
+	if idxPos < len(upper) && upper[idxPos] != nil {
+		cmp := compareRowValue(v, upper[idxPos])
+		if cmp > 0 {
+			return false
+		}
+		if cmp == 0 && !upperInclusive {
+			return false
+		}
+	}
+	return true
+}
+
+// cloneRowSnapshot returns a shallow copy of the given row.
+func cloneRowSnapshot(row Row) Row {
+	out := make(Row, len(row))
+	for k, v := range row {
+		out[k] = v
+	}
+	return out
+}
+
+// FindIndex returns the IndexDef for the given name (PRIMARY-aware). The
+// second return is false when the index does not exist on this table.
+//
+// Exposed so the executor can pre-resolve indexes when building an
+// IndexAccessSpec without re-walking the catalog.
+func (t *Table) FindIndex(name string) (catalog.IndexDef, bool) {
+	if t == nil || t.Def == nil {
+		return catalog.IndexDef{}, false
+	}
+	if strings.EqualFold(name, "PRIMARY") {
+		if len(t.Def.PrimaryKey) == 0 {
+			return catalog.IndexDef{}, false
+		}
+		return catalog.IndexDef{
+			Name:    "PRIMARY",
+			Columns: append([]string(nil), t.Def.PrimaryKey...),
+			Unique:  true,
+		}, true
+	}
+	for _, idx := range t.Def.Indexes {
+		if strings.EqualFold(idx.Name, name) {
+			return idx, true
+		}
+	}
+	return catalog.IndexDef{}, false
+}

--- a/storage/index_access_test.go
+++ b/storage/index_access_test.go
@@ -1,0 +1,176 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/myuon/mylite/catalog"
+)
+
+func newIntPKTable() *Table {
+	def := &catalog.TableDef{
+		Name: "t1",
+		Columns: []catalog.ColumnDef{
+			{Name: "id", Type: "INT"},
+			{Name: "v", Type: "INT"},
+		},
+		PrimaryKey: []string{"id"},
+		Indexes: []catalog.IndexDef{
+			{Name: "idx_v", Columns: []string{"v"}},
+		},
+	}
+	t := &Table{Def: def, Rows: []Row{}}
+	for i := int64(1); i <= 5; i++ {
+		t.Rows = append(t.Rows, Row{"id": i, "v": i * 10})
+	}
+	t.Rows = append(t.Rows, Row{"id": int64(6), "v": int64(20)}) // duplicate v=20
+	return t
+}
+
+func TestGetByPK_Hit(t *testing.T) {
+	tbl := newIntPKTable()
+	row, ok := tbl.GetByPK([]interface{}{int64(3)})
+	if !ok {
+		t.Fatalf("expected hit on id=3")
+	}
+	if v, ok := row["v"].(int64); !ok || v != 30 {
+		t.Fatalf("expected v=30, got %v (%T)", row["v"], row["v"])
+	}
+}
+
+func TestGetByPK_Miss(t *testing.T) {
+	tbl := newIntPKTable()
+	if _, ok := tbl.GetByPK([]interface{}{int64(999)}); ok {
+		t.Fatalf("expected miss on id=999")
+	}
+}
+
+func TestGetByPK_NoPK(t *testing.T) {
+	tbl := &Table{Def: &catalog.TableDef{Name: "x", Columns: []catalog.ColumnDef{{Name: "a"}}}}
+	if _, ok := tbl.GetByPK([]interface{}{int64(1)}); ok {
+		t.Fatalf("expected miss when table has no PK")
+	}
+}
+
+func TestScanByIndex_ConstPK(t *testing.T) {
+	tbl := newIntPKTable()
+	rows, err := tbl.ScanByIndex(IndexAccessSpec{
+		Type:           "const",
+		IndexName:      "PRIMARY",
+		EqualityValues: []interface{}{int64(2)},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(rows) != 1 || rows[0]["id"].(int64) != 2 {
+		t.Fatalf("expected single row id=2, got %+v", rows)
+	}
+}
+
+func TestScanByIndex_RefSecondary(t *testing.T) {
+	tbl := newIntPKTable()
+	rows, err := tbl.ScanByIndex(IndexAccessSpec{
+		Type:           "ref",
+		IndexName:      "idx_v",
+		EqualityValues: []interface{}{int64(20)},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 rows for v=20, got %d (%+v)", len(rows), rows)
+	}
+}
+
+func TestScanByIndex_RangeBetween(t *testing.T) {
+	tbl := newIntPKTable()
+	rows, err := tbl.ScanByIndex(IndexAccessSpec{
+		Type:                "range",
+		IndexName:           "PRIMARY",
+		RangeLower:          []interface{}{int64(2)},
+		RangeUpper:          []interface{}{int64(4)},
+		RangeLowerInclusive: true,
+		RangeUpperInclusive: true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(rows) != 3 {
+		t.Fatalf("expected 3 rows for id BETWEEN 2 AND 4, got %d (%+v)", len(rows), rows)
+	}
+}
+
+func TestScanByIndex_RangeIN(t *testing.T) {
+	tbl := newIntPKTable()
+	rows, err := tbl.ScanByIndex(IndexAccessSpec{
+		Type:      "range",
+		IndexName: "PRIMARY",
+		InValues: [][]interface{}{
+			{int64(1)},
+			{int64(3)},
+			{int64(5)},
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(rows) != 3 {
+		t.Fatalf("expected 3 rows for id IN (1,3,5), got %d", len(rows))
+	}
+}
+
+func TestScanByIndex_FallbackToScan(t *testing.T) {
+	tbl := newIntPKTable()
+	rows, err := tbl.ScanByIndex(IndexAccessSpec{Type: "ALL"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(rows) != len(tbl.Rows) {
+		t.Fatalf("expected %d rows, got %d", len(tbl.Rows), len(rows))
+	}
+}
+
+func TestScanByIndex_UnknownIndex(t *testing.T) {
+	tbl := newIntPKTable()
+	rows, err := tbl.ScanByIndex(IndexAccessSpec{
+		Type:      "ref",
+		IndexName: "no_such_idx",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(rows) != len(tbl.Rows) {
+		t.Fatalf("expected fallback full scan, got %d rows", len(rows))
+	}
+}
+
+func TestFindIndex(t *testing.T) {
+	tbl := newIntPKTable()
+	if idx, ok := tbl.FindIndex("PRIMARY"); !ok || idx.Name != "PRIMARY" || idx.Columns[0] != "id" {
+		t.Fatalf("PRIMARY lookup failed: %+v ok=%v", idx, ok)
+	}
+	if idx, ok := tbl.FindIndex("idx_v"); !ok || idx.Name != "idx_v" {
+		t.Fatalf("idx_v lookup failed: %+v ok=%v", idx, ok)
+	}
+	if _, ok := tbl.FindIndex("ghost"); ok {
+		t.Fatalf("expected miss for unknown index")
+	}
+}
+
+func TestValuesEqualLoose(t *testing.T) {
+	cases := []struct {
+		a, b interface{}
+		want bool
+	}{
+		{nil, nil, true},
+		{nil, int64(0), false},
+		{int64(1), int64(1), true},
+		{int64(1), "1", true},
+		{"foo", "foo", true},
+		{"foo", "bar", false},
+	}
+	for _, c := range cases {
+		if got := valuesEqualLoose(c.a, c.b); got != c.want {
+			t.Errorf("valuesEqualLoose(%v,%v) = %v, want %v", c.a, c.b, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Lands the storage interface (`storage.IndexAccessSpec`, `Table.ScanByIndex`, `Table.GetByPK`, `Table.FindIndex`) that Phase 5 of the optimizer work (issue #263) needs to migrate the live SELECT path off the always-on full table scan.
- Adds `executor.buildIndexAccessSpec`: walks a SELECT's WHERE clause and produces a `storage.IndexAccessSpec` for PK / secondary / BETWEEN / IN-list cases — i.e. plumbs the concrete key VALUES through, complementing `explainDetectAccessType`'s metadata-only classification.
- Hooks the executor into `buildFromExpr` at the single base-table read site (`tbl.Scan()` → `e.scanTableForFrom(tbl, alias, lookupTable)`). Routing is gated by `useIndexAccessSpecs` (default `false`) and the `indexAccessSpecs` map (default empty), so today's behaviour is byte-identical until a follow-up flips the gate.

## Why scaffolding only
The issue is L-sized (400-600 lines) and explicitly notes the SELECT hot path is risky. Wiring buildIndexAccessSpec into execSelect end-to-end requires careful coexistence with joins, derived tables, correlated subqueries, and the existing WHERE filter pushdown — each of which has its own contract for what `buildFromExpr` returns. This PR ships the stable interface plus an opt-in entry point that a follow-up can flip on per-query (or per-table) without touching the hot path again.

## Test plan
- [x] `go build ./...`
- [x] `go test ./... -count=1` (storage + executor + harness all green)
- [x] `storage/index_access_test.go`: GetByPK hit/miss, const, ref, BETWEEN range, IN-list range, fallback-to-Scan when AccessSpec is "ALL" or the index is unknown
- [x] `executor/index_access_test.go`: buildIndexAccessSpec on PK const / ref / BETWEEN / non-indexed full scan, plus an end-to-end `Execute("SELECT * FROM t1")` driven by an opt-in spec
- [x] `go run ./cmd/mtrrun -test other/explain -force` — first-diff-line still 310 (unchanged from main)
- [x] `go run ./cmd/mtrrun -suite other -j 1 -max 50 -force` before vs after: identical (26 pass / 14 fail / 1 error / 15 skip on both, zero diffs in test-by-test status)

## Follow-up
Refs #263. The KPI movement (passes on `other/explain` index-scan blocks) will land in a follow-up PR that flips `useIndexAccessSpecs` on after populating the spec map from `execSelect`. The blocker mentioned in #291 (correlated-IN subquery error at line ~310) sits before any new EXPLAIN cases on `other/explain`, so its fix is independently required before this scaffolding can move the first-diff-line.