### PR TITLE
fix(executor): preserve encounter order for DISTINCT-style GROUP BY

### DIFF
--- a/executor/select.go
+++ b/executor/select.go
@@ -4278,12 +4278,27 @@ func (e *Executor) execSelectGroupBy(stmt *sqlparser.Select, allRows []storage.R
 				groups = append(groups, group{key: key, rows: []storage.Row{row}})
 			}
 		}
-		// Sort GROUP BY groups by key so that NULL rows appear before non-NULL rows,
-		// matching MySQL/InnoDB behavior where rows are returned in index/PK order.
-		// This applies both for regular GROUP BY and WITH ROLLUP.
-		sort.SliceStable(groups, func(i, j int) bool {
-			return compareGroupKeys(groups[i].key, groups[j].key) < 0
-		})
+		// MySQL 8.0 GROUP BY ordering: when there are no aggregates in SELECT
+		// (i.e. GROUP BY is acting as DISTINCT), no ORDER BY clause, and no
+		// ROLLUP, MySQL preserves the row encounter order from the underlying
+		// scan (which is index/PK order for InnoDB). For aggregate queries we
+		// continue to sort by GROUP BY key to keep deterministic behaviour for
+		// tests like sum_distinct and aggregate cross joins.
+		hasAggsInSelect := selectExprsHaveAggregates(stmt.SelectExprs.Exprs)
+		if !hasAggsInSelect && stmt.Having != nil {
+			hasAggsInSelect = containsAggregate(stmt.Having.Expr)
+		}
+		preserveEncounterOrder := !hasAggsInSelect &&
+			(stmt.OrderBy == nil || len(stmt.OrderBy) == 0) &&
+			!stmt.GroupBy.WithRollup
+		if !preserveEncounterOrder {
+			// Sort GROUP BY groups by key so that NULL rows appear before non-NULL rows,
+			// matching MySQL/InnoDB behavior where rows are returned in index/PK order.
+			// This applies both for regular GROUP BY and WITH ROLLUP.
+			sort.SliceStable(groups, func(i, j int) bool {
+				return compareGroupKeys(groups[i].key, groups[j].key) < 0
+			})
+		}
 	} else {
 		// No GROUP BY but has aggregates: treat all rows as one group
 		groups = []group{{key: "", rows: allRows}}


### PR DESCRIPTION
## Summary
- MySQL 8.0 hash-aggregates GROUP BY without aggregates in SELECT and returns groups in row encounter order (index/PK scan order for InnoDB), not sorted by GROUP BY key.
- Previously we unconditionally sorted GROUP BY groups by key, which diverged from MySQL on DISTINCT-equivalent queries like ``SELECT c, e FROM t1 GROUP BY c, e``.
- Now skip the key-based sort when SELECT/HAVING contain no aggregates, no ORDER BY, no ROLLUP. Aggregate cases keep the sort to preserve deterministic output for ``sum_distinct`` and aggregate-over-cross-join tests.

## KPI delta
- ``innodb/instant_add_column_basic`` first-diff-line: **804 -> 811** (+7 lines).
  Next blocker (line 811) is unrelated to GROUP BY ordering -- it concerns AUTO_INCREMENT bulk-allocation behavior for ``INSERT INTO t1(...) SELECT ... FROM t1`` (MySQL legacy bulk-mode reserves more AI values than ``innodb_autoinc_lock_mode=2`` does, so ``UPDATE WHERE a < 50`` matches a different number of rows).

## Test plan
- [x] ``go build ./...`` clean
- [x] ``go test ./... -count=1`` green (executor, harness, storage)
- [x] ``mtrrun -test innodb/instant_add_column_basic -force -skipped-only`` advances first-diff-line 804 -> 811
- [x] ``mtrrun -suite innodb -j 1 -force`` -- 93 pass / 1 pre-existing fail (``skip_locked_nowait_isolation``), identical to baseline
- [x] ``mtrrun -suite gcol,gcol_ndb -force`` -- 14 pass, 0 fail
- [x] full ``mtrrun -force`` head-to-head: zero status changes from baseline (1734 pass / 331 fail / 125 errors / 1155 skip on both)

Refs #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)