### PR TITLE
fix(executor): use rightmost-outer cross-join order in WHERE-fused branch

### DIFF
--- a/executor/select.go
+++ b/executor/select.go
@@ -2469,8 +2469,11 @@ func (e *Executor) execSelect(stmt *sqlparser.Select) (*Result, error) {
 				if stepExpr != nil && len(allRows) > 0 && len(rightRows) > 0 {
 					scratch = make(storage.Row, len(allRows[0])+len(rightRows[0]))
 				}
-				for _, leftRow := range allRows {
-					for _, rightRow := range rightRows {
+				// MySQL cross-join ordering: the rightmost (new) table is the outer loop
+				// and the accumulated left rows are the inner loop. This matches MySQL's
+				// natural row ordering for "FROM t1, t2" (t2 is outer, t1 is inner).
+				for _, rightRow := range rightRows {
+					for _, leftRow := range allRows {
 						if stepExpr != nil {
 							// Reuse scratch map: clear and repopulate
 							for k := range scratch {


### PR DESCRIPTION
## Summary
- The implicit cross-join in `execSelect` has two branches: a streaming nested-loop join when `WHERE` is present (with predicate pushdown) and a materialising branch when there is no `WHERE` clause.
- The no-WHERE branch already iterates with the rightmost (new) table as the outer loop, matching MySQL's natural row ordering for `FROM t1, t2`. The WHERE-fused branch iterated leftmost-outer, producing a different post-join row order.
- Swap the WHERE-fused nested loop so the rightmost table is the outer loop, mirroring the no-WHERE branch and MySQL.

## KPI delta
- `other/subquery_sj_mat` first-diff-line: **7523 -> 7995 (+472)**
- `other/subquery_sj_mat_bka` first-diff-line: **7524 -> 7996 (+472)**

Cumulative since Round 24: `subquery_sj_mat` 3397 -> 7995 (+4598).

## Regression check
No regressions:
- `other/subquery_sj_all`: still 4084
- `other/subquery_sj_mat_bka_nixbnl`: still 3521
- `other/opt_hints_subquery`: still 115
- Wider `other` suite (max 280): identical 104 pass / 113 fail / 53 skip / 32 err head-to-head with main.
- Per-test status diff vs main: 0 changes.

## Test plan
- [x] `go build ./...`
- [x] `go test ./... -count=1`
- [x] `go run ./cmd/mtrrun -test other/subquery_sj_mat,other/subquery_sj_mat_bka,other/subquery_sj_mat_bka_nixbnl,other/subquery_sj_all,other/opt_hints_subquery -force`
- [x] `go run ./cmd/mtrrun -suite other -j 1 -max 280 -force` head-to-head with main

🤖 Generated with [Claude Code](https://claude.com/claude-code)