### PR TITLE
docs(explain): map plan-based EXPLAIN parity gaps for subqueries

### DIFF
--- a/executor/explain.go
+++ b/executor/explain.go
@@ -10184,11 +10184,32 @@ func (e *Executor) explainTreeText(query string) string {
 //
 // Falls back for queries with subqueries or derived tables.
 // Simple and JOIN queries are handled by the plan-based path (Phase 3).
+//
+// Refs #262: the new path is structurally capable of expressing DerivedTableNode
+// and SubqueryNode (see plan_explain.collectRows), but the live gate keeps
+// falling back to explainMultiRows because the new path is missing parity with
+// these existing features:
+//   - "no matching row in const table" detection for empty-derived tables and
+//     for subqueries that resolve to const-empty (see queryHasComplexParts and
+//     whereHasSingleSubquery branches in explainSelect, ~line 1909-1957).
+//   - "Range checked for each record (index map: 0xN)" annotation for
+//     multi-table joins where an indexed column is constrained by a range
+//     condition referencing another table's column (~line 1968-1991).
+//   - "Using join buffer (Block Nested Loop)" annotation for non-driving ALL-scan
+//     tables in multi-table joins (~line 1989-1991) and the materialized-subquery
+//     placeholders (~line 248-310, 367-384).
+//   - Semijoin/materialization plan reordering: <subqueryN> placeholder rows,
+//     SIMPLE+MATERIALIZED conversion to PRIMARY+FirstMatch, etc. (~line 92-200).
+//   - Non-merge view detection: PRIMARY+DERIVED rows for view-derived tables.
+//   - Multi-semijoin column reordering and IMPOSSIBLE WHERE collapse logic.
+//
+// Until parity is complete, leaving the gate off is safer than partial-flipping.
+// See PR #291 for the scaffolding (DerivedTableNode, QueryWithSubqueries) and
+// the optimizer pass that already feeds AccessPath into TableScanNodes inside
+// derived blocks.
 func (e *Executor) tryPlanBasedExplainTraditional(sel *sqlparser.Select) ([][]interface{}, bool) {
 	// Fall back for queries with complex parts (subqueries / derived tables).
-	// Phase 4 adds plan-based DerivedTableNode support, but the existing path
-	// has additional logic (empty-derived detection, multi-semijoin, etc.) we
-	// have not yet replicated, so we keep falling back to it.
+	// See doc-comment above for the full list of pending parity items.
 	if e.queryHasComplexParts(sel) {
 		return nil, false
 	}


### PR DESCRIPTION
## Summary
- Adds an in-source parity checklist to the `tryPlanBasedExplainTraditional` gate doc-comment so the next attempt at flipping the live plan-based EXPLAIN path knows what to port from `explainMultiRows`.
- No behaviour change: same baseline KPI on `other/explain`, `other/subquery_sj_mat`, `other/subquery_sj_all`, `other/opt_hints_subquery`.
- Refs #262.

## Investigation findings (relevant to #262)
- The plan-based path (PR #291) is structurally capable of `DerivedTableNode` + `SubqueryNode`/`QueryWithSubqueries` and the optimizer already feeds `AccessPath` into table scans inside derived blocks, but the gate keeps falling back because the new path is missing:
  - `no matching row in const table` for empty-derived / const-empty subqueries (~`explain.go:1909-1957`)
  - `Range checked for each record (index map: 0xN)` for cross-table range refs (~`explain.go:1968-1983`)
  - `Using join buffer (Block Nested Loop)` for non-driving ALL-scan tables (~`explain.go:1989-1991`) and materialized-subquery placeholders (~`explain.go:248-310`, `367-384`)
  - semijoin/materialization plan reordering (`<subqueryN>` rows, `SIMPLE+MATERIALIZED` → `PRIMARY+FirstMatch`)
  - non-merge view → `PRIMARY+DERIVED` rows
  - multi-semijoin column reordering / IMPOSSIBLE WHERE collapse
- The KPI target on `other/explain` (advance first-diff-line from 310 by +500) is **also blocked by a non-EXPLAIN bug**: at line ~310 the `SELECT outr.dt FROM t1 AS outr WHERE outr.dt IN (SELECT innr.dt FROM t2 AS innr WHERE outr.dt IS NULL)` correlated IN-subquery returns 0 rows where MySQL returns 2 rows. So flipping the gate alone — even with full parity — would not move the first-diff-line beyond 310.
- Recommendation: tackle the non-EXPLAIN correlated-IN execution bug as a separate scope (PR #281 made progress on `firstmatch`+IN under DEPENDENT SUBQUERY but the `IS NULL` correlated case is still broken), and only flip the gate after that or after parity items #1-#3 above are ported. Partial-flipping risks regressions on the simple-JOIN path that already uses the new code.

## Test plan
- [x] `go build ./...`
- [x] `go test ./... -count=1`
- [x] `go run ./cmd/mtrrun -test other/explain,other/subquery_sj_mat,other/subquery_sj_all,other/opt_hints_subquery -force` — first-diff-lines unchanged (310 / 5969 / 4084 / 115)

🤖 Generated with [Claude Code](https://claude.com/claude-code)