### PR TITLE
fix(explain): identify SET-target tables in multi-table UPDATE EXPLAIN

### DIFF
--- a/executor/explain.go
+++ b/executor/explain.go
@@ -1139,13 +1139,72 @@ func (e *Executor) explainMultiRows(query string) [][]interface{} {
 			}
 		}
 	case *sqlparser.Update:
-		// EXPLAIN UPDATE: first table gets select_type="UPDATE", subsequent tables get "SIMPLE".
-		// Collect all table names from the UPDATE's TableExprs.
-		var tableNames []string
-		for _, te := range s.TableExprs {
-			tableNames = append(tableNames, e.extractAllTableNames(te)...)
+		// EXPLAIN UPDATE: tables actually being updated (those referenced in SET clause)
+		// get select_type="UPDATE", others get "SIMPLE". Updated tables come first.
+		// Collect all table names and their aliases from TableExprs.
+		type updTblEntry struct {
+			name    string
+			aliases []string
 		}
-		for i, tblName := range tableNames {
+		var entries []updTblEntry
+		for _, te := range s.TableExprs {
+			realNames := e.extractAllTableNames(te)
+			displayNames := e.extractAllTableDisplayNames(te)
+			for i, n := range realNames {
+				entry := updTblEntry{name: n}
+				entry.aliases = append(entry.aliases, strings.ToLower(n))
+				if i < len(displayNames) {
+					entry.aliases = append(entry.aliases, strings.ToLower(displayNames[i]))
+				}
+				entries = append(entries, entry)
+			}
+		}
+		// Determine which tables are SET targets by inspecting Exprs qualifiers.
+		// A SET target column "tbl.col" or "alias.col" identifies tbl/alias as updated.
+		// If the SET has no qualifier (single-table UPDATE), all tables are targets.
+		updatedSet := make(map[int]bool)
+		hasQualifier := false
+		for _, ue := range s.Exprs {
+			qualStr := strings.Trim(sqlparser.String(ue.Name.Qualifier), "`")
+			if qualStr == "" {
+				continue
+			}
+			hasQualifier = true
+			// qualStr may be "db.tbl" or "tbl" or alias
+			qualLower := strings.ToLower(qualStr)
+			tail := qualLower
+			if idx := strings.LastIndex(qualLower, "."); idx >= 0 {
+				tail = qualLower[idx+1:]
+			}
+			for i, en := range entries {
+				for _, a := range en.aliases {
+					if a == qualLower || a == tail {
+						updatedSet[i] = true
+						break
+					}
+				}
+			}
+		}
+		// If no qualifiers (e.g. single-table UPDATE), all entries are targets.
+		if !hasQualifier {
+			for i := range entries {
+				updatedSet[i] = true
+			}
+		}
+		// Reorder: updated tables first (preserving relative order), then others.
+		var ordered []int
+		for i := range entries {
+			if updatedSet[i] {
+				ordered = append(ordered, i)
+			}
+		}
+		for i := range entries {
+			if !updatedSet[i] {
+				ordered = append(ordered, i)
+			}
+		}
+		for outIdx, idx := range ordered {
+			tblName := entries[idx].name
 			var rowCount int64 = 1
 			if e.Storage != nil {
 				if tbl, err := e.Storage.GetTable(e.CurrentDB, tblName); err == nil {
@@ -1155,11 +1214,11 @@ func (e *Executor) explainMultiRows(query string) [][]interface{} {
 				}
 			}
 			st := "SIMPLE"
-			if i == 0 {
+			if updatedSet[idx] {
 				st = "UPDATE"
 			}
 			var updateExtra interface{} = nil
-			if i == 0 && s.Where != nil {
+			if outIdx == 0 && s.Where != nil {
 				updateExtra = "Using where"
 			}
 			result = append(result, explainSelectType{


### PR DESCRIPTION
## Summary
- For multi-table UPDATE, EXPLAIN now marks only the tables referenced in the SET clause as `select_type="UPDATE"` and emits them before non-target tables, matching MySQL behavior.
- Previously the first table in the FROM list was always tagged `UPDATE`, so `EXPLAIN UPDATE t1,t2 SET t2.b=0;` produced `1 UPDATE t1 / 1 SIMPLE t2` instead of the expected `1 UPDATE t2 / 1 SIMPLE t1`.
- Single-table UPDATE behavior is unchanged (no qualifier on SET targets -> every table stays flagged `UPDATE`).

## Test plan
- [x] `go build ./...`
- [x] `go test ./... -count=1`
- [x] `go run ./cmd/mtrrun -test other/multi_update_innodb -force` -> pass
- [x] Full mtrrun head-to-head with main: 1735 -> 1736 passed (+1 `other/multi_update_innodb`), 0 regressions

mtrrun delta:
```
before: Suites: 29, Total: 3345, Passed: 1735, Failed: 331, Skipped: 1154, Errors: 125
after:  Suites: 29, Total: 3345, Passed: 1736, Failed: 330, Skipped: 1154, Errors: 125
```

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>