### PR TITLE
fix(executor): keep NOT IN body MATERIALIZED when nested IN has LEFT JOIN

### DIFF
--- a/executor/explain.go
+++ b/executor/explain.go
@@ -3399,6 +3399,70 @@ func exprHasColEqColEquality(expr sqlparser.Expr) bool {
 	return false
 }
 
+// joinExprHasAnyLeftJoin returns true if the table expression contains any
+// LEFT JOIN (equi or non-equi).  Used to detect cases where DuplicateWeedout
+// is inappropriate for NOT IN anti-joins because LEFT JOIN preserves NULL-
+// extended rows.
+func joinExprHasAnyLeftJoin(te sqlparser.TableExpr) bool {
+	jte, ok := te.(*sqlparser.JoinTableExpr)
+	if !ok {
+		if pte, isParen := te.(*sqlparser.ParenTableExpr); isParen {
+			for _, sub := range pte.Exprs {
+				if joinExprHasAnyLeftJoin(sub) {
+					return true
+				}
+			}
+		}
+		return false
+	}
+	if jte.Join == sqlparser.LeftJoinType || jte.Join == sqlparser.NaturalLeftJoinType {
+		return true
+	}
+	if joinExprHasAnyLeftJoin(jte.LeftExpr) {
+		return true
+	}
+	return joinExprHasAnyLeftJoin(jte.RightExpr)
+}
+
+// nestedINSubqueryHasLeftJoin returns true if any nested IN subquery
+// (recursively walking inner.Where) has a FROM clause that contains any
+// LEFT JOIN.  This signals that DuplicateWeedout is unsafe in NOT IN /
+// anti-join contexts: a LEFT JOIN can NULL-extend rows, and weeding out
+// duplicates by primary key would erase those preserved rows.  MySQL falls
+// back to MATERIALIZED for the entire NOT IN body in that case.
+func nestedINSubqueryHasLeftJoin(inner *sqlparser.Select) bool {
+	if inner == nil || inner.Where == nil {
+		return false
+	}
+	found := false
+	_ = sqlparser.Walk(func(n sqlparser.SQLNode) (bool, error) {
+		if found {
+			return false, nil
+		}
+		if cmp, ok := n.(*sqlparser.ComparisonExpr); ok {
+			if cmp.Operator == sqlparser.InOp || cmp.Operator == sqlparser.NotInOp {
+				if sub, ok := cmp.Right.(*sqlparser.Subquery); ok {
+					if nestedSel, ok := sub.Select.(*sqlparser.Select); ok {
+						for _, te := range nestedSel.From {
+							if joinExprHasAnyLeftJoin(te) {
+								found = true
+								return false, nil
+							}
+						}
+						if nestedINSubqueryHasLeftJoin(nestedSel) {
+							found = true
+							return false, nil
+						}
+					}
+					return false, nil
+				}
+			}
+		}
+		return true, nil
+	}, inner.Where)
+	return found
+}
+
 // nestedINSubqueryHasNonEquiLeftJoin returns true if any nested IN subquery
 // (recursively walking inner.Where) has a FROM clause whose JOIN tree contains
 // a LEFT JOIN with a non-equi ON condition. See joinExprHasNonEquiLeftJoin.
@@ -5041,6 +5105,25 @@ func hasImpossibleNullComparison(expr sqlparser.Expr) bool {
 	return found
 }
 
+// isSubqueryInNotInContext checks if a Subquery node is used as the right-hand
+// side of a NOT IN or != ANY (= ALL via NotEqualOp ANY) comparison.  This is a
+// strict subset of isSubqueryInINContext: only NOT-IN-style anti-join forms.
+func isSubqueryInNotInContext(node sqlparser.SQLNode, sub *sqlparser.Subquery) bool {
+	found := false
+	_ = sqlparser.Walk(func(n sqlparser.SQLNode) (bool, error) {
+		if cmp, ok := n.(*sqlparser.ComparisonExpr); ok {
+			if cmp.Operator == sqlparser.NotInOp {
+				if subR, ok := cmp.Right.(*sqlparser.Subquery); ok && subR == sub {
+					found = true
+					return false, nil
+				}
+			}
+		}
+		return true, nil
+	}, node)
+	return found
+}
+
 // isSubqueryInINContext checks if a Subquery node is used in an IN, NOT IN, or = ANY / != ANY context.
 // Note: plain scalar equality like "col = (SELECT 1 FROM t2)" (without ANY/ALL) is NOT IN context;
 // those are SUBQUERY not semijoin-flattenable.
