### PR TITLE
feat(ddl): track per-partition instant_cols for REORGANIZE PARTITION

### DIFF
--- a/catalog/catalog.go
+++ b/catalog/catalog.go
@@ -119,6 +119,11 @@ type PartitionDef struct {
 	MinRows           *int
 	Engine            string   // e.g. "InnoDB"
 	SubPartitionNames []string // names of subpartitions within this partition (if subpartitioned)
+	// InstantColsOverride, when non-nil, overrides the table-level InstantCols
+	// when reporting information_schema.innodb_tables. Used for partial-rebuild
+	// operations like REORGANIZE PARTITION which reset instant_cols only on the
+	// reorganized partitions while leaving the others intact.
+	InstantColsOverride *int
 }
 
 // ColType returns the type string for a column by name (case-insensitive).

--- a/executor/information_schema.go
+++ b/executor/information_schema.go
@@ -1326,18 +1326,18 @@ func (e *Executor) infoSchemaInnoDBTables() []storage.Row {
 				displayedTableID = tableID + int64(def.RebuildSeq)*10000
 			}
 			if def != nil && def.PartitionType != "" {
-				partNames := innodbPartitionNames(def)
-				for _, partName := range partNames {
+				partEntries := innodbPartitionEntries(def, instantCols)
+				for _, pe := range partEntries {
 					rows = append(rows, storage.Row{
 						"TABLE_ID":      displayedTableID,
-						"NAME":          prefix + "#p#" + partName,
+						"NAME":          prefix + "#p#" + pe.name,
 						"SPACE":         space,
 						"FLAG":          flag,
 						"N_COLS":        nCols,
 						"ROW_FORMAT":    rowFmt,
 						"ZIP_PAGE_SIZE": zipPageSize,
 						"SPACE_TYPE":    "Single",
-						"INSTANT_COLS":  instantCols,
+						"INSTANT_COLS":  pe.instantCols,
 					})
 					tableID++
 					if def != nil && def.RebuildSeq != 0 {
@@ -1393,6 +1393,50 @@ func innodbPartitionNames(def *catalogPkg.TableDef) []string {
 		}
 	}
 	return names
+}
+
+// partitionEntry pairs a partition name suffix with its effective instant_cols.
+type partitionEntry struct {
+	name        string
+	instantCols int64
+}
+
+// innodbPartitionEntries returns each partition's name suffix paired with its
+// effective INSTANT_COLS value. Per-partition InstantColsOverride takes
+// precedence; otherwise the table-level default is used. This lets partial
+// rebuild operations (REORGANIZE PARTITION) reset instant_cols only on the
+// rebuilt partitions while leaving siblings untouched.
+func innodbPartitionEntries(def *catalogPkg.TableDef, defaultInstantCols int64) []partitionEntry {
+	var entries []partitionEntry
+	if len(def.PartitionDefs) > 0 {
+		for _, pd := range def.PartitionDefs {
+			ic := defaultInstantCols
+			if pd.InstantColsOverride != nil {
+				ic = int64(*pd.InstantColsOverride)
+			}
+			if len(pd.SubPartitionNames) > 0 {
+				for _, sp := range pd.SubPartitionNames {
+					entries = append(entries, partitionEntry{
+						name:        strings.ToLower(pd.Name) + "#sp#" + strings.ToLower(sp),
+						instantCols: ic,
+					})
+				}
+			} else {
+				entries = append(entries, partitionEntry{
+					name:        strings.ToLower(pd.Name),
+					instantCols: ic,
+				})
+			}
+		}
+	} else if def.PartitionCount > 0 {
+		for i := 0; i < def.PartitionCount; i++ {
+			entries = append(entries, partitionEntry{
+				name:        fmt.Sprintf("p%d", i),
+				instantCols: defaultInstantCols,
+			})
+		}
+	}
+	return entries
 }
 
 // infoSchemaInnoDBIndexes returns rows for information_schema.INNODB_INDEXES.

--- a/executor/preprocess.go
+++ b/executor/preprocess.go
@@ -870,8 +870,12 @@ func (e *Executor) preprocessQuery(query string) (string, *Result, error) {
 		query = "REPLACE " + query[len("REPLACE DELAYED "):]
 	}
 
-	// Handle ALTER TABLE ... REORGANIZE PARTITION as no-op
+	// Handle ALTER TABLE ... REORGANIZE PARTITION as no-op for execution,
+	// but apply minimal catalog updates first so information_schema reflects
+	// partial-rebuild semantics on instant_cols (only the new partitions
+	// reset instant_cols; sibling partitions retain it).
 	if strings.HasPrefix(upper, "ALTER TABLE") && strings.Contains(upper, "REORGANIZE PARTITION") {
+		e.applyReorganizePartitionCatalog(query)
 		return "", &Result{}, nil
 	}
 
@@ -2503,6 +2507,18 @@ func (e *Executor) handleMultiAddPartition(query string) (*Result, error, bool) 
 			return nil, tblErr, true
 		}
 		tableDef.PartitionCount += n
+		// HASH/KEY ADD PARTITION PARTITIONS n requires a full table rebuild
+		// to redistribute rows; any INSTANT-added columns are physically
+		// materialized and information_schema.innodb_tables reports
+		// instant_cols=0 across every partition afterwards.
+		if tableDef.InstantCols != 0 {
+			tableDef.InstantCols = 0
+			for ci := range tableDef.Columns {
+				tableDef.Columns[ci].IsInstantAdded = false
+				tableDef.Columns[ci].InstantDefault = ""
+			}
+			tableDef.RebuildSeq++
+		}
 		return &Result{}, nil, true
 	}
 
