### PR TITLE
fix(executor): report unknown LHS column before IN-subquery column-count mismatch (Refs #81)

### DIFF
--- a/executor/expr_eval.go
+++ b/executor/expr_eval.go
@@ -7133,6 +7133,67 @@ func (e *Executor) evalHaving(expr sqlparser.Expr, havingRow storage.Row, groupR
 	return e.evalWhere(expr, enrichedRow)
 }
 
+// findUnknownColInTupleForIN walks the LHS expressions of an IN/ANY/ALL
+// predicate looking for bare ColName references that resolve to neither the
+// current row nor any correlated outer row. If found, it returns a
+// MySQL-compatible "Unknown column 'X' in 'IN/ALL/ANY subquery'" error so
+// callers can report it BEFORE the column-count mismatch error fires.
+//
+// MySQL resolves names during query preparation, so an unknown column in the
+// IN's LHS is reported before the column-count mismatch between LHS and
+// subquery. We mirror that ordering by checking the tuple here.
+//
+// Only unqualified ColName references are checked. Qualified references
+// (table.col) require deeper schema context that this lightweight pass
+// intentionally avoids.
+func (e *Executor) findUnknownColInTupleForIN(exprs []sqlparser.Expr, row storage.Row) error {
+	for _, ex := range exprs {
+		col, ok := ex.(*sqlparser.ColName)
+		if !ok {
+			continue
+		}
+		if !col.Qualifier.IsEmpty() {
+			continue
+		}
+		name := col.Name.String()
+		if row != nil {
+			if _, found := row[name]; found {
+				continue
+			}
+			upper := strings.ToUpper(name)
+			matched := false
+			for k := range row {
+				if strings.ToUpper(k) == upper {
+					matched = true
+					break
+				}
+			}
+			if matched {
+				continue
+			}
+		}
+		// Check correlatedRow (outer query columns)
+		if e.correlatedRow != nil {
+			if _, found := e.correlatedRow[name]; found {
+				continue
+			}
+			upper := strings.ToUpper(name)
+			outerMatched := false
+			for k := range e.correlatedRow {
+				if strings.ToUpper(k) == upper {
+					outerMatched = true
+					break
+				}
+			}
+			if outerMatched {
+				continue
+			}
+		}
+		return mysqlError(1054, "42S22", fmt.Sprintf("Unknown column '%s' in 'IN/ALL/ANY subquery'", name))
+	}
+	return nil
+}
+
 // evalWhere evaluates a WHERE predicate against a row.
 func (e *Executor) evalWhere(expr sqlparser.Expr, row storage.Row) (bool, error) {
 	switch v := expr.(type) {
@@ -7147,6 +7208,13 @@ func (e *Executor) evalWhere(expr sqlparser.Expr, row storage.Row) (bool, error)
 				}
 				// Check if left side is a tuple: (a,b) IN (SELECT x,y FROM ...)
 				if leftTuple, ok := v.Left.(sqlparser.ValTuple); ok {
+					// MySQL resolves names during query preparation, so an
+					// unresolved column on the LHS surfaces as
+					// "Unknown column 'X' in 'IN/ALL/ANY subquery'" before any
+					// row evaluation. Mirror that ordering.
+					if colErr := e.findUnknownColInTupleForIN([]sqlparser.Expr(leftTuple), row); colErr != nil {
+						return false, colErr
+					}
 					result, err := e.execSubquery(sub, row)
 					if err != nil {
 						return false, err

--- a/executor/select.go
+++ b/executor/select.go
@@ -7188,6 +7188,11 @@ func (e *Executor) evalInSubquery(leftVal interface{}, leftExpr sqlparser.Expr, 
 	// Check if left is a tuple: (a,b) IN (SELECT x,y FROM ...)
 	if leftTuple, ok := leftExpr.(sqlparser.ValTuple); ok {
 		if len(result.Columns) != len(leftTuple) {
+			// MySQL reports unknown-column errors on the LHS tuple BEFORE
+			// reporting "Operand should contain N column(s)". Mirror that.
+			if colErr := e.findUnknownColInTupleForIN([]sqlparser.Expr(leftTuple), nil); colErr != nil {
+				return nil, colErr
+			}
 			return nil, mysqlError(1241, "21000", fmt.Sprintf("Operand should contain %d column(s)", len(leftTuple)))
 		}
 		leftVals := make([]interface{}, len(leftTuple))


### PR DESCRIPTION
Refs #81 (Round 25, follow-up to #315)

## Summary

MySQL resolves names during query preparation, so an unresolved column on the LHS of a row `IN` subquery is reported as `Unknown column 'X' in 'IN/ALL/ANY subquery'` (`ER_BAD_FIELD_ERROR`) **before** `Operand should contain N column(s)` (`ER_OPERAND_COLUMNS`). mylite was checking the column-count mismatch first, which:

- surfaced the wrong error first when both conditions held; and
- silently treated unresolved LHS columns as NULL when the LHS/RHS counts happened to match.

This patch adds a lightweight pre-check in both the WHERE evaluator (`evalWhere` tuple-IN-subquery branch) and `evalInSubquery`. They now look up each unqualified `ColName` on the LHS tuple against the current row and any correlated outer row; if a name resolves to neither, they return the MySQL-worded error. Qualified references (`table.col`) keep the existing code path so this is strictly additive.

Concretely it fixes the OUTR test cases at lines 6274 and 6278 of `other/subquery_sj_mat`:

```sql
SELECT varchar_nokey FROM C
WHERE (varchar_nokey, OUTR) IN (SELECT varchar_nokey FROM BB);
-- expected: ERROR 42S22: Unknown column 'OUTR' in 'IN/ALL/ANY subquery'
```

## KPI delta (first-diff-line)

| Test | Before | After | Delta |
| --- | --- | --- | --- |
| `other/subquery_sj_mat` | 6274 | 6685 | +411 |
| `other/subquery_sj_mat_bka` | 6275 | 6686 | +411 |
| `other/subquery_sj_mat_bka_nixbnl` | 3521 | 3521 | 0 |
| `other/subquery_sj_all` | 4084 | 4084 | 0 |
| `other/opt_hints_subquery` | 115 | 115 | 0 |

Cumulative for `subquery_sj_mat` since Round 24: **3397 -> 6685 (+3288)**.

No regressions in the targeted set.

## Test plan

- [x] `go build ./...`
- [x] `go test ./... -count=1`
- [x] `go run ./cmd/mtrrun -test other/subquery_sj_mat,other/subquery_sj_mat_bka,other/subquery_sj_mat_bka_nixbnl,other/subquery_sj_all,other/opt_hints_subquery -force`

🤖 Generated with [Claude Code](https://claude.com/claude-code)