### PR TITLE
fix(explain): cost-based DuplicateWeedout vs MATERIALIZED (Refs #306)

### DIFF
--- a/executor/explain.go
+++ b/executor/explain.go
@@ -2832,11 +2832,189 @@ func (e *Executor) collectAllTablesForDuplicateWeedout(inner *sqlparser.Select) 
 // (i.e., its WHERE has an IN subquery), which triggers MySQL's DuplicateWeedout semijoin strategy.
 // When DuplicateWeedout is used, MySQL flattens all tables from all nesting levels into a
 // single id=1 SIMPLE join with "Start temporary" / "End temporary" markers.
+//
+// When optimizer_switch=duplicateweedout=off, we apply a cost-based heuristic to decide
+// whether to still flatten or to use MATERIALIZED:
+//   - If any nested IN subquery contains more than one table in its FROM clause
+//     (e.g. 4-level nested IN with multi-table inner subqueries: longblob/correlated case),
+//     MySQL still falls back to DuplicateWeedout-style flattening. → return true.
+//   - If every inner table has a PRIMARY KEY / UNIQUE INDEX on its join column,
+//     MySQL can flatten cheaply via eq_ref lookups (the view+procedure case where
+//     `t1` has PRIMARY KEY on t1field). → return true.
+//   - Otherwise (EMPNUM-style: flat single-table chain with no index on join cols),
+//     MySQL prefers MATERIALIZED. → return false.
 func (e *Executor) shouldUseDuplicateWeedout(inner *sqlparser.Select) bool {
 	if !e.isSemijoinEnabled() {
 		return false
 	}
-	return selectWhereHasINSubquery(inner)
+	if !selectWhereHasINSubquery(inner) {
+		return false
+	}
+	// When the duplicateweedout switch is enabled, keep the original behaviour:
+	// flatten any nested IN subquery chain into id=1 SIMPLE rows.
+	if e.isOptimizerSwitchEnabled("duplicateweedout") {
+		return true
+	}
+	// duplicateweedout=off: fall back to DuplicateWeedout when complex nested IN
+	// pattern is detected (multi-table inner subqueries) OR when every inner table
+	// has an index on the IN-join column (cheap eq_ref flatten path).
+	if innerINSubqueryHasMultiTableSelect(inner) {
+		return true
+	}
+	if e.allInnerINJoinColsIndexed(inner) {
+		return true
+	}
+	return false
+}
+
+// allInnerINJoinColsIndexed returns true when every nested IN subquery in
+// `inner`'s WHERE chain has its join column backed by a PRIMARY KEY or
+// UNIQUE / leading secondary index. This indicates MySQL can flatten cheaply
+// via eq_ref lookups, producing all-SIMPLE EXPLAIN rows even when
+// optimizer_switch=duplicateweedout=off.
+//
+// Returns false (i.e. prefer MATERIALIZED) if the inner SELECT has no
+// nested IN subquery at all, or if any nested join column lacks an index.
+func (e *Executor) allInnerINJoinColsIndexed(inner *sqlparser.Select) bool {
+	if inner == nil || inner.Where == nil || e.Storage == nil {
+		return false
+	}
+	hasNested := false
+	allIndexed := true
+	_ = sqlparser.Walk(func(n sqlparser.SQLNode) (bool, error) {
+		if cmp, ok := n.(*sqlparser.ComparisonExpr); ok {
+			if cmp.Operator == sqlparser.InOp {
+				if sub, ok := cmp.Right.(*sqlparser.Subquery); ok {
+					if nestedSel, ok := sub.Select.(*sqlparser.Select); ok {
+						hasNested = true
+						// Determine the join column projected from the inner SELECT.
+						joinCol := ""
+						if nestedSel.SelectExprs != nil && len(nestedSel.SelectExprs.Exprs) > 0 {
+							if ae, ok2 := nestedSel.SelectExprs.Exprs[0].(*sqlparser.AliasedExpr); ok2 {
+								if c, ok3 := ae.Expr.(*sqlparser.ColName); ok3 {
+									joinCol = c.Name.String()
+								}
+							}
+						}
+						if joinCol == "" {
+							allIndexed = false
+							return false, nil
+						}
+						// Walk inner's FROM tables and require an index on joinCol on
+						// at least one of them (the table the column projects from).
+						colIndexed := false
+						for _, te := range nestedSel.From {
+							for _, tn := range e.extractAllTableNames(te) {
+								if strings.EqualFold(tn, "dual") {
+									continue
+								}
+								tbl, terr := e.Storage.GetTable(e.CurrentDB, tn)
+								if terr != nil || tbl.Def == nil {
+									continue
+								}
+								if len(tbl.Def.PrimaryKey) > 0 && strings.EqualFold(tbl.Def.PrimaryKey[0], joinCol) {
+									colIndexed = true
+									break
+								}
+								for _, idx := range tbl.Def.Indexes {
+									if len(idx.Columns) > 0 && strings.EqualFold(idx.Columns[0], joinCol) {
+										colIndexed = true
+										break
+									}
+								}
+								if colIndexed {
+									break
+								}
+							}
+							if colIndexed {
+								break
+							}
+						}
+						if !colIndexed {
+							allIndexed = false
+							return false, nil
+						}
+						// Recurse: deeper nesting must also be fully indexed.
+						if !e.allInnerINJoinColsIndexed(nestedSel) && nestedSel.Where != nil && selectWhereHasINSubquery(nestedSel) {
+							allIndexed = false
+							return false, nil
+						}
+					}
+					// Handled this IN-subquery node; don't recurse via the walker.
+					return false, nil
+				}
+			}
+		}
+		return true, nil
+	}, inner.Where)
+	return hasNested && allIndexed
+}
+
+// innerINSubqueryHasMultiTableSelect walks the IN subqueries reachable from
+// `inner`'s WHERE clause and returns true if any of them has more than one
+// table in its FROM clause. This is used as the cost-based heuristic to keep
+// DuplicateWeedout flattening for "complex" nested IN cases (e.g. correlated
+// or multi-table inner subqueries) even when optimizer_switch=duplicateweedout=off.
+func innerINSubqueryHasMultiTableSelect(inner *sqlparser.Select) bool {
+	if inner == nil || inner.Where == nil {
+		return false
+	}
+	found := false
+	_ = sqlparser.Walk(func(n sqlparser.SQLNode) (bool, error) {
+		if found {
+			return false, nil
+		}
+		if cmp, ok := n.(*sqlparser.ComparisonExpr); ok {
+			if cmp.Operator == sqlparser.InOp {
+				if sub, ok := cmp.Right.(*sqlparser.Subquery); ok {
+					if nestedSel, ok := sub.Select.(*sqlparser.Select); ok {
+						// Count tables in this nested SELECT's FROM (excluding dual).
+						tableCount := 0
+						for _, te := range nestedSel.From {
+							switch te.(type) {
+							case *sqlparser.AliasedTableExpr, *sqlparser.JoinTableExpr, *sqlparser.ParenTableExpr:
+								// Recursively count joined tables.
+								tableCount += countTablesInTableExpr(te)
+							}
+						}
+						if tableCount > 1 {
+							found = true
+							return false, nil
+						}
+						// Recurse into the nested SELECT's WHERE for deeper nesting.
+						if innerINSubqueryHasMultiTableSelect(nestedSel) {
+							found = true
+							return false, nil
+						}
+					}
+					// Don't descend further into the subquery node via the outer walker;
+					// we've handled it explicitly above.
+					return false, nil
+				}
+			}
+		}
+		return true, nil
+	}, inner.Where)
+	return found
+}
+
+// countTablesInTableExpr returns the number of base tables referenced by a
+// TableExpr (handles aliased tables, joins, paren-grouped joins, and derived
+// tables). Derived tables (subselects in FROM) count as 1 table.
+func countTablesInTableExpr(te sqlparser.TableExpr) int {
+	switch t := te.(type) {
+	case *sqlparser.AliasedTableExpr:
+		return 1
+	case *sqlparser.JoinTableExpr:
+		return countTablesInTableExpr(t.LeftExpr) + countTablesInTableExpr(t.RightExpr)
+	case *sqlparser.ParenTableExpr:
+		n := 0
+		for _, sub := range t.Exprs {
+			n += countTablesInTableExpr(sub)
+		}
+		return n
+	}
+	return 0
 }
 
 // shouldMaterializeSubquery returns true if an IN subquery should use the MATERIALIZED strategy.

--- a/executor/test_dweedout_off_test.go
+++ b/executor/test_dweedout_off_test.go
@@ -1,0 +1,187 @@
+package executor
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/myuon/mylite/catalog"
+	"github.com/myuon/mylite/storage"
+)
+
+// TestDweedoutOff_EMPNUM verifies that when optimizer_switch=duplicateweedout=off
+// and the inner SELECT is "EMPNUM-style" (flat nested IN where every nested
+// subquery has exactly 1 table in FROM), mylite uses MATERIALIZED rather than
+// flatten via DuplicateWeedout. See issue #306.
+func TestDweedoutOff_EMPNUM(t *testing.T) {
+	cat := catalog.New()
+	store := storage.NewEngine()
+	e := New(cat, store)
+	if _, err := e.Execute("CREATE DATABASE IF NOT EXISTS test"); err != nil {
+		t.Fatalf("create db: %v", err)
+	}
+	e.CurrentDB = "test"
+
+	cmds := []string{
+		"SET optimizer_switch='semijoin=on,materialization=on'",
+		"SET optimizer_switch='loosescan=off'",
+		"SET optimizer_switch='firstmatch=off'",
+		"SET optimizer_switch='duplicateweedout=off'",
+		"CREATE TABLE staff (EMPNUM CHAR(3) NOT NULL, EMPNAME CHAR(20), GRADE DECIMAL(4), CITY CHAR(15))",
+		"CREATE TABLE proj (PNUM CHAR(3) NOT NULL, PNAME CHAR(20), PTYPE CHAR(6), BUDGET DECIMAL(9), CITY CHAR(15))",
+		"CREATE TABLE works (EMPNUM CHAR(3) NOT NULL, PNUM CHAR(3) NOT NULL, HOURS DECIMAL(5))",
+		"INSERT INTO staff VALUES ('E1','Alice',12,'Deale')",
+		"INSERT INTO staff VALUES ('E2','Betty',10,'Vienna')",
+		"INSERT INTO staff VALUES ('E3','Carmen',13,'Vienna')",
+		"INSERT INTO proj VALUES  ('P1','MXSS','Design',10000,'Deale')",
+		"INSERT INTO proj VALUES  ('P2','CALM','Code',30000,'Vienna')",
+		"INSERT INTO works VALUES  ('E1','P1',40)",
+	}
+	for _, cmd := range cmds {
+		if _, err := e.Execute(cmd); err != nil {
+			t.Fatalf("Setup %q failed: %v", cmd, err)
+		}
+	}
+
+	res, err := e.Execute("EXPLAIN SELECT EMPNUM, EMPNAME FROM staff WHERE EMPNUM IN (SELECT EMPNUM FROM works WHERE PNUM IN (SELECT PNUM FROM proj))")
+	if err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+	hasMaterialized := false
+	hasStartTemporary := false
+	for _, row := range res.Rows {
+		st := fmt.Sprintf("%v", row[1])
+		ex := fmt.Sprintf("%v", row[11])
+		if st == "MATERIALIZED" {
+			hasMaterialized = true
+		}
+		if strings.Contains(ex, "Start temporary") {
+			hasStartTemporary = true
+		}
+	}
+	if !hasMaterialized {
+		t.Errorf("Expected at least one MATERIALIZED row for EMPNUM-style nested IN with duplicateweedout=off; got rows: %+v", res.Rows)
+	}
+	if hasStartTemporary {
+		t.Errorf("Did not expect DuplicateWeedout flatten (Start temporary) for EMPNUM-style; got rows: %+v", res.Rows)
+	}
+}
+
+// TestDweedoutOff_4Level verifies that when optimizer_switch=duplicateweedout=off
+// and the inner SELECT has a multi-table inner subquery (4-level nested IN),
+// mylite still falls back to DuplicateWeedout-style flatten (Start temporary /
+// End temporary), matching MySQL. See issue #306.
+func TestDweedoutOff_4Level(t *testing.T) {
+	cat := catalog.New()
+	store := storage.NewEngine()
+	e := New(cat, store)
+	if _, err := e.Execute("CREATE DATABASE IF NOT EXISTS test"); err != nil {
+		t.Fatalf("create db: %v", err)
+	}
+	e.CurrentDB = "test"
+
+	cmds := []string{
+		"SET optimizer_switch='semijoin=on,materialization=on'",
+		"SET optimizer_switch='loosescan=off'",
+		"SET optimizer_switch='firstmatch=off'",
+		"SET optimizer_switch='duplicateweedout=off'",
+		"CREATE TABLE t1_16 (a1 blob(16), a2 blob(16))",
+		"CREATE TABLE t2_16 (b1 blob(16), b2 blob(16))",
+		"CREATE TABLE t1 (a1 char(8), a2 char(8))",
+		"CREATE TABLE t2 (b1 char(8), b2 char(8))",
+		"CREATE TABLE t3 (c1 char(8), c2 char(8))",
+		"INSERT INTO t1_16 VALUES ('1 - 01xxxxxxxxxxxx', '2 - 01xxxxxxxxxxxx')",
+		"INSERT INTO t2_16 VALUES ('1 - 01xxxxxxxxxxxx', '2 - 01xxxxxxxxxxxx')",
+		"INSERT INTO t1 VALUES ('1 - 01', '2 - 01')",
+		"INSERT INTO t2 VALUES ('1 - 01', '2 - 01')",
+		"INSERT INTO t3 VALUES ('1 - 01', '2 - 01')",
+	}
+	for _, cmd := range cmds {
+		if _, err := e.Execute(cmd); err != nil {
+			t.Fatalf("Setup %q failed: %v", cmd, err)
+		}
+	}
+
+	q := `EXPLAIN SELECT * FROM t1
+WHERE CONCAT(a1,'x') IN
+(SELECT LEFT(a1,8) FROM t1_16
+WHERE (a1,a2) IN
+(SELECT t2_16.b1, t2_16.b2 FROM t2_16, t2
+WHERE t2.b2 = SUBSTRING(t2_16.b2,1,6) AND
+t2.b1 IN (SELECT c1 FROM t3 WHERE c2 > '0')))`
+	res, err := e.Execute(q)
+	if err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+	hasMaterialized := false
+	hasStartTemporary := false
+	allSimpleID1 := true
+	for _, row := range res.Rows {
+		st := fmt.Sprintf("%v", row[1])
+		ex := fmt.Sprintf("%v", row[11])
+		if st == "MATERIALIZED" {
+			hasMaterialized = true
+		}
+		if strings.Contains(ex, "Start temporary") {
+			hasStartTemporary = true
+		}
+		if fmt.Sprintf("%v", row[0]) != "1" || st != "SIMPLE" {
+			allSimpleID1 = false
+		}
+	}
+	if hasMaterialized {
+		t.Errorf("Did not expect MATERIALIZED rows for 4-level multi-table inner subquery with duplicateweedout=off; got rows: %+v", res.Rows)
+	}
+	if !hasStartTemporary {
+		t.Errorf("Expected DuplicateWeedout flatten (Start temporary marker) for 4-level case; got rows: %+v", res.Rows)
+	}
+	if !allSimpleID1 {
+		t.Errorf("Expected all rows to be id=1 SIMPLE for 4-level DuplicateWeedout flatten; got rows: %+v", res.Rows)
+	}
+}
+
+// TestDweedoutOff_IndexedFlatten verifies that when nested IN join columns are
+// backed by PRIMARY KEY indexes, mylite still flattens (eq_ref path) even with
+// duplicateweedout=off, matching the v1 view + procedure case in
+// other/subquery_sj_mat (BUG#50089).
+func TestDweedoutOff_IndexedFlatten(t *testing.T) {
+	cat := catalog.New()
+	store := storage.NewEngine()
+	e := New(cat, store)
+	if _, err := e.Execute("CREATE DATABASE IF NOT EXISTS test"); err != nil {
+		t.Fatalf("create db: %v", err)
+	}
+	e.CurrentDB = "test"
+
+	cmds := []string{
+		"SET optimizer_switch='semijoin=on,materialization=on'",
+		"SET optimizer_switch='loosescan=off'",
+		"SET optimizer_switch='firstmatch=off'",
+		"SET optimizer_switch='duplicateweedout=off'",
+		"CREATE TABLE t1 (t1field INTEGER, PRIMARY KEY(t1field))",
+		"INSERT INTO t1 VALUES (1),(2)",
+	}
+	for _, cmd := range cmds {
+		if _, err := e.Execute(cmd); err != nil {
+			t.Fatalf("Setup %q failed: %v", cmd, err)
+		}
+	}
+
+	// EXPLAIN SELECT t1field FROM t1 WHERE t1field IN
+	//   (SELECT t1field FROM t1 a WHERE a.t1field IN (SELECT t1field FROM t1));
+	// MySQL flattens to 3 SIMPLE rows because t1.t1field has PRIMARY KEY → eq_ref.
+	res, err := e.Execute("EXPLAIN SELECT t1field FROM t1 WHERE t1field IN (SELECT t1field FROM t1 a WHERE a.t1field IN (SELECT t1field FROM t1))")
+	if err != nil {
+		t.Fatalf("Error: %v", err)
+	}
+	hasMaterialized := false
+	for _, row := range res.Rows {
+		if fmt.Sprintf("%v", row[1]) == "MATERIALIZED" {
+			hasMaterialized = true
+			break
+		}
+	}
+	if hasMaterialized {
+		t.Errorf("Expected flatten (no MATERIALIZED) for indexed nested IN with duplicateweedout=off; got rows: %+v", res.Rows)
+	}
+}


