### PR TITLE
feat(explain): promote ALL → system for sole-table 1-row SELECTs (Refs #81)

### DIFF
--- a/executor/explain.go
+++ b/executor/explain.go
@@ -2224,6 +2224,29 @@ func (e *Executor) explainSelect(sel *sqlparser.Select, idCounter *int64, select
 				ref = accessInfo.ref
 			}
 
+			// Promote ALL → system for sole-table SELECTs whose target table is known to
+			// hold exactly 1 row.  MySQL's optimizer detects this from storage stats and
+			// reports "system" (a special case of const) regardless of whether the WHERE
+			// references the table — the single row is read once and treated as a constant.
+			// Restrict to len(allTableNames) == 1 to avoid disturbing multi-table joins
+			// where mylite's optimizer ordering may not match MySQL's.
+			if accessType == "ALL" && len(allTableNames) == 1 && idx == 0 && !rangeCheckedForEachRecord &&
+				!tableIsEmpty && rowCount == int64(1) {
+				accessType = "system"
+				possibleKeys = nil
+				key = nil
+				keyLen = nil
+				ref = nil
+				// MySQL drops "Using where" / "Using join buffer" for system-access tables;
+				// any prior assignment in this iteration was based on accessType==ALL, so reset.
+				if extra != nil {
+					extraStr := fmt.Sprintf("%v", extra)
+					if extraStr == "Using where" || extraStr == "Using join buffer (Block Nested Loop)" {
+						extra = nil
+					}
+				}
+			}
+
 			if accessInfo.accessType == "const" || accessInfo.accessType == "eq_ref" || accessInfo.accessType == "ref" {
 				rowCount = int64(1)
 			} else if accessInfo.accessType == "range" && sel.Where != nil && e.Storage != nil {
@@ -2294,7 +2317,9 @@ func (e *Executor) explainSelect(sel *sqlparser.Select, idCounter *int64, select
 
 			// Add "Using where" for ALL-access tables that have WHERE conditions filtering them.
 			// MySQL adds "Using where" when the engine applies a WHERE filter during a full scan.
-			if accessInfo.accessType == "ALL" && sel.Where != nil {
+			// Skip when we have promoted accessType to "system" (1-row table) — MySQL drops
+			// "Using where" for system access since the WHERE is evaluated against the constant row.
+			if accessInfo.accessType == "ALL" && accessType != "system" && sel.Where != nil {
 				dbName := e.CurrentDB
 				if dbName == "" {
 					dbName = "test"


### PR DESCRIPTION
## Summary

Salvaged from a Round 56 subquery_sj_mat 8385 attempt that was interrupted by usage-policy error.

## Bug

MySQL's optimizer reports \`access_type=system\` (special case of const) for sole-table SELECTs whose target table has exactly 1 row. mylite was reporting \"ALL\" (full scan) for the same case.

## Fix

In \`explainSelect\`, when \`accessType==\"ALL\"\` and \`len(allTableNames)==1\` and \`rowCount==1\`, promote to \"system\" and clear \`possibleKeys/key/keyLen/ref\`. Also drop the \"Using where\" / \"Using join buffer\" extras that ALL would have set, matching MySQL's system-access output.

Restricted to \`len(allTableNames)==1\` to avoid disturbing multi-table joins where mylite's optimizer ordering may not match MySQL's.

## KPI

- \`other/subquery_sj_mat\` first-diff-line: **8385 → 8403** (+18)
- \`other/subquery_sj_mat_bka\` first-diff-line: **8386 → 8404** (+18)
- Other test first-diffs unchanged (subquery_sj_all 4084, subquery_sj_mat_bka_nixbnl 3521, opt_hints_subquery 115)

## Test plan

- [x] \`go build ./...\`
- [x] \`go test ./... -count=1\`
- [x] \`go run ./cmd/mtrrun -test other/subquery_sj_mat,other/subquery_sj_mat_bka,other/subquery_sj_mat_bka_nixbnl,other/subquery_sj_all,other/opt_hints_subquery -force\` — only target tests advance, no regressions

Refs #81 (Semijoin Optimizer)