### PR TITLE
fix: coerce instant ALTER TABLE column DEFAULT through column type (Refs #256)

### DIFF
--- a/executor/ddl.go
+++ b/executor/ddl.go
@@ -4281,6 +4281,15 @@ func (e *Executor) execAlterTable(stmt *sqlparser.AlterTable) (*Result, error) {
 					if colDef.Default != nil {
 						// Parse the default string as a literal if possible.
 						defVal = *colDef.Default
+						// Coerce the parsed default literal through the column's
+						// type so that, e.g., BIT(M) DEFAULT b'010101' is stored
+						// as int64(0x15) (the bit value) rather than the literal
+						// 8-character string "b'010101'". Without coercion the
+						// raw literal survives backfill and comparisons like
+						// `WHERE col = b'010101'` mismatch the stored string.
+						if defVal != nil {
+							defVal = coerceColumnValue(colDef.Type, defVal)
+						}
 					} else if !colDef.Nullable {
 						// NOT NULL column without explicit DEFAULT gets the type's zero value
 						defVal = implicitDefaultForType(colDef.Type)


### PR DESCRIPTION
## Summary

Salvaged from a Round 37 attempt at #256 BIT default that was interrupted mid-flight (usage-policy error). The 9-line slice committed here is self-contained, builds clean, and produces real KPI improvement.

## Bug

When ALTER TABLE adds a NOT NULL column with explicit DEFAULT (e.g. `BIT(8) DEFAULT b'010101'`), the parsed literal was stored as the raw 8-character string `"b'010101'"` rather than the integer bit value 0x15. Subsequent comparisons / IS NULL checks against backfilled rows mismatched.

## Fix

Coerce `defVal` through `coerceColumnValue(colDef.Type, ...)` before applying it as backfill / instant-default in `executor/ddl.go` execAlterTable.

## KPI

`innodb/instant_add_column_basic` first-diff-line: **299 → 338 (+39 lines)**.

Next blocker (out of scope): CHAR / VARCHAR / BLOB column defaults at line 338 — defVal is being coerced but VARCHAR/CHAR/BLOB defaults still surface as NULL for backfilled rows. Tracked under #256.

## Test plan

- [x] `go build ./...`
- [x] `go test ./... -count=1`
- [x] `go run ./cmd/mtrrun -test innodb/instant_add_column_basic -force -skipped-only` — diff advances 299 → 338
- [x] `go run ./cmd/mtrrun -suite innodb -j 1 -force` — no regressions

Refs #256 (issue stays open for VARCHAR/CHAR/BLOB default backfill follow-up).