### PR TITLE
feat(ddl): model INSTANT-add limits and table rebuild for ALTER TABLE

### DIFF
--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -94,6 +94,10 @@ type TableDef struct {
 	// returns ER_TABLESPACE_DISCARDED until ALTER TABLE ... IMPORT
 	// TABLESPACE clears the flag.
 	InstantCols           int                 // number of columns at the time the first INSTANT ADD COLUMN was applied (0 = no instant cols)
+	// RebuildSeq counts the number of table rebuilds (non-instant ALTERs that
+	// would change InnoDB's internal table_id). Used so information_schema
+	// reports a different TABLE_ID after a rebuild, mirroring MySQL behavior.
+	RebuildSeq int
 	Discarded bool
 }
 

--- a/executor/ddl.go
+++ b/executor/ddl.go
@@ -4171,7 +4171,15 @@ func (e *Executor) execAlterTable(stmt *sqlparser.AlterTable) (*Result, error) {
 	// Pre-check: ALGORITHM=INPLACE rejection for operations that require COPY
 	alterIsInplace := false
 	alterIsInstant := false
+	alterHasNonAddOp := false // exposed to inner ADD COLUMN handling (e.g. ADD KEY alongside ADD COLUMN forces rebuild)
+	alterHasForce := false    // FORCE keyword forces rebuild even with only ADD COLUMN
 	{
+		// Detect FORCE keyword by re-rendering the statement; vitess preserves
+		// the keyword in its output even when it doesn't expose it on the AST.
+		upperRaw := strings.ToUpper(sqlparser.String(stmt))
+		if strings.Contains(upperRaw, ", FORCE") || strings.HasSuffix(strings.TrimSpace(upperRaw), " FORCE") || strings.Contains(upperRaw, ",FORCE") {
+			alterHasForce = true
+		}
 		isInplace := false
 		isInstant := false
 		hasStoredGcolAdd := false
@@ -4222,6 +4230,7 @@ func (e *Executor) execAlterTable(stmt *sqlparser.AlterTable) (*Result, error) {
 				hasNonAddOp = true
 			}
 		}
+		alterHasNonAddOp = hasNonAddOp
 		if isInplace && hasStoredGcolAdd {
 			return nil, mysqlError(1846, "0A000", "ALGORITHM=INPLACE is not supported for this operation. Try ALGORITHM=COPY.")
 		}
@@ -4580,12 +4589,14 @@ func (e *Executor) execAlterTable(stmt *sqlparser.AlterTable) (*Result, error) {
 					}
 				}
 				// Determine whether this ADD COLUMN should be treated as INSTANT.
