### PR TITLE
fix(innodb): exclude VIRTUAL gcols from has_default in innodb_columns

### DIFF
--- a/executor/information_schema.go
+++ b/executor/information_schema.go
@@ -1657,8 +1657,16 @@ func (e *Executor) infoSchemaInnoDBColumns() []storage.Row {
 				for i, col := range def.Columns {
 					hasDefault := int64(0)
 					var defaultValue interface{} = nil
+					// VIRTUAL generated columns are not physically stored, so they
+					// never carry an InnoDB-level default value (the value is
+					// computed from the expression on read). MySQL reports
+					// has_default=0 for them in INNODB_COLUMNS even when added
+					// via INSTANT.
+					genExpr := generatedColumnExpr(col.Type)
+					isStoredGen := genExpr != "" && strings.Contains(strings.ToUpper(col.Type), "STORED")
+					isVirtualGen := genExpr != "" && !isStoredGen
 					// Only INSTANT-added columns have their default tracked in INNODB_COLUMNS.
-					if col.IsInstantAdded {
+					if col.IsInstantAdded && !isVirtualGen {
 						hasDefault = 1
 						if col.Nullable && col.Default == nil {
 							// Nullable column without explicit default: default is SQL NULL.

--- a/executor/instant_virtual_default_test.go
+++ b/executor/instant_virtual_default_test.go
@@ -1,0 +1,105 @@
+package executor
+
+import (
+	"testing"
+)
+
+// TestInstantAddVirtualHasDefault verifies that VIRTUAL generated columns
+// added via INSTANT ALTER do not appear in INFORMATION_SCHEMA.INNODB_COLUMNS
+// with has_default=1. MySQL only marks physically stored INSTANT-added
+// columns with has_default=1 because virtual columns are computed on read
+// and never carry an InnoDB-level default.
+func TestInstantAddVirtualHasDefault(t *testing.T) {
+	e := newTestExecutor(t)
+	if _, err := e.Execute("CREATE TABLE tinst_vd(a INT NOT NULL AUTO_INCREMENT PRIMARY KEY, b INT) ROW_FORMAT=REDUNDANT"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := e.Execute("ALTER TABLE tinst_vd ADD COLUMN c INT NOT NULL, ADD COLUMN d INT GENERATED ALWAYS AS ((b * 2)) VIRTUAL"); err != nil {
+		t.Fatal(err)
+	}
+
+	// Get table_id from innodb_tables.
+	r, err := e.Execute("SELECT table_id FROM information_schema.innodb_tables WHERE name like '%tinst_vd%'")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(r.Rows) == 0 {
+		t.Fatalf("no innodb_tables row for tinst_vd")
+	}
+	tableID := r.Rows[0][0]
+
+	// count(*) WHERE has_default=1 should be 1 (only column `c`).
+	r, err = e.Execute("SELECT count(*) FROM information_schema.innodb_columns WHERE table_id = ? AND has_default = 1")
+	if err != nil {
+		// Fallback: literal interpolation if the placeholder route is unsupported here.
+		r, err = e.Execute("SELECT count(*) FROM information_schema.innodb_columns WHERE has_default = 1 AND table_id = " + sprintAny(tableID))
+		if err != nil {
+			t.Fatal(err)
+		}
+	} else {
+		_ = tableID
+	}
+	if len(r.Rows) == 0 {
+		t.Fatalf("no count rows")
+	}
+	got := r.Rows[0][0]
+	if !equalInt(got, 1) {
+		t.Fatalf("expected count(*) WHERE has_default=1 = 1 (only `c`), got %v", got)
+	}
+
+	// Sanity: the virtual column `d` should be present with has_default=0.
+	r, err = e.Execute("SELECT name, has_default FROM information_schema.innodb_columns WHERE name = 'd' AND has_default = 1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(r.Rows) != 0 {
+		t.Fatalf("virtual column `d` must not have has_default=1, rows=%v", r.Rows)
+	}
+}
+
+func sprintAny(v interface{}) string {
+	switch x := v.(type) {
+	case int64:
+		return itoa(x)
+	case int:
+		return itoa(int64(x))
+	}
+	return ""
+}
+
+func itoa(i int64) string {
+	// minimal int64 to string without strconv import noise.
+	if i == 0 {
+		return "0"
+	}
+	neg := i < 0
+	if neg {
+		i = -i
+	}
+	var buf [20]byte
+	pos := len(buf)
+	for i > 0 {
+		pos--
+		buf[pos] = byte('0' + i%10)
+		i /= 10
+	}
+	if neg {
+		pos--
+		buf[pos] = '-'
+	}
+	return string(buf[pos:])
+}
+
+func equalInt(v interface{}, want int64) bool {
+	switch x := v.(type) {
+	case int:
+		return int64(x) == want
+	case int32:
+		return int64(x) == want
+	case int64:
+		return x == want
+	case uint64:
+		return int64(x) == want
+	}
+	return false
+}


### PR DESCRIPTION
## Summary
- VIRTUAL generated columns are computed on read and never carry an
  InnoDB-level default. MySQL reports ``has_default=0`` for them in
  ``INFORMATION_SCHEMA.INNODB_COLUMNS`` even when the column was added
  via INSTANT ALTER.
- We were marking every ``IsInstantAdded`` column with ``has_default=1``,
  double-counting virtual columns when tests check
  ``count(*) ... WHERE has_default = 1``.

## KPI delta
- ``innodb/instant_add_column_basic`` first-diff-line: **576 -> 656**
  (+80 lines). The next blocker is the GENERATED column expression
  formatting parens (separate issue, noted in the previous PR).

## Test plan
- [x] ``go build ./...`` clean
- [x] ``go test ./... -count=1`` green (added unit test
      ``TestInstantAddVirtualHasDefault``)
- [x] ``mtrrun -test innodb/instant_add_column_basic -force
      -skipped-only`` advances first-diff-line 576 -> 656
- [x] ``mtrrun -suite innodb -force`` -- pass list identical to baseline
      (93 passed, single pre-existing failure
      ``skip_locked_nowait_isolation``)
- [x] ``mtrrun -suite gcol,gcol_ndb -force`` -- 14 pass, 0 fail (no
      regression)
- [x] ``mtrrun -suite innodb_zip,innodb_fts,innodb_undo -force`` -- pass
      list identical to baseline (single pre-existing
      ``innodb_zip/wl5522_zip``)
- [x] ``mtrrun -suite parts -force`` -- failure list identical to
      baseline (``partition_bit_innodb``, ``partition_int_innodb``)

Refs #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)