### PR TITLE
fix(explain): merge nested MATERIALIZED IN subqueries into outer id (Refs #306)

### DIFF
--- a/executor/explain.go
+++ b/executor/explain.go
@@ -5622,10 +5622,41 @@ func (e *Executor) walkForSubqueries(node sqlparser.SQLNode, idCounter *int64, r
 					// path above), MySQL merges its tables into the outer subquery's id level rather
 					// than creating a new subquery id. Use outerIDBeforeIncrement instead.
 					mergedDependent := selectType == "DEPENDENT SUBQUERY" && outerSelectTypeOuter == "DEPENDENT SUBQUERY" && inContext
+					// MATERIALIZED merge: when the parent context is itself MATERIALIZED and the
+					// nested IN subquery also chooses MATERIALIZED, MySQL absorbs the nested
+					// subquery's tables into the parent's MATERIALIZED block (same id),
+					// instead of allocating a new <subqueryN> placeholder.
+					// E.g. EMPNUM: SELECT FROM staff WHERE EMPNUM IN
+					//        (SELECT EMPNUM FROM works WHERE PNUM IN (SELECT PNUM FROM proj))
+					// → both works (id=2 MATERIALIZED) and proj (also id=2 MATERIALIZED, NOT id=3)
+					// share <subquery2>.
+					mergedMaterialized := selectType == "MATERIALIZED" && outerSelectTypeOuter == "MATERIALIZED" && inContext
+					if mergedMaterialized {
+						// Roll back the id allocation: the merged rows reuse the parent's
+						// MATERIALIZED id (outerIDBeforeIncrement), so this subquery does not
+						// consume a new id slot.
+						*idCounter = outerIDBeforeIncrement
+					}
 					subRows := e.explainSelect(inner, idCounter, selectType)
 					if len(subRows) > 0 {
 						if mergedDependent {
 							subRows[0].id = outerIDBeforeIncrement
+						} else if mergedMaterialized {
+							// Force the first row's id to the parent's MATERIALIZED id.
+							// Any deeper-merged MATERIALIZED rows in subRows already share
+							// this id because explainSelect was invoked with idCounter rolled back.
+							subRows[0].id = outerIDBeforeIncrement
+							// Any MATERIALIZED rows that were emitted at the rolled-back id
+							// cascade up automatically (recursive calls see outerSelectType="MATERIALIZED"
+							// and propagate the merge). Force any stray MATERIALIZED rows that still
+							// hold the old subQueryID to use outerIDBeforeIncrement.
+							for i := range subRows {
+								if subRows[i].selectType == "MATERIALIZED" {
+									if id, ok := subRows[i].id.(int64); ok && id == subQueryID {
+										subRows[i].id = outerIDBeforeIncrement
+									}
+								}
+							}
 						} else {
 							subRows[0].id = subQueryID
 						}


### PR DESCRIPTION
Refs #306

## Summary
- Fixes the structural row-merging issue called out in #310 — mylite was emitting `<subquery2>` + `<subquery3>` (two placeholders, separate MATERIALIZED ids 2 and 3) where MySQL emits a single `<subquery2>` with both inner tables joined under id=2 for nested IN subqueries that both choose MATERIALIZED.
- When `walkForSubqueries` detects that the parent context is itself MATERIALIZED and the nested IN subquery also chose MATERIALIZED, the new `mergedMaterialized` branch rolls back the id counter and forces the recursively-collected MATERIALIZED rows' id back to the parent's MATERIALIZED id, mirroring the existing `mergedDependent` (DEPENDENT SUBQUERY) merge logic.

## Example (EMPNUM, BUG#45191 in `subquery_sj_mat`)
```sql
SET optimizer_switch='duplicateweedout=off';
EXPLAIN SELECT EMPNUM,EMPNAME FROM staff
WHERE EMPNUM IN (SELECT EMPNUM FROM works WHERE PNUM IN (SELECT PNUM FROM proj));
```

MySQL:
```
1 SIMPLE staff
1 SIMPLE <subquery2>  eq_ref ...
2 MATERIALIZED proj
2 MATERIALIZED works
```

mylite (before):
```
1 SIMPLE <subquery2>
1 SIMPLE <subquery3>  ← extra placeholder
1 SIMPLE staff
3 MATERIALIZED proj   ← wrong id
2 MATERIALIZED works
```

mylite (after):
```
1 SIMPLE <subquery2>
1 SIMPLE staff
2 MATERIALIZED works
2 MATERIALIZED proj
```

## KPI / regression check

| test                                | first-diff before | after |
| ----------------------------------- | ----------------- | ----- |
| `other/subquery_sj_mat`             | 6056              | 6119 (+63) |
| `other/subquery_sj_mat_bka`         | 6057              | 6120 (+63) |
| `other/subquery_sj_mat_bka_nixbnl`  | 3521              | 3521 |
| `other/subquery_sj_all`             | 4084              | 4084 |
| `other/opt_hints_subquery`          | 115               | 115 |

Full suite head-to-head (29 suites, 3345 tests):
- before: passed=1734, failed=331, skipped=1155, errors=125
- after:  passed=1734, failed=331, skipped=1155, errors=125
- per-test status diff: 0 regressions, 0 changes
- first-diff-line: 2 advances (subquery_sj_mat, subquery_sj_mat_bka), 0 regressions

## Test plan
- [x] `go build ./...`
- [x] `go test ./... -count=1`
- [x] `go run ./cmd/mtrrun -test other/subquery_sj_mat,other/subquery_sj_mat_bka,other/subquery_sj_all,other/opt_hints_subquery -force` — first-diff advances on the two materialized tests, no regressions
- [x] `go run ./cmd/mtrrun` full suite head-to-head — identical pass/fail/error sets

🤖 Generated with [Claude Code](https://claude.com/claude-code)