### PR TITLE
fix: compare BINARY/VARBINARY column to 0xNN literal byte-wise (#256)

### DIFF
--- a/executor/expr_eval.go
+++ b/executor/expr_eval.go
@@ -7732,6 +7732,27 @@ func (e *Executor) evalWhere(expr sqlparser.Expr, row storage.Row) (bool, error)
 		if rightWhereOvErr != nil {
 			e.addWarning("Warning", 1292, formatOverflowWarningMsg(rightWhereOvErr))
 		}
+		// VARBINARY/BINARY-column vs HexNum literal: in MySQL, `0xNN` is a
+		// hexadecimal literal that defaults to a binary string. When compared
+		// to a binary column, the bytes should match directly. Vitess parses
+		// `0xNN` as an integer (HexNum), so we explicitly convert it back to
+		// its big-endian byte representation when the other side is a binary
+		// column. This applies to =, !=, <, >, <=, >= operators.
+		if isOrderingOrEqualityOp(v.Operator) || v.Operator == sqlparser.NullSafeEqualOp {
+			if e.isBinaryExpr(leftExprW) && isHexNumLiteral(rightExprW) {
+				if _, isStr := left.(string); isStr {
+					if conv, ok := hexIntToBytes(right).(string); ok {
+						right = conv
+					}
+				}
+			} else if e.isBinaryExpr(rightExprW) && isHexNumLiteral(leftExprW) {
+				if _, isStr := right.(string); isStr {
+					if conv, ok := hexIntToBytes(left).(string); ok {
+						left = conv
+					}
+				}
+			}
+		}
 		// FLOAT-column-vs-literal: model MySQL's single-precision storage
 		// semantics. e.g. `WHERE float_col = 12.34` does not match a row that
 		// stored 12.34, because MySQL stores float32(12.34) = 12.340000152...


### PR DESCRIPTION
## Summary
- Vitess parses ``0x55667788`` as a HexNum integer literal, but in MySQL a hexadecimal literal is a binary string by default. When the other side of the comparison is a BINARY or VARBINARY column, the bytes should match directly.
- Detect this case in ``evalWhere`` (when ``isBinaryExpr(col)`` and ``isHexNumLiteral(literal)``): convert the integer back to its big-endian byte representation before delegating to ``compareValues``.
- Advances ``innodb/instant_add_column_basic`` first-diff-line **396 → 431** (the o2 VARBINARY default was being stored correctly but became unreachable from ``WHERE o2 = 0x55667788`` queries).

## KPI delta
- ``innodb/instant_add_column_basic`` first-diff-line: **396 → 431** (+35 lines)
- All previously-passing tests still pass (verified across sys_vars, jp, gcol, collations, parts, gis, perfschema, sysschema, funcs_1, funcs_2, json, memcached, innodb_fts, innodb_zip, innodb_undo, encryption, clone, opt_trace, binlog, engine_iuds — fail/error sets identical to main).

## Test plan
- [x] ``go build ./...``
- [x] ``go test ./... -count=1``
- [x] ``go run ./cmd/mtrrun -test innodb/instant_add_column_basic -force -skipped-only`` shows new first-diff-line at 431
- [x] No regressions vs main on multiple suites

Refs #256

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>