@@ -6161,7 +6244,14 @@ func (e *Executor) walkForSubqueries(node sqlparser.SQLNode, idCounter *int64, r
 				}
 				tablePulloutWeedout := selectType == "MATERIALIZED" && e.isSemijoinEnabled() &&
 					e.innerHasCorrelatedPKWithOuter(inner, outerTablesList)
-				if selectType == "MATERIALIZED" && (e.shouldUseDuplicateWeedout(inner) || tablePulloutWeedout) {
+				// NOT IN anti-join exception: when the outer comparison is NOT IN
+				// and the nested IN subquery's body contains a LEFT JOIN, MySQL keeps
+				// the entire body MATERIALIZED rather than flattening to DuplicateWeedout.
+				// Anti-joins must preserve NULL-extended rows from the LEFT JOIN, so
+				// DuplicateWeedout (which weeds duplicates by primary key) would discard them.
+				notInLeftJoinBlocksWeedout := selectType == "MATERIALIZED" &&
+					isSubqueryInNotInContext(node, sub) && nestedINSubqueryHasLeftJoin(inner)
+				if selectType == "MATERIALIZED" && !notInLeftJoinBlocksWeedout && (e.shouldUseDuplicateWeedout(inner) || tablePulloutWeedout) {
 					// Collect all tables from the nested IN chain (or the inner FROM list
 					// when the trigger is table-pullout rather than nested IN).
 					var allTables []string

--- a/executor/test_notin_nested_in_test.go
+++ b/executor/test_notin_nested_in_test.go
@@ -1,0 +1,75 @@
+package executor
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/myuon/mylite/catalog"
+	"github.com/myuon/mylite/storage"
+)
+
+// TestNotInNestedInMaterialized covers the Bug#12797534 query from
+// subquery_sj_mat.result: a NOT IN (SELECT … WHERE col IN (SELECT … LEFT JOIN …))
+// must keep the inner body MATERIALIZED instead of being flattened to
+// DuplicateWeedout.  DuplicateWeedout is unsafe in anti-join contexts when the
+// nested IN body has a LEFT JOIN, because LEFT JOIN preserves NULL-extended
+// rows that DuplicateWeedout would erroneously discard.
+//
+// Expected EXPLAIN structure (id is masked by mtr in the .result file):
+//
+//	1 SIMPLE       t1
+//	1 SIMPLE       <subquery2>     eq_ref <auto_key>
+//	2 MATERIALIZED parent1         ALL
+//	2 MATERIALIZED parent2         eq_ref PRIMARY
+//	2 MATERIALIZED grandparent1    ref col_varchar_key
+func TestNotInNestedInMaterialized(t *testing.T) {
+	cat := catalog.New()
+	store := storage.NewEngine()
+	e := New(cat, store)
+	if _, err := e.Execute("CREATE DATABASE IF NOT EXISTS test"); err != nil {
+		t.Fatalf("create db: %v", err)
+	}
+	e.CurrentDB = "test"
+
+	cmds := []string{
+		"CREATE TABLE t1 (g1 VARCHAR(1) NOT NULL) charset utf8mb4 ENGINE=InnoDB",
+		"INSERT INTO t1 VALUES ('d'), ('s')",
+		"CREATE TABLE t2 (pk INT NOT NULL, col_int_key INT NOT NULL, col_varchar_key VARCHAR(1) NOT NULL, col_varchar_nokey VARCHAR(1) NOT NULL, PRIMARY KEY (pk), KEY col_varchar_key(col_varchar_key, col_int_key)) charset utf8mb4 ENGINE=InnoDB",
+		"INSERT INTO t2 VALUES (1,4,'j','j'), (2,6,'v','v'), (3,3,'c','c'), (4,5,'m','m'), (5,3,'d','d'), (6,246,'d','d'), (7,2,'y','y'), (8,9,'t','t'), (9,3,'d','d'), (10,8,'s','s'), (11,1,'r','r'), (12,8,'m','m'), (13,8,'b','b'), (14,5,'x','x'), (15,7,'g','g'), (16,5,'p','p'), (17,1,'q','q'), (18,6,'w','w'), (19,2,'d','d'), (20,9,'e','e')",
+		"CREATE TABLE t3 (pk INTEGER NOT NULL, PRIMARY KEY (pk)) ENGINE=InnoDB",
+		"INSERT INTO t3 VALUES (10)",
+	}
+	for _, cmd := range cmds {
+		if _, err := e.Execute(cmd); err != nil {
+			t.Fatalf("Setup %q failed: %v", cmd, err)
+		}
+	}
+
+	q := `EXPLAIN SELECT *
+FROM t1
+WHERE g1 NOT IN
+(SELECT  grandparent1.col_varchar_nokey AS g1
+FROM t2 AS grandparent1
+WHERE grandparent1.col_varchar_key IN
+(SELECT parent1.col_varchar_nokey AS p1
+FROM t2 AS parent1 LEFT JOIN t3 AS parent2 USING (pk)
+)
+AND grandparent1.col_varchar_key IS NOT NULL
+)`
+	res, err := e.Execute(q)
+	if err != nil {
+		t.Fatalf("explain: %v", err)
+	}
+	if len(res.Rows) != 5 {
+		t.Errorf("expected 5 EXPLAIN rows, got %d", len(res.Rows))
+	}
+	matRows := 0
+	for _, row := range res.Rows {
+		if fmt.Sprintf("%v", row[1]) == "MATERIALIZED" {
+			matRows++
+		}
+	}
+	if matRows != 3 {
+		t.Errorf("expected 3 MATERIALIZED rows (parent1, parent2, grandparent1), got %d", matRows)
+	}
+}


### PR DESCRIPTION
## Summary
- Bug#12797534 in subquery_sj_mat: when the outer comparison is NOT IN and the inner subquery's nested IN contains a LEFT JOIN, MySQL keeps the body materialized rather than flattening to DuplicateWeedout. Anti-joins must preserve NULL-extended rows; weeding duplicates by primary key would discard them.
- Add isSubqueryInNotInContext / nestedINSubqueryHasLeftJoin helpers and use them as a guard around the existing DuplicateWeedout flatten path.

## KPI delta
- `other/subquery_sj_mat` first-diff-line: **7995 -> 8247 (+252)**
- `other/subquery_sj_mat_bka` first-diff-line: **7996 -> 8248 (+252)**

Cumulative since Round 24: `subquery_sj_mat` 3397 -> 8247 (+4850).

## Regression check
No regressions:
- `other/subquery_sj_all`: still 4084
- `other/subquery_sj_mat_bka_nixbnl`: still 3521
- `other/opt_hints_subquery`: still 115
- Wider `other` suite (max 280): identical 104 pass / 113 fail / 53 skip / 32 err head-to-head with main.
- Per-test status diff vs main: 0 changes.

## Test plan
- [x] `go build ./...`
- [x] `go test ./... -count=1`
- [x] `go run ./cmd/mtrrun -test other/subquery_sj_mat,other/subquery_sj_mat_bka,other/subquery_sj_mat_bka_nixbnl,other/subquery_sj_all,other/opt_hints_subquery -force`
- [x] `go run ./cmd/mtrrun -suite other -j 1 -max 280 -force` head-to-head with main

🤖 Generated with [Claude Code](https://claude.com/claude-code)