### PR DESCRIPTION
Refs #306

## Summary
- When `optimizer_switch=duplicateweedout=off`, mylite previously still flattened any nested IN subquery into id=1 SIMPLE rows via DuplicateWeedout, ignoring the switch.
- Refines `shouldUseDuplicateWeedout` with a cost-based heuristic that fires only under `duplicateweedout=off`:
  1. Any inner subquery has >1 table in FROM (4-level longblob/correlated case) → still flatten (matches MySQL's fallback).
  2. Every inner table is indexed on its IN-join column (BUG#50089 v1+procedure case where `t1` has PRIMARY KEY on `t1field`) → still flatten via cheap eq_ref path.
  3. Otherwise (EMPNUM-style, no index, flat single-table chain) → drop through to the upstream MATERIALIZED decision.
- Default behaviour (`duplicateweedout=on`) is unchanged.

## Why "Refs" not "Closes"
The strategy decision is now correct for the EMPNUM case (mylite picks MATERIALIZED instead of flattening), and the 4-level case still flattens. However, the EMPNUM EXPLAIN still differs from MySQL in row layout: mylite emits two `<subqueryN>` placeholders + two separate `MATERIALIZED` ids (id=2, id=3), whereas MySQL emits a single `<subquery2>` placeholder with both inner tables joined under one `id=2` materialization. That row-merging is structurally separate from the strategy decision and outside the scope of this issue.

## KPI / regression check

| test | first-diff-line before | after |
| --- | --- | --- |
| `other/subquery_sj_mat` | 6056 | 6056 (no regression; first miss is now MATERIALIZED-row-layout, not strategy choice) |
| `other/subquery_sj_mat_bka` | 6057 | 6057 |
| `other/subquery_sj_mat_bka_nixbnl` | 3521 | 3521 |
| `other/subquery_sj_all` | 4084 | 4084 |
| `other/opt_hints_subquery` | 115 | 115 |

`other` suite head-to-head, first 50 tests:
- before: passed=26, failed=14, skipped=15, errors=1
- after:  passed=26, failed=14, skipped=15, errors=1
- per-test status diff: identical

## Strategy verification (unit tests)
- EMPNUM-style (`duplicateweedout=off`, flat 3-table nested IN over un-indexed CHAR) → MATERIALIZED rows, no `Start temporary` marker.
- 4-level (`duplicateweedout=off`, inner has 2 tables in FROM) → all-SIMPLE id=1 rows with `Start temporary` marker.
- Indexed flatten (`duplicateweedout=off`, t1 has PRIMARY KEY) → no MATERIALIZED rows; flatten preserved.
- Default (`duplicateweedout=on`) on EMPNUM → flatten preserved (3 SIMPLE rows).

## Test plan
- [x] `go build ./...`
- [x] `go test ./... -count=1`
- [x] New unit tests `TestDweedoutOff_EMPNUM`, `TestDweedoutOff_4Level`, `TestDweedoutOff_IndexedFlatten` all pass
- [x] `go run ./cmd/mtrrun -test other/subquery_sj_mat,other/subquery_sj_mat_bka,other/subquery_sj_mat_bka_nixbnl,other/subquery_sj_all,other/opt_hints_subquery -force` — no first-diff regressions
- [x] `go run ./cmd/mtrrun -suite other -j 1 -max 50 -force` head-to-head — identical pass/fail/error sets

🤖 Generated with [Claude Code](https://claude.com/claude-code)