### PR TITLE
fix: round FLOAT(M,D) half-away-from-zero on float64 before f32 cast

### DIFF
--- a/executor/coerce.go
+++ b/executor/coerce.go
@@ -3864,15 +3864,16 @@ func formatDecimalValue(colType string, v interface{}) interface{} {
 			return applyZerofillStr(fmt.Sprintf("%.*f", d, f))
 		}
 		// FLOAT/DOUBLE/REAL(M,D): round to d decimal places.
-		// For FLOAT(M,D), apply single-precision rounding via float32 cast first so that
-		// the value reflects what single-precision arithmetic produces (e.g. 4294967295 →
-		// 4294967296.0 because float32 cannot represent 4294967295 exactly).
-		// For d <= 2, use fmt.Sprintf directly on the float64 value, which correctly
-		// handles tie-breaking (e.g. 999.985 → 999.99) by using the full float64 binary
-		// representation rather than scaled multiplication which loses precision.
+		// For d <= 2, round half-away-from-zero on the original float64 first so that
+		// tie-breaking cases like 999.985 → 999.99 are handled correctly (rather than
+		// 999.98 which would result from float32 casting first, since float32(999.985)
+		// is 999.9849...). After rounding, apply the float32 cast for FLOAT(M,D) so
+		// that out-of-range values like 4294967295 → 4294967296.0 reflect single-
+		// precision arithmetic.
 		// For d > 2, use banker's rounding (RoundToEven) which matches MySQL behavior
 		// for values like FLOAT(5,4) with -9.12345 → -9.1234 (RoundToEven(-91234.5) = -91234).
 		if d <= 2 {
+			f = roundHalfAwayFromZero(f, d)
 			if prefix == "float" {
 				f = float64(float32(f))
 			}
@@ -3897,6 +3898,23 @@ func roundToEvenScale(f float64, d int) float64 {
 		factor *= 10
 	}
 	return math.RoundToEven(f*factor) / factor
+}
+
+// roundHalfAwayFromZero rounds f to d decimal places using half-away-from-zero
+// rounding (e.g. 999.985 → 999.99, -999.985 → -999.99). MySQL uses this rule
+// when storing values into FLOAT/DOUBLE/DECIMAL(M,D) columns.
+func roundHalfAwayFromZero(f float64, d int) float64 {
+	if math.IsNaN(f) || math.IsInf(f, 0) {
+		return f
+	}
+	factor := 1.0
+	for i := 0; i < d; i++ {
+		factor *= 10
+	}
+	if f >= 0 {
+		return math.Floor(f*factor+0.5) / factor
+	}
+	return math.Ceil(f*factor-0.5) / factor
 }
 
 // normalizeFloatSignificant rounds f to n significant digits.


### PR DESCRIPTION
## Summary
- For FLOAT(M,D) with d<=2 (e.g. FLOAT(5,2)), our coercion path used to cast the parsed float64 to float32 first, which loses precision (`float32(999.985)` is `999.9849...`), then formatted via `%.2f`, producing `999.98`. MySQL stores these values rounded half-away-from-zero, so the expected output is `999.99`.
- Fix: round half-away-from-zero on the original float64 first, then apply the float32 cast, then format. The float32 cast is preserved so out-of-range values like `4294967295` still get bumped to `4294967296.0` per single-precision semantics.

## KPI impact
- `other/const_folding` first-diff-line advances from 23785 → 24997 (+1212 lines).
- Also advances `other/explain_json_all` (+136), `other/explain_json_none` (+137), `other/subquery_antijoin` (+1).
- No regressions in mtrrun full suite (3345 tests, Passed 1736 / Failed 330 / Errors 125 vs baseline 1735 / 331 / 125; the +1 pass comes from PR #350 already merged into main).

## Test plan
- [x] `go build ./...`
- [x] `go test ./... -count=1`
- [x] `go run ./cmd/mtrrun -test other/const_folding -force` (first-diff line moves forward)
- [x] `go run ./cmd/mtrrun` (no regressions in full suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)