### PR TITLE
feat(executor): InnoDB lock_mode=1 bulk reservation for INSERT...SELECT

### DIFF
--- a/executor/dml_insert.go
+++ b/executor/dml_insert.go
@@ -352,6 +352,44 @@ func (e *Executor) execInsert(stmt *sqlparser.Insert) (*Result, error) {
 		var firstAutoInsertID int64
 		var affected uint64
 
+		// InnoDB lock_mode=1 bulk-INSERT...SELECT reservation: when the source
+		// row count is N, MySQL's "bulk INSERT" mode (used for INSERT...SELECT
+		// because the engine doesn't know N upfront) reserves AI values in
+		// power-of-2 chunks (1, 2, 4, 8, ...) until enough are reserved to
+		// cover N. After the statement, any unused reservation is left as a
+		// gap, so the global AI counter advances by 2^ceil(log2(N+1)) - 1
+		// rather than N. We snapshot the counter before the bulk loop and
+		// advance it past the reservation after the loop completes. This
+		// matches MySQL's lock_mode=1 default behaviour and is required by
+		// tests like innodb/instant_add_column_basic and innodb/autoinc_persist.
+		isInnoDBLikeEngine := func() bool {
+			eng := strings.ToUpper(tbl.Def.Engine)
+			if eng == "" {
+				if v, ok := e.getSysVar("default_storage_engine"); ok && v != "" {
+					eng = strings.ToUpper(v)
+				}
+			}
+			return eng != "MYISAM" && eng != "MRG_MYISAM" && eng != "MEMORY" && eng != "ARCHIVE" && eng != "CSV"
+		}()
+		bulkAISelPreCounter := int64(-1)
+		bulkAISelReserved := 0
+		bulkAISelApplies := false
+		if autoColName != "" && isInnoDBLikeEngine && len(selResult.Rows) > 0 {
+			if lm, ok := e.getSysVar("innodb_autoinc_lock_mode"); !ok || lm != "0" {
+				n := len(selResult.Rows)
+				// reservation = smallest 2^k - 1 >= n, i.e. 1+2+4+...+2^(k-1).
+				reserved := 1
+				for reserved < n {
+					reserved = reserved*2 + 1
+				}
+				bulkAISelReserved = reserved
+				tbl.Lock()
+				bulkAISelPreCounter = tbl.AutoIncrementValue()
+				tbl.Unlock()
+				bulkAISelApplies = true
+			}
+		}
+
 		// Pre-allocate bulk rows
 		bulkRows := make([]storage.Row, 0, len(selResult.Rows))
 
@@ -517,6 +555,19 @@ func (e *Executor) execInsert(stmt *sqlparser.Insert) (*Result, error) {
 				}
 				affected++
 			}