@@ -2562,6 +2578,81 @@ func (e *Executor) handleMultiAddPartition(query string) (*Result, error, bool) 
 	}
 
 	return &Result{}, nil, true
+}
+
+// reReorganizePartitionStmt captures the table reference, source partition
+// list, and the new-partition definitions body for an
+// ALTER TABLE ... REORGANIZE PARTITION ... INTO (...) statement.
+var reReorganizePartitionStmt = regexp.MustCompile(`(?is)ALTER\s+TABLE\s+` +
+	`(` + "`[^`]*`" + `|[A-Za-z0-9_]+(?:\.(?:` + "`[^`]*`" + `|[A-Za-z0-9_]+))?` + `)` +
+	`\s+(?:[^,]*?,\s*)*REORGANIZE\s+PARTITION\s+([^()]+?)\s+INTO\s*\((.*)\)\s*$`)
+
+// applyReorganizePartitionCatalog updates the catalog for an
+// ALTER TABLE ... REORGANIZE PARTITION ... INTO (...) statement so that
+// information_schema.innodb_tables reports instant_cols correctly: the new
+// partitions get instant_cols=0 (they are freshly written), while sibling
+// partitions retain the table-level InstantCols.
+func (e *Executor) applyReorganizePartitionCatalog(query string) {
+	m := reReorganizePartitionStmt.FindStringSubmatch(query)
+	if m == nil {
+		return
+	}
+	tableRef := strings.TrimSpace(m[1])
+	sourceList := strings.TrimSpace(m[2])
+	newDefsBody := strings.TrimSpace(m[3])
+
+	dbName, tableName := e.splitTableRef(strings.Trim(tableRef, "`"))
+	db, err := e.Catalog.GetDatabase(dbName)
+	if err != nil {
+		return
+	}
+	tableDef, err := db.GetTable(tableName)
+	if err != nil || tableDef == nil {
+		return
+	}
+
+	sourceSet := make(map[string]bool)
+	for _, name := range strings.Split(sourceList, ",") {
+		nm := strings.Trim(strings.TrimSpace(name), "`")
+		if nm != "" {
+			sourceSet[strings.ToLower(nm)] = true
+		}
+	}
+
+	defStrs := splitPartitionDefs(newDefsBody)
+	if len(defStrs) == 0 {
+		return
+	}
+	zero := 0
+	var newDefs []catalog.PartitionDef
+	for _, ds := range defStrs {
+		pdef := parsePartitionDef(strings.TrimSpace(ds))
+		if pdef.Name == "" {
+			continue
+		}
+		pdef.InstantColsOverride = &zero
+		newDefs = append(newDefs, pdef)
+	}
+	if len(newDefs) == 0 {
+		return
+	}
+
+	var rebuilt []catalog.PartitionDef
+	inserted := false
+	for _, pd := range tableDef.PartitionDefs {
+		if sourceSet[strings.ToLower(pd.Name)] {
+			if !inserted {
+				rebuilt = append(rebuilt, newDefs...)
+				inserted = true
+			}
+			continue
+		}
+		rebuilt = append(rebuilt, pd)
+	}
+	if !inserted {
+		rebuilt = append(rebuilt, newDefs...)
+	}
+	tableDef.PartitionDefs = rebuilt
 }
 
 // splitTableRef splits a [db.]tableName reference into (dbName, tableName).


### PR DESCRIPTION
## Summary
- REORGANIZE PARTITION p_old INTO (p_new, ...) is a partial table rebuild: only the reorganized partitions are physically rewritten, so information_schema.innodb_tables reports instant_cols=0 for them while sibling partitions retain the original instant_cols.
- Previously REORGANIZE was a preprocess-level no-op, so every partition kept reporting the table-level InstantCols. Now we update the partition list in place and tag the new partitions with InstantColsOverride=0; information_schema reads the override when emitting innodb_tables rows.
- ADD PARTITION PARTITIONS n on a HASH/KEY table is a full rebuild (rows redistributed across all partitions), so instant_cols resets to 0 on every partition.

## KPI delta
- innodb/instant_add_column_basic first-diff-line: 1256 → 1680 (advanced past row-count mismatches)
- Remaining diffs at 1680+ are unrelated: DROP COLUMN table id and TEXT padding.

## Test plan
- [x] go build ./... && go test ./... -count=1 (clean)
- [x] go run ./cmd/mtrrun -test innodb/instant_add_column_basic -force -skipped-only (first-diff-line 1256 → 1680)
- [x] full mtrrun head-to-head with main: identical totals (1734 passed, 331 failed, 1155 skipped, 125 errors). No regressions.

Refs #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)