### PR TITLE
feat(explain): preserve column case in auto-named indexes & include covering indexes (Refs #81)

### DIFF
--- a/executor/ddl.go
+++ b/executor/ddl.go
@@ -1607,6 +1607,16 @@ func (e *Executor) execCreateTable(stmt *sqlparser.CreateTable) (*Result, error)
 		}
 		var idxCols []string
 		var idxOrders []string
+		var idxColOrigNames []string // resolved-case column names for auto-named indexes
+		// Helper: find the column name as defined in the table (preserves CREATE TABLE case).
+		resolveColCase := func(name string) string {
+			for _, c := range columns {
+				if strings.EqualFold(c.Name, name) {
+					return c.Name
+				}
+			}
+			return name
+		}
 		for _, idxCol := range idx.Columns {
 			if err := validateArrayIndexExpression(idxCol.Expression); err != nil {
 				return nil, err
@@ -1614,11 +1624,16 @@ func (e *Executor) execCreateTable(stmt *sqlparser.CreateTable) (*Result, error)
 			if hasArrayCastExpr(idxCol.Expression) {
 				hasArrayMVIIndex = true
 			}
-			colStr := strings.ToLower(idxCol.Column.String())
+			refName := idxCol.Column.String()
+			colStr := strings.ToLower(refName)
 			if idxCol.Expression != nil {
 				colStr = fmt.Sprintf("(%s)", strings.TrimSpace(sqlparser.String(idxCol.Expression)))
+				idxColOrigNames = append(idxColOrigNames, colStr)
 			} else if idxCol.Length != nil {
 				colStr += fmt.Sprintf("(%d)", *idxCol.Length)
+				idxColOrigNames = append(idxColOrigNames, fmt.Sprintf("%s(%d)", resolveColCase(refName), *idxCol.Length))
+			} else {
+				idxColOrigNames = append(idxColOrigNames, resolveColCase(refName))
 			}
 			idxCols = append(idxCols, colStr)
 			if idxCol.Direction == sqlparser.DescOrder {
@@ -1858,8 +1873,14 @@ func (e *Executor) execCreateTable(stmt *sqlparser.CreateTable) (*Result, error)
 				if cn := idx.Info.ConstraintName.String(); cn != "" {
 					idxName = cn
 				} else {
-					// Use column name without prefix length for default index name
-					idxName = stripPrefixLengthFromCol(idxCols[0])
+					// Use column name without prefix length for default index name.
+					// Preserve original case from the CREATE TABLE definition (MySQL uses
+					// the column identifier as written for the auto-generated index name).
+					if len(idxColOrigNames) > 0 {
+						idxName = stripPrefixLengthFromCol(idxColOrigNames[0])
+					} else {
+						idxName = stripPrefixLengthFromCol(idxCols[0])
+					}
 				}
 			}
 			idxComment := ""

--- a/executor/explain.go
+++ b/executor/explain.go
@@ -6078,6 +6078,26 @@ func (e *Executor) explainDetectAccessType(sel *sqlparser.Select, tableName stri
 	for i, m := range matches {
 		possibleKeyNames[i] = m.index.Name
 	}
+	// Also include indexes that cover the SELECT projection (covering-index candidates).
+	// MySQL lists these in possible_keys even when they don't match the WHERE clause.
+	if sel.SelectExprs != nil {
+		selectCols, isStar := explainExtractSelectColumns(sel.SelectExprs, tableName)
+		if !isStar && len(selectCols) > 0 {
+			already := map[string]bool{}
+			for _, n := range possibleKeyNames {
+				already[strings.ToLower(n)] = true
+			}
+			for _, idx := range td.Indexes {
+				if already[strings.ToLower(idx.Name)] {
+					continue
+				}
+				if explainIndexCoversColumns(td, idx.Name, selectCols) {
+					possibleKeyNames = append(possibleKeyNames, idx.Name)
+					already[strings.ToLower(idx.Name)] = true
+				}
+			}
+		}
+	}
 	result.possibleKeys = strings.Join(possibleKeyNames, ",")
 
 	// Choose the best index: prefer const > eq_ref > ref > range
@@ -6895,7 +6915,8 @@ func (e *Executor) explainJSONTableBlock(row []interface{}, query string) []orde
 							break
 						}
 						accum += explainKeyLen(colDef, td.Charset)
-						usedKeyParts = append(usedKeyParts, col)
+						// Use the original-case column name from the table definition.
+						usedKeyParts = append(usedKeyParts, colDef.Name)
 						if accum >= keyLenVal {
 							break
 						}
@@ -6903,7 +6924,12 @@ func (e *Executor) explainJSONTableBlock(row []interface{}, query string) []orde
 				} else if len(idxCols) > 0 {
 					// No key_len, use all index columns
 					for _, col := range idxCols {
-						usedKeyParts = append(usedKeyParts, col)
+						colDef := findColumnDef(td, col)
+						if colDef != nil {
+							usedKeyParts = append(usedKeyParts, colDef.Name)
+						} else {
+							usedKeyParts = append(usedKeyParts, col)
+						}
 					}
 				}
 			}


### PR DESCRIPTION
## Summary
- When CREATE TABLE defines `INDEX (Population)` without an explicit index name, MySQL uses the column's declared case as the index name. We previously lowercased to `population`, breaking EXPLAIN JSON output. Now resolve from the column definition's case.
- Extend `possible_keys` to include indexes that cover the SELECT projection (covering-index candidates), matching MySQL.
- Use declared column case in `used_key_parts`.

## KPI
- `other/subquery_sj_mat` first-diff-line: 6685 -> 6715 (+30)
- `other/subquery_sj_mat_bka` first-diff-line: 6686 -> 6716 (+30)
- No regressions in suite `other` (full run).
- `insert_update` still passes (the duplicate-key error message uses the column's declared case, which is what MySQL emits).

## Test plan
- [x] `go build ./...`
- [x] `go test ./... -count=1`
- [x] `go run ./cmd/mtrrun -test other/subquery_sj_mat,other/subquery_sj_mat_bka,other/subquery_sj_mat_bka_nixbnl,other/subquery_sj_all,other/opt_hints_subquery,other/insert_update`
- [x] `go run ./cmd/mtrrun -suite other -j 1` baseline vs after — no pass→fail regressions, 2 advances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)