+		}
+
+		// Apply InnoDB lock_mode=1 bulk-INSERT...SELECT reservation: advance
+		// the global AI counter past (preCounter + reserved). Only meaningful
+		// when at least one row auto-generated an AI value (firstAutoInsertID
+		// > 0); otherwise the source rows all carried explicit AI values.
+		if bulkAISelApplies && bulkAISelPreCounter >= 0 && firstAutoInsertID > 0 && bulkAISelReserved > 0 {
+			reserved := bulkAISelPreCounter + int64(bulkAISelReserved)
+			tbl.Lock()
+			if cur := tbl.AutoIncrementValue(); cur < reserved {
+				tbl.AutoIncrement.Store(reserved)
+			}
+			tbl.Unlock()
 		}
 
 		if firstAutoInsertID > 0 {

--- a/executor/test_insert_select_bulkai_test.go
+++ b/executor/test_insert_select_bulkai_test.go
@@ -1,0 +1,52 @@
+package executor
+
+import (
+	"testing"
+
+	"github.com/myuon/mylite/catalog"
+	"github.com/myuon/mylite/storage"
+)
+
+// TestInsertSelectBulkAIReservation verifies that INSERT...SELECT under the
+// default innodb_autoinc_lock_mode (1) reserves AUTO_INCREMENT values in
+// power-of-2 chunks like MySQL's "bulk INSERT" mode.
+func TestInsertSelectBulkAIReservation(t *testing.T) {
+	cat := catalog.New()
+	store := storage.NewEngine()
+	e := New(cat, store)
+
+	if _, err := e.Execute("CREATE DATABASE IF NOT EXISTS test"); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	e.CurrentDB = "test"
+
+	if _, err := e.Execute("CREATE TABLE t1 (a INT NOT NULL AUTO_INCREMENT PRIMARY KEY, b INT) ENGINE=InnoDB"); err != nil {
+		t.Fatalf("create t1: %v", err)
+	}
+	if _, err := e.Execute("INSERT INTO t1 VALUES(0, 1), (0, 2), (0, 3), (0, 4), (0, 5)"); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	// 3x INSERT...SELECT, doubling each time.
+	for i := 0; i < 3; i++ {
+		if _, err := e.Execute("INSERT INTO t1(b) SELECT b FROM t1"); err != nil {
+			t.Fatalf("insert select #%d: %v", i, err)
+		}
+	}
+
+	tbl, err := store.GetTable("test", "t1")
+	if err != nil {
+		t.Fatalf("get table: %v", err)
+	}
+	got := tbl.AutoIncrementValue()
+	// AutoIncrementValue() stores the last-used AI value, so SHOW CREATE TABLE
+	// reports AUTO_INCREMENT=last+1. With power-of-2 bulk reservation:
+	//   seed   (5 rows VALUES, reserve=5): last=5
+	//   round 1 (5 src,  reserve=7):       last=12
+	//   round 2 (10 src, reserve=15):      last=27
+	//   round 3 (20 src, reserve=31):      last=58
+	// SHOW CREATE TABLE would report AUTO_INCREMENT=59.
+	if got != 58 {
+		t.Errorf("expected AI counter = 58 after 3 INSERT...SELECT (SHOW would print AUTO_INCREMENT=59), got %d", got)
+	}
+}


### PR DESCRIPTION
## Summary

Round 34 of #256 (#255 follow-up). Extends PR #300's lock_mode=1 multi-row VALUES reservation to ``INSERT...SELECT``.

In MySQL's InnoDB ``innodb_autoinc_lock_mode=1`` (default before 8.0), the engine doesn't know the source row count up front when running ``INSERT...SELECT``, so it reserves AUTO_INCREMENT values in power-of-2 chunks (1, 2, 4, ...). After the statement, any unused reservation is left as a gap; the global counter advances by ``2^ceil(log2(N+1)) - 1`` rather than ``N``. This is the InnoDB ``lock_mode=1`` "bulk INSERT" semantic.

The fast-path ``insertSelectFastPath`` now snapshots the AI counter before the bulk loop and, when at least one row auto-generated an AI value, advances the counter past ``preCounter + reserved`` once the loop finishes.

## KPI delta

``innodb/instant_add_column_basic`` first-diff-line: **811 -> 944** (+133 lines).

The scenario-4 sequence
``CREATE; INSERT VALUES (5 rows); 3x INSERT...SELECT b,c,e FROM t1; DELETE; UPDATE; INSERT...SELECT b,c,e FROM t1`` now correctly reports ``AUTO_INCREMENT=90`` in ``SHOW CREATE TABLE`` (matching the documented dolt-mysql-tests result), instead of 57 with the old ``lock_mode=2``-equivalent behaviour.

## Test plan

- [x] ``go build ./...`` clean
- [x] ``go test ./... -count=1`` green (executor, harness, storage)
- [x] new unit test ``TestInsertSelectBulkAIReservation`` exercising the 5/10/20-row INSERT...SELECT cascade
- [x] ``mtrrun -test innodb/instant_add_column_basic -force -skipped-only`` first-diff-line 811 -> 944
- [x] full ``mtrrun -force`` head-to-head: **1734 pass / 331 fail / 125 errors / 1155 skip on both** baseline (main@acb3267) and this branch -- zero status changes, zero regressions

Refs #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)