### PR TITLE
feat(executor): emit covering-index order for no-WHERE SELECT

### DIFF
--- a/executor/index_access.go
+++ b/executor/index_access.go
@@ -25,7 +25,7 @@ import (
 // returns ok=false so the caller stays on the legacy scan-and-filter
 // path until those cases are integrated end-to-end.
 func (e *Executor) buildIndexAccessSpec(sel *sqlparser.Select, tableName string) (storage.IndexAccessSpec, bool) {
-	if sel == nil || sel.Where == nil {
+	if sel == nil {
 		return storage.IndexAccessSpec{}, false
 	}
 	td := e.explainGetTableDef(tableName)
@@ -36,6 +36,19 @@ func (e *Executor) buildIndexAccessSpec(sel *sqlparser.Select, tableName string)
 	ai := e.explainDetectAccessType(sel, tableName)
 	at := strings.ToLower(ai.accessType)
 	keyName := stringify(ai.key)
+	// Full covering-index scan ("Using index" with no WHERE filter): the
+	// planner has already verified the chosen index covers the SELECT
+	// projection. We just need to plumb it through to storage so the
+	// scan returns rows in index order.
+	if at == "index" && keyName != "" {
+		return storage.IndexAccessSpec{
+			Type:      "index",
+			IndexName: keyName,
+		}, true
+	}
+	if sel.Where == nil {
+		return storage.IndexAccessSpec{}, false
+	}
 	if keyName == "" || at == "" || at == "all" || at == "index" {
 		return storage.IndexAccessSpec{}, false
 	}
@@ -453,21 +466,32 @@ func (e *Executor) installIndexAccessSpecForSelect(sel *sqlparser.Select) func()
 			return restore
 		}
 	}
-	if sel.Where == nil {
+	if sel.Where != nil && exprHasSubquery(sel.Where.Expr) {
 		return restore
 	}
-	if exprHasSubquery(sel.Where.Expr) {
-		return restore
+	// The covering-index "index" path also requires no GROUP BY / HAVING /
+	// ORDER BY / DISTINCT / LIMIT — those would either re-order the
+	// result or imply additional access semantics we have not validated.
+	hasNoWhere := sel.Where == nil
+	if hasNoWhere {
+		if sel.GroupBy != nil || sel.Having != nil || sel.OrderBy != nil ||
+			sel.Distinct || sel.Limit != nil {
+			return restore
+		}
 	}
 	spec, ok := e.buildIndexAccessSpec(sel, tableName)
 	if !ok {
 		return restore
 	}
-	// Narrow scope: only flip the gate for "const" / "eq_ref" lookups —
-	// the safest single-row PK case. "ref" and "range" remain on the
-	// legacy scan path until follow-up work validates them end-to-end.
+	// Narrow scope: flip the gate for "const" / "eq_ref" / "index" only.
+	// "ref" and "range" remain on the legacy scan path. "index" is the
+	// covering-index full-scan case; it must come from a no-WHERE SELECT
+	// per the buildIndexAccessSpec contract.
 	t := strings.ToLower(spec.Type)
-	if t != "const" && t != "eq_ref" {
+	if t != "const" && t != "eq_ref" && t != "index" {
+		return restore
+	}
+	if t == "index" && !hasNoWhere {
 		return restore
 	}
 	alias, _, _ := extractTableAliasFromAliased(ate)

--- a/storage/index_access.go
+++ b/storage/index_access.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/myuon/mylite/catalog"
@@ -178,8 +179,18 @@ func (t *Table) ScanByIndex(spec IndexAccessSpec) ([]Row, error) {
 		return nil, fmt.Errorf("ScanByIndex: nil table")
 	}
 	switch strings.ToLower(spec.Type) {
-	case "", "all", "index":
+	case "", "all":
 		return t.Scan(), nil
+	case "index":
+		// Full index scan: return all rows in the order of the named
+		// index. Mirrors MySQL's covering-index full-scan behaviour
+		// (Extra="Using index"), where the result set is implicitly
+		// sorted by the index's leading columns.
+		idxCols, ok := t.resolveIndexColumns(spec.IndexName)
+		if !ok || len(idxCols) == 0 {
+			return t.Scan(), nil
+		}
+		return t.scanByIndexOrder(idxCols), nil
 	}
 
 	idxCols, ok := t.resolveIndexColumns(spec.IndexName)
@@ -261,6 +272,60 @@ func (t *Table) ScanByIndex(spec IndexAccessSpec) ([]Row, error) {
 	}
 
 	return t.Scan(), nil
+}
+
+// scanByIndexOrder returns all rows sorted by the supplied index
+// column list (in declaration order). Used to simulate a covering
+// secondary-index full scan: rows come back in index-key order rather
+// than primary-key order.
+//
+// Ties are broken by the table's primary key (when present), matching
+// InnoDB's secondary-index physical layout where each leaf entry is
+// (idx_cols..., pk_cols...).
+func (t *Table) scanByIndexOrder(idxCols []string) []Row {
+	t.Mu.RLock()
+	defer t.Mu.RUnlock()
+	out := make([]Row, len(t.Rows))
+	for i, row := range t.Rows {
+		out[i] = cloneRowSnapshot(row)
+	}
+	if len(out) <= 1 {
+		return out
+	}
+	bare := make([]string, len(idxCols))
+	for i, c := range idxCols {
+		bare[i] = stripPrefixLength(c)
+	}
+	var pkCols []string
+	if t.Def != nil {
+		pkCols = make([]string, len(t.Def.PrimaryKey))
+		for i, c := range t.Def.PrimaryKey {
+			pkCols[i] = stripPrefixLength(c)
+		}
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		ri, rj := out[i], out[j]
+		for _, c := range bare {
+			cmp := compareRowValue(rowGetCI(ri, c), rowGetCI(rj, c))
+			if cmp < 0 {
+				return true
+			}
+			if cmp > 0 {
+				return false
+			}
+		}
+		for _, c := range pkCols {
+			cmp := compareRowValue(rowGetCI(ri, c), rowGetCI(rj, c))
+			if cmp < 0 {
+				return true
+			}
+			if cmp > 0 {
+				return false
+			}
+		}
+		return false
+	})
+	return out
 }
 
 // inRange reports whether v lies within the lower/upper bounds for the


### PR DESCRIPTION
## Summary
- For `SELECT col1, col2, ... FROM t` (no WHERE / ORDER BY / GROUP BY / HAVING / DISTINCT / LIMIT) where the projected columns are fully covered by a single secondary index, MySQL performs a full index scan and returns rows in that index's key order — not in primary-key order.
- Plumb the planner's existing `accessType="index"` (Extra="Using index") path through `installIndexAccessSpecForSelect` -> `buildIndexAccessSpec` -> `Table.ScanByIndex`, and add `scanByIndexOrder` in storage so the rows come back sorted by the index columns (PK as tie-breaker, mirroring InnoDB's secondary-index leaf layout).
- This unblocks Scenario 8 of `innodb/instant_add_column_basic`, where `SELECT c FROM t2` (with `KEY(c)`) is expected to return rows in c-order after `FK ON UPDATE CASCADE` rewrites them.

## KPI
- `innodb/instant_add_column_basic` first-diff-line **1086 -> 1120** (+34 lines, advancing past the entire FK CASCADE row-ordering scenario).
- Next failure is in Scenario 9 (HASH partition row order) at line 1120 — separate issue from covering-index scans.

## Regression check
- `go build ./...` and `go test ./... -count=1` both green.
- Full `go run ./cmd/mtrrun`: **1734 / 331 / 1155 / 125 / 0** — identical to main baseline (`result-20260501-110506.json`).
- Per-test status diff vs baseline: **0 differences** across all 3345 tests.

## Test plan
- [x] `go build ./...`
- [x] `go test ./... -count=1`
- [x] `go run ./cmd/mtrrun -test innodb/instant_add_column_basic -force -skipped-only` shows first diff at line 1120 (was 1086).
- [x] Full `go run ./cmd/mtrrun`: pass/fail/skip/error counts unchanged vs main; per-test status diff is empty.

Refs #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)