### PR TITLE
feat(ddl): bump RebuildSeq on DROP COLUMN to model table rebuild

### DIFF
--- a/executor/ddl.go
+++ b/executor/ddl.go
@@ -4794,6 +4794,20 @@ func (e *Executor) execAlterTable(stmt *sqlparser.AlterTable) (*Result, error) {
 				return nil, dropErr
 			}
 			tbl.DropColumn(colName)
+			// DROP COLUMN forces a table rebuild in MySQL: clear any INSTANT
+			// metadata so subsequent ADD COLUMN ... INSTANT starts from a clean
+			// slate, and bump RebuildSeq so information_schema reports a new
+			// TABLE_ID (matches MySQL "Table ID differed" semantics).
+			if tableDef, tdErr := db.GetTable(tableName); tdErr == nil && tableDef != nil {
+				if tableDef.InstantCols != 0 {
+					tableDef.InstantCols = 0
+					for i := range tableDef.Columns {
+						tableDef.Columns[i].IsInstantAdded = false
+						tableDef.Columns[i].InstantDefault = ""
+					}
+				}
+				tableDef.RebuildSeq++
+			}
 
 		case *sqlparser.ModifyColumn:
 			colDef := columnDefFromAST(op.NewColDefinition)


### PR DESCRIPTION
## Summary
- ALTER TABLE DROP COLUMN now bumps `catalog.TableDef.RebuildSeq` and clears INSTANT-add metadata, so `information_schema.innodb_tables` reports a different TABLE_ID after the drop (matches MySQL's "Table ID differed" semantics).
- Mirrors the rebuild handling already in place for CHANGE COLUMN (#336), OPTIMIZE on InnoDB, REORGANIZE/ADD/EXCHANGE PARTITION, etc.

## KPI
`innodb/instant_add_column_basic` first-diff-line: **1680 → 2229** (+549 lines, advancing past Scenario 19 DROP COLUMN check).

Remaining diff at line 2229 is the TEXT padding issue called out as out-of-scope in #341.

## Test plan
- [x] `go build ./...`
- [x] `go test ./... -count=1` green
- [x] `go run ./cmd/mtrrun -test innodb/instant_add_column_basic -force -skipped-only` first-diff-line advances to 2229
- [ ] Full `go run ./cmd/mtrrun` regression check (no failed-from-pass)

Refs #256

🤖 Generated with [Claude Code](https://claude.com/claude-code)