### PR TITLE
fix: trigger re-entrancy guard on UPDATE + FLUSH PRIVILEGES error code (closes #250)

### DIFF
--- a/executor/dml_update.go
+++ b/executor/dml_update.go
@@ -176,6 +176,18 @@ func (e *Executor) execUpdate(stmt *sqlparser.Update) (*Result, error) {
 	if err := e.checkTablespaceDiscarded(updateDB, tableName); err != nil {
 		return nil, err
 	}
+
+	// MySQL error 1442: can't modify a table inside a trigger if the triggering statement is
+	// already modifying that table (re-entrancy guard preventing infinite recursion).
+	if e.functionOrTriggerDepth > 0 && strings.EqualFold(e.modifyingTable, tableName) {
+		return nil, mysqlError(1442, "HY000",
+			fmt.Sprintf("Can't update table '%s' in stored function/trigger because it is already used by statement which invoked this stored function/trigger.", tableName))
+	}
+	// Track the table being modified so nested trigger calls can detect recursive modifications.
+	prevModifyingTable := e.modifyingTable
+	e.modifyingTable = tableName
+	defer func() { e.modifyingTable = prevModifyingTable }()
+
 	// If updating through a view, validate that SET targets are updatable columns (direct col refs).
 	if viewColMap != nil {
 		for _, upd := range stmt.Exprs {

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -3372,9 +3372,24 @@ func (e *Executor) Execute(query string) (res *Result, retErr error) {
 		if s.WithLock && e.tableLockManager != nil && e.tableLockManager.HasLocks(e.connectionID) {
 			return nil, mysqlError(1192, "HY000", "Can't execute the given command because you have active locked tables or an active transaction")
 		}
+		// FLUSH PRIVILEGES under active LOCK TABLES needs to surface
+		// ER_TABLE_NOT_LOCKED ("Table 'user' was not locked with LOCK TABLES")
+		// rather than the generic READ-lock 1099. Detect it before the
+		// generic FLUSH TABLES guard below.
+		flushPrivilegesUnderLock := false
+		if !s.WithLock && len(s.TableNames) == 0 && e.tableLockManager != nil && e.tableLockManager.HasLocks(e.connectionID) {
+			for _, opt := range s.FlushOptions {
+				if strings.HasPrefix(strings.ToUpper(strings.TrimSpace(opt)), "PRIVILEGES") {
+					flushPrivilegesUnderLock = true
+					break
+				}
+			}
+		}
 		// FLUSH TABLES (no specific table names) when LOCK TABLES is active:
 		// all locked tables must have WRITE lock; READ-locked tables produce 1099.
-		if !s.WithLock && len(s.TableNames) == 0 && e.tableLockManager != nil && e.tableLockManager.HasLocks(e.connectionID) {
+		// Skip this when the flush is FLUSH PRIVILEGES — that case is handled
+		// further below with its own error code.
+		if !s.WithLock && len(s.TableNames) == 0 && !flushPrivilegesUnderLock && e.tableLockManager != nil && e.tableLockManager.HasLocks(e.connectionID) {
 			locks := e.tableLockManager.GetLocks(e.connectionID)
 			for _, mode := range locks {
 				if mode == "READ" {


### PR DESCRIPTION
## Summary

Closes #250 by fixing the last two remaining diffs in `other/lock` after PRs #283 and #295.

- **UPDATE trigger re-entrancy guard.** INSERT and DELETE already raised ER_CANT_UPDATE_USED_TABLE_IN_SF_OR_TRG (1442) when a trigger body modifies the same table the outer DML is scanning, via `e.modifyingTable`. UPDATE was missing the same guard, so an `INSERT INTO t1` whose AFTER INSERT trigger ran `UPDATE t1 SET ...` slipped past the check. UPDATE now mirrors INSERT/DELETE: if `e.functionOrTriggerDepth > 0` and the target equals `e.modifyingTable`, return error 1442.
- **FLUSH PRIVILEGES under LOCK TABLES.** With a READ-locked table, `FLUSH PRIVILEGES` was returning the generic `ER_TABLE_NOT_LOCKED_FOR_WRITE` (1099) because the no-table-name FLUSH guard fired before the dedicated FLUSH PRIVILEGES handler. MySQL emits `ER_TABLE_NOT_LOCKED` (1100) "Table 'user' was not locked with LOCK TABLES" instead. Detect FLUSH PRIVILEGES first and skip the generic guard so the existing privilege-table handler reaches its intended error.

## KPI

- `other/lock`: first-diff-line 270 -> **PASS**
- `other/tablelock`: continues to PASS
- `other/locking_clause`: continues to PASS
- `sys_vars`: 503 pass / 0 fail (unchanged)
- `innodb`: 92 pass / 1 fail / 183 skip (unchanged)
- `other` first 110 head-to-head: 43 / 42 / 9 / 25 (unchanged from baseline documented in #295)

## Test plan

- [x] `go build ./...`
- [x] `go test ./... -count=1`
- [x] `go run ./cmd/mtrrun -test other/lock,other/tablelock,other/locking_clause -force`
- [x] `go run ./cmd/mtrrun -suite sys_vars -force`
- [x] `go run ./cmd/mtrrun -suite innodb -force`
- [x] `go run ./cmd/mtrrun -suite other -j 1 -max 110 -force` head-to-head with `main`

Closes #250