### PR TITLE
fix(executor): record DELETE/UPDATE undo entries for transaction rollback

### DIFF
--- a/executor/dml_delete.go
+++ b/executor/dml_delete.go
@@ -486,6 +486,28 @@ func (e *Executor) execDelete(stmt *sqlparser.Delete) (*Result, error) {
 			}
 		}
 
+		// Record undo entries (in ascending original-index order) for transaction rollback.
+		if e.inTransaction && len(deleteSet) > 0 {
+			delIdxOrder := make([]int, 0, len(deleteSet))
+			for idx := range deleteSet {
+				delIdxOrder = append(delIdxOrder, idx)
+			}
+			sort.Ints(delIdxOrder)
+			// Compute rowIndex relative to the surviving rows so that reverse replay
+			// inserts back into the correct position. After all deletes, the run-time
+			// rowIndex of the i-th deleted row (in ascending original order) equals
+			// origIdx - (number of earlier deletes) = origIdx - i.
+			for i, origIdx := range delIdxOrder {
+				row := tbl.Rows[origIdx]
+				e.txnUndoLog = append(e.txnUndoLog, undoEntry{
+					op:       "DELETE",
+					db:       deleteDB,
+					table:    tableName,
+					rowIndex: origIdx - i,
+					oldRow:   storage.CloneRow(row),
+				})
+			}
+		}
 		newRows := make([]storage.Row, 0, len(tbl.Rows)-len(deleteSet))
 		for i, row := range tbl.Rows {
 			if !deleteSet[i] {
@@ -604,9 +626,11 @@ func (e *Executor) execDelete(stmt *sqlparser.Delete) (*Result, error) {
 		// Use pointer identity: storage.Row is a map, so we compare the map header.
 		newRows := make([]storage.Row, 0, len(tbl.Rows))
 		rowRemoved := false
-		for _, r := range tbl.Rows {
+		removedAt := -1
+		for idx, r := range tbl.Rows {
 			if !rowRemoved && rowPtrEqual(r, row) {
 				rowRemoved = true
+				removedAt = idx
 				continue
 			}
 			newRows = append(newRows, r)
@@ -614,6 +638,16 @@ func (e *Executor) execDelete(stmt *sqlparser.Delete) (*Result, error) {
 		tbl.Rows = newRows
 		tbl.InvalidateIndexes()
 		affected++
+		// Record undo entry for transaction rollback.
+		if e.inTransaction && rowRemoved {
+			e.txnUndoLog = append(e.txnUndoLog, undoEntry{
+				op:       "DELETE",
+				db:       deleteDB,
+				table:    tableName,
+				rowIndex: removedAt,
+				oldRow:   storage.CloneRow(row),
+			})
+		}
 
 		// Fire AFTER DELETE trigger immediately after removing this row.
 		// This matches MySQL semantics: AFTER DELETE sees the row already gone.

--- a/executor/dml_update.go
+++ b/executor/dml_update.go
@@ -920,6 +920,16 @@ func (e *Executor) execUpdate(stmt *sqlparser.Update) (*Result, error) {
 		matchedRows++
 		if rowChanged {
 			affected++
+			// Record undo entry for transaction rollback.
+			if e.inTransaction {
+				e.txnUndoLog = append(e.txnUndoLog, undoEntry{
+					op:       "UPDATE",
+					db:       updateDB,
+					table:    tableName,
+					rowIndex: i,
+					oldRow:   storage.CloneRow(oldRow),
+				})
+			}
 			// Apply ON UPDATE CURRENT_TIMESTAMP for columns not explicitly set
 			for _, col := range tbl.Def.Columns {
 				if col.OnUpdateCurrentTimestamp {


### PR DESCRIPTION
## Summary
- `execDelete` and `execUpdate` never appended to `txnUndoLog`, so when a transaction mixed DELETE/UPDATE with INSERT, `replayUndoLog` only reversed the INSERT entries on ROLLBACK and silently dropped the DELETEd rows. The snapshot fallback was bypassed whenever the undo log was non-empty (because INSERT alone made it non-empty).
- Append DELETE entries (with the surviving-rows `rowIndex`, computed for both the fast and trigger-aware paths) and UPDATE entries (with the original `rowIndex` and a clone of `oldRow`) so `replayUndoLog`'s existing DELETE/UPDATE cases actually fire.

## KPI
- innodb/instant_add_column_basic: first-diff-line **944 -> 996** (~52 lines further into the test, advancing past the Scenario 6 DELETE+INSERT+ROLLBACK block).
- Full mtrrun head-to-head (3345 tests): identical pass/fail/skip/error tallies (1734/331/1155/125, 0 timeouts). No regressions.

## Test plan
- [x] `go build ./...`
- [x] `go test ./... -count=1`
- [x] `go run ./cmd/mtrrun -test innodb/instant_add_column_basic -force -skipped-only` shows first diff at line 996 (was 944).
- [x] Full `go run ./cmd/mtrrun`: pass/fail/skip/error counts unchanged vs main; per-test diff is empty.

Refs #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)