-				// MySQL 8.0.29+ defaults to INSTANT when possible. We treat it as
-				// INSTANT either when ALGORITHM=INSTANT was explicitly requested,
-				// or by default for plain ADD COLUMN at the end of the table on
-				// non-MyISAM/CSV tables (mirrors MySQL's "instant by default").
+				// MySQL 8.0.29+ defaults to INSTANT when possible. INSTANT works
+				// for ADD COLUMN at the end of the table, and for adds at any
+				// position (FIRST/AFTER) when no INSTANT-added column is already
+				// present. Once an INSTANT add at a mid-position has been applied
+				// to the table (InstantCols > 0), subsequent mid-position adds
+				// fall back to a copy/rebuild.
 				if !alterIsInplace {
-					instantEligible := position == "" && !colDef.PrimaryKey
+					instantEligible := !colDef.PrimaryKey
 					if instantEligible {
 						genExprPre := generatedColumnExpr(colDef.Type)
 						if genExprPre != "" && strings.Contains(strings.ToUpper(colDef.Type), "STORED") {
@@ -4593,6 +4604,19 @@ func (e *Executor) execAlterTable(stmt *sqlparser.AlterTable) (*Result, error) {
 						}
 						if colDef.AutoIncrement {
 							instantEligible = false
+						}
+						// Multi-op ALTER (ADD COLUMN combined with ADD KEY/DROP/etc.)
+						// or explicit FORCE forces a rebuild, so the new column is
+						// not INSTANT-added.
+						if alterHasNonAddOp || alterHasForce {
+							instantEligible = false
+						}
+						if position != "" {
+							// FIRST/AFTER: only the first INSTANT mid-position add per
+							// table is allowed; subsequent mid-position adds rebuild.
+							if tableDef0, _ := db.GetTable(tableName); tableDef0 != nil && tableDef0.InstantCols != 0 {
+								instantEligible = false
+							}
 						}
 					}
 					if instantEligible {
@@ -4608,8 +4632,14 @@ func (e *Executor) execAlterTable(stmt *sqlparser.AlterTable) (*Result, error) {
 				}
 				// Update InstantCols on the table when the first INSTANT-added
 				// column is recorded (snapshot of column count before this add).
-				if colDef.IsInstantAdded {
-					if tableDef, tdErr := db.GetTable(tableName); tdErr == nil && tableDef != nil {
+				// When the add was NOT instant but would have been at end-of-table
+				// (i.e. position is FIRST/AFTER and we already had INSTANT cols),
+				// model the underlying rebuild: clear InstantCols, mark all
+				// previously-INSTANT columns as no-longer-instant (their defaults
+				// are now physically materialized), and bump RebuildSeq so
+				// information_schema reports a new TABLE_ID.
+				if tableDef, tdErr := db.GetTable(tableName); tdErr == nil && tableDef != nil {
+					if colDef.IsInstantAdded {
 						if tableDef.InstantCols == 0 {
 							// Set to the number of "regular" columns just before this add
 							// (i.e. columns that existed prior to this INSTANT).
@@ -4621,6 +4651,17 @@ func (e *Executor) execAlterTable(stmt *sqlparser.AlterTable) (*Result, error) {
 							}
 							tableDef.InstantCols = n
 						}
+					} else if position != "" || alterHasNonAddOp || alterHasForce || alterIsInplace {
+						// Non-instant add (mid-position with prior INSTANTs, multi-op
+						// ALTER, FORCE keyword, or ALGORITHM=INPLACE): rebuild.
+						if tableDef.InstantCols != 0 {
+							tableDef.InstantCols = 0
+							for i := range tableDef.Columns {
+								tableDef.Columns[i].IsInstantAdded = false
+								tableDef.Columns[i].InstantDefault = ""
+							}
+						}
+						tableDef.RebuildSeq++
 					}
 				}
 				// If the new column is a primary key (inline KEY or PRIMARY KEY), set it

--- a/executor/information_schema.go
+++ b/executor/information_schema.go
@@ -1318,11 +1318,18 @@ func (e *Executor) infoSchemaInnoDBTables() []storage.Row {
 			if def != nil {
 				instantCols = int64(def.InstantCols)
 			}
+			// Offset TABLE_ID by RebuildSeq*10000 so a rebuilt table reports
+			// a different TABLE_ID, mirroring MySQL behavior where rebuilds
+			// allocate a new internal id.
+			displayedTableID := tableID
+			if def != nil && def.RebuildSeq != 0 {
+				displayedTableID = tableID + int64(def.RebuildSeq)*10000
+			}
 			if def != nil && def.PartitionType != "" {
 				partNames := innodbPartitionNames(def)
 				for _, partName := range partNames {
 					rows = append(rows, storage.Row{
-						"TABLE_ID":      tableID,
+						"TABLE_ID":      displayedTableID,
 						"NAME":          prefix + "#p#" + partName,
 						"SPACE":         space,
 						"FLAG":          flag,
@@ -1333,11 +1340,16 @@ func (e *Executor) infoSchemaInnoDBTables() []storage.Row {
 						"INSTANT_COLS":  instantCols,
 					})
 					tableID++
+					if def != nil && def.RebuildSeq != 0 {
+						displayedTableID = tableID + int64(def.RebuildSeq)*10000
+					} else {
+						displayedTableID = tableID
+					}
 					space++
 				}
 			} else {
 				rows = append(rows, storage.Row{
-					"TABLE_ID":      tableID,
+					"TABLE_ID":      displayedTableID,
 					"NAME":          prefix,
 					"SPACE":         space,
 					"FLAG":          flag,
@@ -1429,10 +1441,14 @@ func (e *Executor) infoSchemaInnoDBIndexes() []storage.Row {
 			if len(def.PrimaryKey) > 0 {
 				pkName = "PRIMARY"
 			}
+			displayedTableID := tableID
+			if def.RebuildSeq != 0 {
+				displayedTableID = tableID + int64(def.RebuildSeq)*10000
+			}
 			rows = append(rows, storage.Row{
 				"INDEX_ID": indexID,
 				"NAME":     pkName,
-				"TABLE_ID": tableID,
+				"TABLE_ID": displayedTableID,
 				"TYPE":     int64(3), // clustered
 				"SPACE":    space,
 			})
@@ -1445,7 +1461,7 @@ func (e *Executor) infoSchemaInnoDBIndexes() []storage.Row {
 				rows = append(rows, storage.Row{
 					"INDEX_ID": indexID,
 					"NAME":     idx.Name,
-					"TABLE_ID": tableID,
+					"TABLE_ID": displayedTableID,
 					"TYPE":     int64(0),
 					"SPACE":    space,
 				})
@@ -1654,6 +1670,10 @@ func (e *Executor) infoSchemaInnoDBColumns() []storage.Row {
 				}
 			}
 			for p := 0; p < partCount; p++ {
+				displayedTableID := tableID
+				if def.RebuildSeq != 0 {
+					displayedTableID = tableID + int64(def.RebuildSeq)*10000
+				}
 				for i, col := range def.Columns {
 					hasDefault := int64(0)
 					var defaultValue interface{} = nil
@@ -1682,7 +1702,7 @@ func (e *Executor) infoSchemaInnoDBColumns() []storage.Row {
 						}
 					}
 					rows = append(rows, storage.Row{
-						"TABLE_ID":      tableID,
+						"TABLE_ID":      displayedTableID,
 						"NAME":          col.Name,
 						"POS":           int64(i),
 						"MTYPE":         innodbColumnMTYPE(col.Type),


### PR DESCRIPTION
## Summary
- Allow INSTANT for ADD COLUMN at FIRST/AFTER positions when no INSTANT add already exists on the table (matches MySQL 8.0.29+ semantics).
- Treat ADD COLUMN combined with ADD KEY/DROP/etc., the FORCE keyword, or ALGORITHM=INPLACE as a rebuild (not INSTANT).
- Add ``catalog.TableDef.RebuildSeq`` and bump it on every non-instant rebuild. Reset ``InstantCols`` and clear per-column ``IsInstantAdded``/``InstantDefault`` so ``information_schema.innodb_columns.has_default`` returns to a clean state after the rebuild.
- Surface ``RebuildSeq`` through ``information_schema.innodb_tables``, ``innodb_columns``, and ``innodb_indexes`` by offsetting ``TABLE_ID`` by ``RebuildSeq*10000`` so MTR scripts that compare ``table_id`` before and after an ALTER see the expected change.

## KPI
- ``innodb/instant_add_column_basic`` first-diff-line **996 -> 1061** (+65 lines, advancing past Scenario 7 ``c/d AFTER b`` and the ``e/f/g`` ADD KEY/FORCE/INPLACE rebuilds).
- Full mtrrun head-to-head (3345 tests): identical pass/fail/skip/error tallies (1734/331/1155/125, 0 timeouts). No regressions vs main.

## Test plan
- [x] ``go build ./...``
- [x] ``go test ./... -count=1``
- [x] ``go run ./cmd/mtrrun -test innodb/instant_add_column_basic -force -skipped-only`` shows first diff at line 1061 (was 996).
- [x] Full ``go run ./cmd/mtrrun``: pass/fail/skip/error counts unchanged vs main.

Refs #256