### PR TITLE
fix: compare ENUM column to integer literal by ENUM index (#256)

### DIFF
--- a/executor/coerce.go
+++ b/executor/coerce.go
@@ -1140,9 +1140,9 @@ func implicitZeroValue(colType string) interface{} {
 		inner := colType[5 : len(colType)-1]
 		vals := splitEnumValues(inner)
 		if len(vals) > 0 {
-			return EnumValue(strings.Trim(vals[0], "'"))
+			return EnumValue{Value: strings.Trim(vals[0], "'"), Index: 1}
 		}
-		return EnumValue("")
+		return EnumValue{Value: "", Index: 0}
 	}
 	// Default for string types (including SET which defaults to empty)
 	return ""
@@ -2921,10 +2921,10 @@ func validateEnumSetValue(colType string, v interface{}) interface{} {
 			// ENUM: index 1..N maps to the Nth element; index 0 = empty string (valid).
 			// Out-of-range indices are left as int64 for the INSERT path to reject.
 			if iv == 0 {
-				return EnumValue("")
+				return EnumValue{Value: "", Index: 0}
 			}
 			if iv >= 1 && int(iv) <= len(allowed) {
-				return EnumValue(allowed[iv-1])
+				return EnumValue{Value: allowed[iv-1], Index: int(iv)}
 			}
 			// Out of range: leave as int64 for strict mode to handle
 			return v
@@ -2961,24 +2961,24 @@ func validateEnumSetValue(colType string, v interface{}) interface{} {
 	}
 	if isEnum {
 		if s == "" {
-			return EnumValue(s)
+			return EnumValue{Value: "", Index: 0}
 		}
 		// Check if the string is a numeric index (stored as string representation of int)
 		if idx, err := strconv.ParseInt(s, 10, 64); err == nil {
 			if idx == 0 {
-				return EnumValue("")
+				return EnumValue{Value: "", Index: 0}
 			}
 			if idx >= 1 && int(idx) <= len(allowed) {
-				return EnumValue(allowed[idx-1])
+				return EnumValue{Value: allowed[idx-1], Index: int(idx)}
 			}
-			return EnumValue("")
+			return EnumValue{Value: "", Index: 0}
 		}
-		for _, a := range allowed {
+		for i, a := range allowed {
 			if strings.EqualFold(s, a) {
-				return EnumValue(a)
+				return EnumValue{Value: a, Index: i + 1}
 			}
 		}
-		return EnumValue("")
+		return EnumValue{Value: "", Index: 0}
 	}
 	// SET validation
 	if s == "" {

--- a/executor/dml_insert.go
+++ b/executor/dml_insert.go
@@ -2155,7 +2155,7 @@ func (e *Executor) execInsert(stmt *sqlparser.Insert) (*Result, error) {
 						sv, isStr := rv.(string)
 						if !isStr {
 							if ev, isEnum := rv.(EnumValue); isEnum {
-								sv = string(ev)
+								sv = ev.Value
 								isStr = true
 							}
 						}
@@ -2165,7 +2165,7 @@ func (e *Executor) execInsert(stmt *sqlparser.Insert) (*Result, error) {
 								if os, ok3 := ov.(string); ok3 {
 									origStr = os
 								} else if oev, ok3 := ov.(EnumValue); ok3 {
-									origStr = string(oev)
+									origStr = oev.Value
 								}
 							}
 							// ENUM: empty string is invalid unless '' is explicitly in the allowed list

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -314,7 +314,20 @@ type cteTable struct {
 // can avoid the generic "non-numeric string → 0" coercion that MySQL applies
 // to plain strings.  The dolt test suite expects ENUM-vs-integer comparisons
 // to use the ENUM index rather than string coercion.
-type EnumValue string
+//
+// Value is the textual ENUM label (e.g. "value1"). Index is the 1-based ENUM
+// position when known (1 for the first enum element). Index is 0 for the
+// special "empty" enum value (assigned when an out-of-range integer is
+// inserted) and may be 0 when the index is not available, in which case
+// ENUM-vs-integer comparisons fall back to string coercion (false).
+type EnumValue struct {
+	Value string
+	Index int
+}
+
+// String implements fmt.Stringer so that fmt.Sprintf("%v", EnumValue) emits
+// just the underlying label (matching the previous EnumValue-as-string behavior).
+func (e EnumValue) String() string { return e.Value }
 
 // psDigestEntry tracks a statement digest for performance_schema tables.
 type psDigestEntry struct {

--- a/executor/expr_eval.go
+++ b/executor/expr_eval.go
@@ -8213,9 +8213,20 @@ func compareValues(left, right interface{}, op sqlparser.ComparisonExprOperator)
 		if errL == nil && errR == nil {
 			return false, nil
 		}
-		// ENUM values compared with integers: do not coerce via string→0 rule.
-		_, leftIsEnum := left.(EnumValue)
-		_, rightIsEnum := right.(EnumValue)
+		// ENUM values compared with integers: MySQL compares using the ENUM's
+		// 1-based index (so q1 = 1 matches the first enum element).
+		leftEnum, leftIsEnum := left.(EnumValue)
+		rightEnum, rightIsEnum := right.(EnumValue)
+		if leftIsEnum && errR == nil && isNativeNumericType(right) {
+			if leftEnum.Index > 0 {
+				return float64(leftEnum.Index) == fr, nil
+			}
+		}
+		if rightIsEnum && errL == nil && isNativeNumericType(left) {
+			if rightEnum.Index > 0 {
+				return fl == float64(rightEnum.Index), nil
+			}
+		}
 		// MySQL type coercion: when one operand is a DATE/TIME-like string
 		// and the other is a native integer, convert the integer to DATE/TIME
 		// format for comparison (e.g., 19830907 → "1983-09-07", 000400 → "00:04:00").
@@ -8387,8 +8398,19 @@ func compareValues(left, right interface{}, op sqlparser.ComparisonExprOperator)
 		if errL == nil && errR == nil {
 			return true, nil
 		}
-		_, leftIsEnum := left.(EnumValue)
-		_, rightIsEnum := right.(EnumValue)
+		leftEnum, leftIsEnum := left.(EnumValue)
+		rightEnum, rightIsEnum := right.(EnumValue)
+		// ENUM compared with integer uses the ENUM's 1-based index.
+		if leftIsEnum && errR == nil && isNativeNumericType(right) {
+			if leftEnum.Index > 0 {
+				return float64(leftEnum.Index) != fr, nil
+			}
+		}
+		if rightIsEnum && errL == nil && isNativeNumericType(left) {
+			if rightEnum.Index > 0 {
+				return fl != float64(rightEnum.Index), nil
+			}
+		}
 		// MySQL type coercion: when one operand is a native numeric type
 		// and the other is a non-numeric string, try DATE/TIME coercion first.
 		if errL == nil && errR != nil && isNativeNumericType(left) {

--- a/executor/typeutil.go
+++ b/executor/typeutil.go
@@ -334,7 +334,7 @@ func toString(v interface{}) string {
 	case HexBytes:
 		return string(val)
 	case EnumValue:
-		return string(val)
+		return val.Value
 	case []byte:
 		return string(val)
 	case int64:

--- a/server/server.go
+++ b/server/server.go
@@ -494,7 +494,7 @@ func normalizeRows(rows [][]interface{}) [][]interface{} {
 			} else if ar, ok := val.(executor.AvgResult); ok {
 				rows[i][j] = ar.String()
 			} else if ev, ok := val.(executor.EnumValue); ok {
-				rows[i][j] = string(ev)
+				rows[i][j] = ev.Value
 			} else if hb, ok := val.(executor.HexBytes); ok {
 				// HexBytes stores hex-encoded data (e.g. "31" for x'31').
 				// Decode to raw bytes for the wire protocol.


### PR DESCRIPTION
## Summary
- ``ENUM('value1','value2','value3')`` column compared to integer literal now uses the 1-based ENUM index (so ``WHERE q1 = 1`` matches rows where ``q1 = 'value1'``).
- ``EnumValue`` is now a struct carrying both ``Value`` and ``Index``; ``compareValues`` maps the integer operand against ``EnumValue.Index`` for ``=`` / ``!=``.
- Existing ``string(ev)`` casts (server protocol, dml_insert) replaced with ``ev.Value``; ``EnumValue.String()`` keeps ``%v`` formatting unchanged.

## KPI delta
- ``innodb/instant_add_column_basic`` first-diff-line: **457 -> 497** (+40 lines). Next blocker at 497 is unrelated BLOB hex display (``0102030405`` vs ``102030405``).

## Test plan
- [x] ``go build ./...`` clean
- [x] ``go test ./... -count=1`` green
- [x] ``mtrrun -test innodb/instant_add_column_basic -force -skipped-only`` advances first-diff-line 457 -> 497
- [x] ``mtrrun -suite innodb,opt_trace,parts,gcol -force`` fail set identical to main (``innodb/skip_locked_nowait_isolation``, ``parts/partition_bit_innodb``, ``parts/partition_int_innodb`` -- all pre-existing flaky)

Refs #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)