### PR TITLE
fix: store 0xNN hex literal as raw bytes when inserting into BLOB column

### DIFF
--- a/executor/ddl.go
+++ b/executor/ddl.go
@@ -6062,6 +6062,20 @@ func isVarbinaryType(colType string) bool {
 	return strings.HasPrefix(lower, "varbinary(")
 }
 
+// isBlobColType returns true if the column type is one of the BLOB family
+// (BLOB, TINYBLOB, MEDIUMBLOB, LONGBLOB), with or without a length spec.
+func isBlobColType(colType string) bool {
+	lower := strings.ToLower(strings.TrimSpace(colType))
+	if i := strings.IndexByte(lower, '('); i >= 0 {
+		lower = strings.TrimSpace(lower[:i])
+	}
+	switch lower {
+	case "blob", "tinyblob", "mediumblob", "longblob":
+		return true
+	}
+	return false
+}
+
 // looksLikeBinaryData returns true if s contains bytes that are unlikely to appear
 // in a normal text string (null bytes or bytes < 0x09), indicating it's binary data
 // from a BINARY/VARBINARY column.

--- a/executor/dml_insert.go
+++ b/executor/dml_insert.go
@@ -998,6 +998,20 @@ func (e *Executor) execInsert(stmt *sqlparser.Insert) (*Result, error) {
 				}
 			}
 			v, err := e.evalExpr(val)
+			// For BLOB family columns, hex-number literals (0xNN) are stored as the
+			// raw bytes they encode (matching VARBINARY behaviour), so HEX(col)
+			// round-trips to the original digits including any leading zero byte.
+			// Plain integer/decimal literals retain their string representation.
+			if err == nil && v != nil && isHexNumLiteral(val) {
+				for _, col := range tbl.Def.Columns {
+					if col.Name == colNames[i] {
+						if isBlobColType(col.Type) {
+							v = hexIntToBytes(v)
+						}
+						break
+					}
+				}
+			}
 			// For INSERT ... SET col1=val1, col2=col1 — if the expression is a bare
 			// column name reference and that column was already assigned in this same
 			// INSERT SET clause, use the previously-assigned value (left-to-right


### PR DESCRIPTION
## Summary
- ``INSERT INTO ... VALUES(0x0102030405)`` into a BLOB column now stores the
  value as the 5-byte sequence ``\x01\x02\x03\x04\x05`` (matching VARBINARY
  behaviour), so ``HEX(col)`` round-trips to the original digits including
  any leading zero byte.
- Plain integer/decimal literals still retain their string representation
  (e.g. ``INSERT (..., 17, ...)`` into a BLOB stores ``\"17\"``).
- New ``isBlobColType`` helper covers BLOB/TINYBLOB/MEDIUMBLOB/LONGBLOB.

## KPI delta
- ``innodb/instant_add_column_basic`` first-diff-line: **497 -> 511** (+14 lines).
- Full mtrrun regression check: identical pass/fail/error counts (1734/331/125)
  and identical pass list vs main.

## Test plan
- [x] ``go build ./...`` clean
- [x] ``go test ./... -count=1`` green
- [x] ``mtrrun -test innodb/instant_add_column_basic -force -skipped-only``
      advances first-diff-line 497 -> 511
- [x] Targeted regression: ``other/default``, ``other/innodb_mrr``, ``other/myisam_mrr``,
      ``other/type_blob``, ``other/type_binary``, ``other/binary_to_hex``,
      ``other/ctype_binary``, ``other/func_concat`` -- no regression
- [x] ``mtrrun -force`` (full suite) -- pass list identical to main

Refs #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)