### PR TITLE
feat(ddl): rebuild ADD COLUMN on tables with FULLTEXT index

### DIFF
--- a/executor/ddl.go
+++ b/executor/ddl.go
@@ -4595,6 +4595,18 @@ func (e *Executor) execAlterTable(stmt *sqlparser.AlterTable) (*Result, error) {
 				// present. Once an INSTANT add at a mid-position has been applied
 				// to the table (InstantCols > 0), subsequent mid-position adds
 				// fall back to a copy/rebuild.
+				// Detect tables with FULLTEXT indexes; INSTANT cannot be used
+				// when the table contains a FULLTEXT index, so the ADD COLUMN
+				// must rebuild the table.
+				tableHasFulltext := false
+				if tableDef0, _ := db.GetTable(tableName); tableDef0 != nil {
+					for _, idx := range tableDef0.Indexes {
+						if strings.EqualFold(idx.Type, "FULLTEXT") {
+							tableHasFulltext = true
+							break
+						}
+					}
+				}
 				if !alterIsInplace {
 					instantEligible := !colDef.PrimaryKey
 					if instantEligible {
@@ -4617,6 +4629,11 @@ func (e *Executor) execAlterTable(stmt *sqlparser.AlterTable) (*Result, error) {
 							if tableDef0, _ := db.GetTable(tableName); tableDef0 != nil && tableDef0.InstantCols != 0 {
 								instantEligible = false
 							}
+						}
+						// Tables with a FULLTEXT index cannot use INSTANT for
+						// ADD COLUMN; MySQL falls back to a rebuild.
+						if tableHasFulltext {
+							instantEligible = false
 						}
 					}
 					if instantEligible {
@@ -4651,7 +4668,7 @@ func (e *Executor) execAlterTable(stmt *sqlparser.AlterTable) (*Result, error) {
 							}
 							tableDef.InstantCols = n
 						}
-					} else if position != "" || alterHasNonAddOp || alterHasForce || alterIsInplace {
+					} else if position != "" || alterHasNonAddOp || alterHasForce || alterIsInplace || tableHasFulltext {
 						// Non-instant add (mid-position with prior INSTANTs, multi-op
 						// ALTER, FORCE keyword, or ALGORITHM=INPLACE): rebuild.
 						if tableDef.InstantCols != 0 {


### PR DESCRIPTION
## Summary
- MySQL cannot use INSTANT for ADD COLUMN on a table that already has a FULLTEXT index; it falls back to a table rebuild.
- Detect FULLTEXT indexes on the target table in `execAlterTable` and force the rebuild path so `information_schema.innodb_tables` reports a new TABLE_ID and `Table ID differed` is emitted by the test scaffolding.

## KPI
- `innodb/instant_add_column_basic` first-diff-line **1061 -> 1086** (+25 lines, advancing past the entire FULLTEXT-table scenario from #330's PR description).
- Next failure is in Scenario 8 (FK with `ON UPDATE CASCADE`) at line 1086 — unrelated to FULLTEXT/INSTANT.

## Regression check
- `go build ./...` and `go test ./... -count=1` both green.
- Full `go run ./cmd/mtrrun`: 1734 / 331 / 1155 / 125 / 0 timeouts — identical to main baseline (`result-20260501-110506.json`).
- Per-test status diff vs baseline: 0 differences.

## Test plan
- [x] `go build ./...`
- [x] `go test ./... -count=1`
- [x] `go run ./cmd/mtrrun -test innodb/instant_add_column_basic -force -skipped-only` shows first diff at line 1086 (was 1061).
- [x] Full `go run ./cmd/mtrrun`: pass/fail/skip/error counts unchanged vs main.

Refs #256

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>