### PR TITLE
fix(show): wrap nested binary subexpressions in parens for SHOW CREATE TABLE

### DIFF
--- a/executor/show.go
+++ b/executor/show.go
@@ -1354,7 +1354,17 @@ func mysqlGenExprNode(expr sqlparser.Expr, colCharset string) string {
 	case *sqlparser.ColName:
 		return "`" + e.Name.String() + "`"
 	case *sqlparser.BinaryExpr:
-		return fmt.Sprintf("%s %s %s", mysqlGenExprNode(e.Left, colCharset), e.Operator.ToString(), mysqlGenExprNode(e.Right, colCharset))
+		// MySQL wraps nested binary subexpressions in parens in SHOW CREATE TABLE
+		// generated column display (e.g. ((`a` * 2) + `b`)).
+		leftStr := mysqlGenExprNode(e.Left, colCharset)
+		if _, ok := e.Left.(*sqlparser.BinaryExpr); ok {
+			leftStr = "(" + leftStr + ")"
+		}
+		rightStr := mysqlGenExprNode(e.Right, colCharset)
+		if _, ok := e.Right.(*sqlparser.BinaryExpr); ok {
+			rightStr = "(" + rightStr + ")"
+		}
+		return fmt.Sprintf("%s %s %s", leftStr, e.Operator.ToString(), rightStr)
 	case *sqlparser.FuncExpr:
 		args := make([]string, len(e.Exprs))
 		for i, arg := range e.Exprs {

--- a/executor/show_gen_expr_parens_test.go
+++ b/executor/show_gen_expr_parens_test.go
@@ -1,0 +1,32 @@
+package executor
+
+import "testing"
+
+// TestMysqlFormatGenExprNestedParens verifies that nested binary
+// subexpressions in a GENERATED ALWAYS AS expression are wrapped in
+// parens to match MySQL's SHOW CREATE TABLE output.
+//
+// MySQL renders e.g. ``GENERATED ALWAYS AS (((`h` * 2) + `b`))`` —
+// each nested BinaryExpr operand of another BinaryExpr is wrapped in
+// parens regardless of operator precedence.
+func TestMysqlFormatGenExprNestedParens(t *testing.T) {
+	cases := []struct {
+		name string
+		expr string
+		want string
+	}{
+		{"simple_mul", "b * 2", "(`b` * 2)"},
+		{"add_with_mul_left", "h * 2 + b", "((`h` * 2) + `b`)"},
+		{"add_with_mul_right", "b + c * 2", "(`b` + (`c` * 2))"},
+		{"with_outer_parens", "(c * 2 + b)", "((`c` * 2) + `b`)"},
+		{"with_double_outer_parens", "((c * 2 + b))", "((`c` * 2) + `b`)"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := mysqlFormatGenExpr(tc.expr, "")
+			if got != tc.want {
+				t.Errorf("mysqlFormatGenExpr(%q) = %q, want %q", tc.expr, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- MySQL renders nested binary operations inside ``GENERATED ALWAYS AS (...)`` with each inner ``BinaryExpr`` operand wrapped in parens, regardless of operator precedence (e.g. ``GENERATED ALWAYS AS (((`h` * 2) + `b`)) VIRTUAL``).
- ``mysqlGenExprNode`` now wraps a ``BinaryExpr`` child of another ``BinaryExpr`` in parens to match this display format.
- Added ``TestMysqlFormatGenExprNestedParens`` covering simple multiplication, nested ``a*b + c`` / ``a + b*c``, and CREATE TABLE forms with extra outer parens.

## KPI delta
- ``innodb/instant_add_column_basic`` first-diff-line: **656 -> 804** (+148 lines).
  Next blocker (line 804) is unrelated to expression formatting (UPDATE behavior on INSTANT-added columns).

## Test plan
- [x] ``go build ./...`` clean
- [x] ``go test ./... -count=1`` green (added unit test ``TestMysqlFormatGenExprNestedParens``)
- [x] ``mtrrun -test innodb/instant_add_column_basic -force -skipped-only`` advances 656 -> 804
- [x] ``mtrrun -suite innodb -force`` -- 93 pass / 1 fail (``skip_locked_nowait_isolation`` pre-existing, identical to PR322 baseline)
- [x] ``mtrrun -suite innodb_zip,innodb_fts,innodb_undo -force`` -- single pre-existing ``wl5522_zip`` failure
- [x] ``mtrrun -suite gcol,gcol_ndb -force`` -- 14 pass, 0 fail

Refs #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)