### PR TITLE
fix(mtrrunner): preserve newline when eval terminates with ';' on own line

### DIFF
--- a/mtrrunner/runner.go
+++ b/mtrrunner/runner.go
@@ -1545,21 +1545,38 @@ func (ctx *execContext) handleDirective(directive string) (handled bool, skip bo
 				// For eval: trim leading whitespace, remove trailing semicolon preserving any
 				// trailing space before it (e.g. "ENGINE=INNODB ;" echoes as "ENGINE=INNODB ;").
 				args = strings.TrimLeft(args, " \t\r\n")
-				// Strip trailing newlines but not trailing spaces (preserve "word ;"-style spacing)
-				args = strings.TrimRight(args, "\r\n")
+				// Detect whether the original directive ended with `;` on its own line
+				// (i.e. args has a trailing newline because the bare-directive collector
+				// stripped a `;` that lived on its own line). In that case mysqltest
+				// preserves the source line break so the synthesized `;` lands on its own
+				// line in the echoed output, sometimes with a blank line ahead of it
+				// when the substituted variable also contributed a trailing newline.
+				preserveTrailingNL := strings.HasSuffix(args, "\n")
 				// Strip trailing whitespace that appears AFTER a semicolon
 				// (e.g. "EXPLAIN ... colA < 256;   " left after comment stripping → "EXPLAIN ... colA < 256;")
 				// but NOT spaces before the semicolon (e.g. "ENGINE=INNODB ;" should preserve the space).
-				if strings.HasSuffix(strings.TrimRight(args, " \t"), ";") {
-					args = strings.TrimRight(args, " \t")
+				if strings.HasSuffix(strings.TrimRight(args, " \t\r\n"), ";") {
+					args = strings.TrimRight(args, " \t\r\n")
+				} else if !preserveTrailingNL {
+					// No trailing `;` and no trailing newline marker: strip trailing
+					// newlines to mirror prior behaviour for single-line eval.
+					args = strings.TrimRight(args, "\r\n")
 				}
 				// Strip only semicolons at the end (any trailing space before ';' was preserved)
 				args = strings.TrimSuffix(args, ";")
 				// In eval context, undefined variables expand to empty string
 				args = ctx.substituteVars(args)
 				args = stripUndefinedVars(args)
-				// Trim only trailing newlines (not spaces) to preserve trailing " " before ";"
-				args = strings.TrimRight(args, "\r\n")
+				if !preserveTrailingNL {
+					// Trim only trailing newlines (not spaces) to preserve trailing " " before ";"
+					args = strings.TrimRight(args, "\r\n")
+				} else if !strings.HasSuffix(args, "\n") {
+					// When the source had `;` on its own line, ensure args still ends with
+					// at least one newline so executeSQL's appended `;` lands on a separate
+					// line. The substituted variable value may have already contributed a
+					// trailing newline (producing the blank line that mysqltest emits).
+					args = args + "\n"
+				}
 			} else {
 				args = strings.TrimSpace(args)
 				args = strings.TrimSuffix(args, ";")


### PR DESCRIPTION
## Summary
- Fix `mtrrunner` so multi-line `eval` directives whose terminating `;` lives on its own line echo the `;` on a separate line, matching `mysqltest` behaviour.
- Track whether `eval`'s args ended with a trailing newline (indicating the source `;` was on its own line) and preserve that newline through variable substitution so `executeSQL`'s appended `;` lands on its own line.
- When the substituted variable value also ends with a newline, the resulting double newline produces the blank line between the SQL body and `;` that `mysqltest` emits (e.g. `WHERE alias1.pk = 58 OR alias1.col_varchar_key = 'o'\n\n;`).

## Background
After #337 the next blocker for `other/subquery_sj_mat` was the `;` echo: actual was `WHERE ... 'o';` on a single line, expected was `WHERE ... 'o'`, blank, `;` on its own line. The source uses `eval CREATE TABLE t2\n  $query\n;`.

## KPI
- `other/subquery_sj_mat`: first-diff-line 8247 -> 8385 (+138)
- `other/subquery_sj_mat_bka`: first-diff-line 8248 -> 8386 (+138)
- Full `mtrrun` head-to-head (3345 tests):
  - Status: identical (1734 pass, 331 fail, 1155 skip, 125 error)
  - first-diff-line regressions: 0
  - Status regressions: 0

## Test plan
- [x] `go build ./...`
- [x] `go test ./... -count=1`
- [x] `go run ./cmd/mtrrun -test other/subquery_sj_mat,other/subquery_sj_mat_bka,...`
- [x] Full `mtrrun` head-to-head vs main — zero regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)