### PR TITLE
fix: preserve explicit empty alias in UNION left side

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -3851,6 +3851,116 @@ func extractExplicitStringAlias(raw string) (string, bool) {
 	return "", false
 }
 
+// extractUnionLeftRaw returns the raw text of the LEFT side of a top-level
+// UNION/INTERSECT/EXCEPT expression in the given query. It tracks string
+// literals, identifier-quoted backticks, line and block comments, and
+// parenthesis nesting so that only top-level UNION/INTERSECT/EXCEPT keywords
+// are matched. Returns "" if no top-level UNION-like keyword is found.
+//
+// This is used to preserve original alias quoting (e.g. AS "") that is lost
+// when reconstructing a query from the Vitess AST: vitess sets
+// AliasedExpr.As.IsEmpty()==true for an explicit empty alias, so
+// sqlparser.String() drops the alias entirely.
+func extractUnionLeftRaw(query string) string {
+	q := strings.TrimSpace(query)
+	if q == "" {
+		return ""
+	}
+	upper := strings.ToUpper(q)
+	depth := 0
+	i := 0
+	for i < len(q) {
+		c := q[i]
+		switch c {
+		case '\'', '"':
+			// Skip string literal
+			quote := c
+			i++
+			for i < len(q) {
+				if q[i] == '\\' && i+1 < len(q) {
+					i += 2
+					continue
+				}
+				if q[i] == quote {
+					if i+1 < len(q) && q[i+1] == quote {
+						// Doubled quote = escaped quote
+						i += 2
+						continue
+					}
+					i++
+					break
+				}
+				i++
+			}
+			continue
+		case '`':
+			// Skip backtick-quoted identifier
+			i++
+			for i < len(q) && q[i] != '`' {
+				i++
+			}
+			if i < len(q) {
+				i++
+			}
+			continue
+		case '/':
+			if i+1 < len(q) && q[i+1] == '*' {
+				// Skip block comment
+				i += 2
+				for i+1 < len(q) {
+					if q[i] == '*' && q[i+1] == '/' {
+						i += 2
+						break
+					}
+					i++
+				}
+				continue
+			}
+		case '-':
+			if i+2 < len(q) && q[i+1] == '-' && (q[i+2] == ' ' || q[i+2] == '\t' || q[i+2] == '\n') {
+				// Line comment
+				for i < len(q) && q[i] != '\n' {
+					i++
+				}
+				continue
+			}
+		case '#':
+			// MySQL line comment
+			for i < len(q) && q[i] != '\n' {
+				i++
+			}
+			continue
+		case '(':
+			depth++
+			i++
+			continue
+		case ')':
+			depth--
+			i++
+			continue
+		}
+		// Match top-level UNION/INTERSECT/EXCEPT keyword: must be at
+		// word boundary (preceded and followed by whitespace or punctuation).
+		if depth == 0 {
+			for _, kw := range []string{"UNION", "INTERSECT", "EXCEPT"} {
+				if i+len(kw) <= len(upper) &&
+					(i == 0 || isWordBoundary(upper[i-1])) &&
+					upper[i:i+len(kw)] == kw &&
+					(i+len(kw) >= len(upper) || isWordBoundary(upper[i+len(kw)])) {
+					return strings.TrimSpace(q[:i])
+				}
+			}
+		}
+		i++
+	}
+	return ""
+}
+
+func isWordBoundary(c byte) bool {
+	return c == ' ' || c == '\t' || c == '\n' || c == '\r' ||
+		c == '(' || c == ')' || c == ';' || c == ','
+}
+
 func extractRawSelectExprs(query string) []string {
 	q := strings.TrimSpace(query)
 	lq := strings.ToLower(q)

--- a/executor/select.go
+++ b/executor/select.go
@@ -6390,8 +6390,16 @@ func (e *Executor) execUnion(stmt *sqlparser.Union) (*Result, error) {
 	// Execute left side directly from AST so nested UNION semantics stay intact.
 	// Temporarily override currentQuery with just the left side's SQL so that
 	// column name extraction (extractRawSelectExprs) doesn't see the UNION clause.
+	// Prefer the original raw left text (extracted from the saved currentQuery)
+	// over reconstructing from AST: AST reconstruction loses information such as
+	// `AS ""` (Vitess treats empty alias as IsEmpty()=true), and we rely on the
+	// raw query text to recover explicit empty aliases for correct column names.
 	savedCurrentQueryForUnion := e.currentQuery
-	e.currentQuery = sqlparser.String(stmt.Left)
+	if leftRaw := extractUnionLeftRaw(savedCurrentQueryForUnion); leftRaw != "" {
+		e.currentQuery = leftRaw
+	} else {
+		e.currentQuery = sqlparser.String(stmt.Left)
+	}
 	leftResult, err := e.execTableStmtForUnion(stmt.Left)
 	e.currentQuery = savedCurrentQueryForUnion
 	if err != nil {

--- a/executor/test_empty_alias_test.go
+++ b/executor/test_empty_alias_test.go
@@ -41,4 +41,19 @@ func TestEmptyStringAlias(t *testing.T) {
 	if res2.Columns[0] != "" {
 		t.Errorf("expected empty column name for AS '', got %q", res2.Columns[0])
 	}
+
+	// Test SELECT @var AS "" UNION SELECT ...
+	// Vitess reconstructs the left side from AST, which loses the explicit AS "".
+	// Verify that the column name is still preserved as empty.
+	res3, err3 := e.Execute(`SELECT @utf8_message AS "" UNION SELECT REPEAT('-', 80)`)
+	if err3 != nil {
+		t.Fatalf("select3: %v", err3)
+	}
+	t.Logf("Columns for AS \"\" UNION ...: %v", res3.Columns)
+	if len(res3.Columns) == 0 {
+		t.Fatal("no columns3")
+	}
+	if res3.Columns[0] != "" {
+		t.Errorf("expected empty column name for AS \"\" UNION, got %q", res3.Columns[0])
+	}
 }


### PR DESCRIPTION
## Summary
- Vitess sets `AliasedExpr.As.IsEmpty()==true` for `SELECT ... AS \"\"`, so `sqlparser.String()` drops the alias when reconstructing the left side of a UNION. Column-name extraction in `execUnion` then saw the expression text instead of the empty string MySQL expects.
- Switch `execUnion` to derive the left side's raw text from the original query by splitting on the top-level `UNION`/`INTERSECT`/`EXCEPT` keyword, falling back to AST reconstruction when extraction fails.
- Helper `extractUnionLeftRaw` is aware of string literals, backticked identifiers, line/block comments, and parenthesis nesting.

## Test plan
- [x] `go build ./...` passes.
- [x] `go test ./... -count=1` passes (extended `TestEmptyStringAlias` covers the UNION case).
- [x] `mtrrun -test funcs_1/innodb_cursors -force` passes (was failing).
- [x] `mtrrun -suite funcs_1` shows 24 pass / 1 fail vs baseline 22 pass / 3 fail; newly passing: `innodb_cursors`, `innodb_trig_frkey`.
- [x] No regressions across `other`, `engine_funcs`, `engine_iuds`, `funcs_2`, `gcol`, `gis`, `innodb`, `innodb_zip`, `jp`, `json`, `large_tests`, `max_parts`, `opt_trace`, `parts`, `auth_sec`, `binlog_nogtid`, `collations`, `encryption`, `gcol_ndb`, `innodb_fts`, `innodb_gis`, `innodb_stress`, `innodb_undo`, `perfschema`, `rpl_gtid`, `sys_vars` (per-suite pass counts identical to baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)