### PR TITLE
fix(mtrrun): preserve leading whitespace after a closed-quote line

### DIFF
--- a/mtrrunner/runner.go
+++ b/mtrrunner/runner.go
@@ -1017,6 +1017,12 @@ func (ctx *execContext) executeLines(lines []string) error {
 		inDoubleQuote := false  // track if we're inside a double-quoted string literal
 		inBlockComment := false // track if we're inside a /* ... */ block comment
 		inStringLiteral := false // combined: true when inside either quote type
+		// prevLineEndedWithQuote: tracks whether the previous line's last
+		// non-whitespace character was a closing quote ('"', "'", or '`').
+		// MySQL's mysqltest preserves leading whitespace on a line when the
+		// previous line ended with a closed quoted string literal (see
+		// convert_to_format_v1 in client/mysqltest.cc — `last_c_was_quote`).
+		prevLineEndedWithQuote := false
 		for i < len(lines) {
 			l := lines[i]
 			t := strings.TrimSpace(l)
@@ -1036,10 +1042,12 @@ func (ctx *execContext) executeLines(lines []string) error {
 			}
 
 			// For echoing: if inside a string literal, preserve leading whitespace.
-			// Otherwise, trim leading whitespace (mysqltest behavior).
+			// Also preserve leading whitespace when the previous line ended with
+			// a closed quote (mysqltest convert_to_format_v1 last_c_was_quote behavior).
+			// Otherwise, trim leading whitespace (mysqltest default behavior).
 			var rawEcho string
 			stmtLine := t
-			if inStringLiteral {
+			if inStringLiteral || prevLineEndedWithQuote {
 				rawEcho = stripCommentAfterDelimiter(strings.TrimRight(l, " \t\r\n"), delim)
 				stmtLine = strings.TrimRight(l, " \t\r\n")
 			} else {
@@ -1111,6 +1119,17 @@ func (ctx *execContext) executeLines(lines []string) error {
 				}
 			}
 			inStringLiteral = inSingleQuote || inDoubleQuote
+			// Update prevLineEndedWithQuote for the NEXT iteration:
+			// true iff the line's last non-whitespace character is a closing
+			// quote (not currently inside an open quote). MySQL preserves
+			// leading whitespace on a line when this is set.
+			lineForCheck := strings.TrimRight(l, " \t\r\n")
+			if !inStringLiteral && len(lineForCheck) > 0 {
+				lastCh := lineForCheck[len(lineForCheck)-1]
+				prevLineEndedWithQuote = lastCh == '\'' || lastCh == '"' || lastCh == '`'
+			} else {
+				prevLineEndedWithQuote = false
+			}
 			// Strip inline comments (# outside quotes) for SQL processing
 			if !inStringLiteral {
 				t = stripInlineComment(t)


### PR DESCRIPTION
Refs #81

## Summary

mysqltest's `convert_to_format_v1` (`client/mysqltest.cc`) tracks `last_c_was_quote`: if the previous line's last non-whitespace character is a closing quote (`'`, `"`, or `` ` ``), the leading whitespace on the next line is preserved when echoing the SQL.

Mirror this behavior in mtrrun's per-line echo loop so multi-line SQL like:

```sql
explain SELECT a.idIndividual FROM t1 a
WHERE a.idIndividual IN
	(	SELECT c.idObj FROM t3 cona
		INNER JOIN t2 c ON c.idContact=cona.idContact
		WHERE cona.postalStripped='T2H3B2'
	);
```

is echoed with the trailing `\t);` after the `'T2H3B2'` quoted literal — matching the MySQL `.result` file. mtrrun was previously stripping the leading tab from every continuation line, including the closing line.

The implementation:
- Adds `prevLineEndedWithQuote` to the SQL echo loop in `executeLines`.
- After processing each line, sets the flag based on whether the last non-whitespace char is `'`, `"`, or `` ` `` and we're not currently inside an open quote.
- When the flag is set, the next line's `rawEcho` preserves leading whitespace (uses the same path as the existing `inStringLiteral` branch).

## KPI / regression check

`other` suite head-to-head with the same binary path:

| test                                | first-diff before | after      |
| ----------------------------------- | ----------------- | ---------- |
| `other/subquery_sj_mat`             | 6119              | 6274 (+155)|
| `other/subquery_sj_mat_bka`         | 6120              | 6275 (+155)|
| `other/subquery_sj_mat_bka_nixbnl`  | 3521              | 3521       |
| `other/subquery_sj_all`             | 4084              | 4084       |
| `other/opt_hints_subquery`          | 115               | 115        |

Full suite head-to-head (29 suites, 3345 tests):
- before: passed=1734, failed=331, skipped=1155, errors=125
- after:  passed=1734, failed=331, skipped=1155, errors=125
- per-test status diff: 0
- first-diff-line: 2 advances (subquery_sj_mat, subquery_sj_mat_bka), 0 regressions

## Test plan
- [x] `go build ./...`
- [x] `go test ./... -count=1`
- [x] `go run ./cmd/mtrrun -test other/subquery_sj_mat,other/subquery_sj_mat_bka,other/subquery_sj_mat_bka_nixbnl,other/subquery_sj_all,other/opt_hints_subquery -force`
- [x] full suite head-to-head — identical pass/fail/error sets, only the two target advances

🤖 Generated with [Claude Code](https://claude.com/claude-code)