### PR TITLE
fix(ddl): reset InstantCols on CHANGE COLUMN to model rebuild

### DIFF
--- a/executor/ddl.go
+++ b/executor/ddl.go
@@ -5012,6 +5012,19 @@ func (e *Executor) execAlterTable(stmt *sqlparser.AlterTable) (*Result, error) {
 			if chgErr := db.ChangeColumn(tableName, oldName, colDef); chgErr != nil {
 				return nil, chgErr
 			}
+			// CHANGE COLUMN forces a table rebuild in MySQL: clear any INSTANT
+			// metadata so subsequent ADD COLUMN ... INSTANT starts from a clean
+			// slate (matches information_schema.innodb_tables.instant_cols=0).
+			if tableDef, tdErr := db.GetTable(tableName); tdErr == nil && tableDef != nil {
+				if tableDef.InstantCols != 0 {
+					tableDef.InstantCols = 0
+					for i := range tableDef.Columns {
+						tableDef.Columns[i].IsInstantAdded = false
+						tableDef.Columns[i].InstantDefault = ""
+					}
+					tableDef.RebuildSeq++
+				}
+			}
 			// Rename the key in all existing rows if the column name changed.
 			if oldName != colDef.Name {
 				tbl.RenameColumn(oldName, colDef.Name)


### PR DESCRIPTION
## Summary
- ALTER TABLE ... CHANGE COLUMN forces a full table rebuild in MySQL 8.0; it is not an INSTANT operation.
- After such a rebuild, all previously-INSTANT columns are physically materialized and `information_schema.innodb_tables.instant_cols` resets to 0.
- We were keeping the prior `InstantCols` value, so the next `ADD COLUMN ... INSTANT` followed the wrong branch in `instant_add_column_exec_and_verify.inc` (taking the "old_instant_cols != 0" path and emitting `Instant columns equal` instead of `count(*) = 1`).

## Implementation
- `executor/ddl.go`: in the `ChangeColumn` ALTER op, after the column metadata is updated, clear `InstantCols`, drop `IsInstantAdded`/`InstantDefault` on every column, and bump `RebuildSeq` so `information_schema.innodb_tables.table_id` reflects the rebuild.

## KPI
- `innodb/instant_add_column_basic` first-diff-line: **1169 -> 1186** (Scenario 9 second sub-scenario now matches MySQL).
- Next divergence is in Scenario 10 (`EXCHANGE PARTITION` instant compatibility check), which is a separate feature.

## Regression
- Test is in the skiplist for full mtrrun runs, so this scoped change cannot affect status of any currently-running test.
- Code change only fires when `tableDef.InstantCols != 0`, i.e. only on tables that have an INSTANT-added column. This is a narrow path used solely by ALGORITHM=INSTANT ADD COLUMN flows.

## Test plan
- [x] `go build ./...`
- [x] `go test ./... -count=1`
- [x] `go run ./cmd/mtrrun -test innodb/instant_add_column_basic -force -skipped-only` (first-diff advances 1169 -> 1186)

Refs #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)