### PR TITLE
feat(storage): order HASH-partitioned scans by partition then PK

### DIFF
--- a/executor/ddl.go
+++ b/executor/ddl.go
@@ -2393,9 +2393,9 @@ func (e *Executor) execCreateTable(stmt *sqlparser.CreateTable) (*Result, error)
 		case sqlparser.KeyType:
 			def.PartitionType = "KEY"
 		}
-		// For RANGE partitions with a simple column expression, record the
+		// For RANGE/HASH partitions with a simple column expression, record the
 		// column so that Scan can sort rows in partition order.
-		if po.Type == sqlparser.RangeType && po.Expr != nil {
+		if (po.Type == sqlparser.RangeType || po.Type == sqlparser.HashType) && po.Expr != nil {
 			if col, ok := po.Expr.(*sqlparser.ColName); ok {
 				def.PartitionColumns = []string{col.Name.String()}
 			}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -1206,19 +1206,71 @@ func (t *Table) Scan() []Row {
 		for idx, pk := range pkCols {
 			pkCollations[idx] = effectivePKCollation(t.Def, pk)
 		}
-		sort.SliceStable(result, func(i, j int) bool {
-			ri, rj := result[i], result[j]
-			for idx, pk := range pkCols {
-				cmp := compareRowValueWithCollation(ri[pk], rj[pk], pkCollations[idx])
-				if cmp < 0 {
-					return true
+		// For HASH-partitioned tables with a simple column expression and a known
+		// partition count, MySQL/InnoDB iterates partitions in order p0, p1, ...,
+		// returning the rows of each partition (clustered by PK) sequentially.
+		// Pair each row with its partition index so the sort key follows the row
+		// across swaps.
+		type rowPart struct {
+			row     Row
+			partIdx int64
+			hasPart bool
+		}
+		usePartitionOrder := t.Def.PartitionType == "HASH" &&
+			len(t.Def.PartitionColumns) == 1 &&
+			t.Def.PartitionCount > 0
+		paired := make([]rowPart, len(result))
+		if usePartitionOrder {
+			partCol := t.Def.PartitionColumns[0]
+			pc := int64(t.Def.PartitionCount)
+			for i, r := range result {
+				v, ok := toComparableFloat(r[partCol])
+				if !ok {
+					usePartitionOrder = false
+					break
 				}
-				if cmp > 0 {
-					return false
+				n := int64(v)
+				if n < 0 {
+					n = -n
 				}
+				paired[i] = rowPart{row: r, partIdx: n % pc, hasPart: true}
 			}
-			return false
-		})
+		}
+		if usePartitionOrder {
+			sort.SliceStable(paired, func(i, j int) bool {
+				if paired[i].partIdx != paired[j].partIdx {
+					return paired[i].partIdx < paired[j].partIdx
+				}
+				ri, rj := paired[i].row, paired[j].row
+				for idx, pk := range pkCols {
+					cmp := compareRowValueWithCollation(ri[pk], rj[pk], pkCollations[idx])
+					if cmp < 0 {
+						return true
+					}
+					if cmp > 0 {
+						return false
+					}
+				}
+				return false
+			})
+			for i := range paired {
+				result[i] = paired[i].row
+			}
+		} else {
+			sort.SliceStable(result, func(i, j int) bool {
+				ri, rj := result[i], result[j]
+				for idx, pk := range pkCols {
+					cmp := compareRowValueWithCollation(ri[pk], rj[pk], pkCollations[idx])
+					if cmp < 0 {
+						return true
+					}
+					if cmp > 0 {
+						return false
+					}
+				}
+				return false
+			})
+		}
 	} else if t.Def != nil && len(t.Def.PrimaryKey) == 0 && len(t.Def.PartitionColumns) > 0 &&
 		t.Def.PartitionType == "RANGE" && len(result) > 1 {
 		// For RANGE-partitioned tables without a PRIMARY KEY, MySQL returns


### PR DESCRIPTION
## Summary
- For tables with `PARTITION BY HASH(col) PARTITIONS N`, sort scans by partition index first, then PK, matching MySQL/InnoDB partition iteration order.
- Captures the simple-column partition column for HASH (in addition to existing RANGE) so `storage.Scan()` can compute the per-row partition index.

## Context
After #333, `innodb/instant_add_column_basic` first failure was at line 1120 (Scenario 9: `PARTITION BY HASH(a) PARTITIONS 3` `SELECT * FROM t1`). MySQL returns the rows partition-by-partition (`3,6 | 1,4,7 | 2,5,8` -> `3,6,1,4,7,2,5,8`); we were returning them PK-sorted (`1..8`).

## Implementation
- `executor/ddl.go`: extend the existing simple-column capture so `PartitionColumns` is populated for HASH (was RANGE only).
- `storage/storage.go`: in `Scan()`, when `PartitionType == "HASH"`, single column, and `PartitionCount > 0`, compute per-row partition index = `abs(value) % PartitionCount` and use as primary sort key; PK as secondary key.
- KEY partitioning intentionally excluded (MySQL hashes strings via password hash; a simple modulus would mismatch).

## KPI
- `innodb/instant_add_column_basic` first-diff-line: **1120 -> 1169** (Scenario 9 HASH ordering now correct; remaining diff is in a later sub-scenario).

## Regression
Full mtrrun head-to-head: identical totals (`1734 pass / 331 fail / 125 error / 1155 skip`), zero status changes, zero first-diff-line regressions across failing tests.

## Test plan
- [x] `go build ./...`
- [x] `go test ./... -count=1`
- [x] `go run ./cmd/mtrrun -test innodb/instant_add_column_basic -force -skipped-only` (first-diff advances)
- [x] Full mtrrun regression check (no regressions)

Refs #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)