### PR TITLE
feat(explain): emit optimized_away_subqueries for empty UNION branch

### DIFF
--- a/executor/explain.go
+++ b/executor/explain.go
@@ -11317,6 +11317,70 @@ func (e *Executor) explainJSONDocument(query string) string {
 			appendByID(p)
 		}
 
+		// Identify "optimized away" subqueries belonging to a UNION branch.
+		// When a UNION branch is collapsed to "no matching row in const table"
+		// because its outer table is empty, the inner subqueries from its
+		// WHERE/SELECT/HAVING are emitted as SUBQUERY rows with extra
+		// "Not optimized, outer query is empty" right after the branch row
+		// and before the UNION RESULT row.  In EXPLAIN FORMAT=JSON these are
+		// nested under that branch's query_block as `optimized_away_subqueries`,
+		// not as outer-level attached_subqueries / order_by_subqueries.
+		//
+		// Walk the parsed rows in order, tracking the most recently-seen
+		// PRIMARY/UNION branch id; any SUBQUERY appearing before the UNION
+		// RESULT row is associated with that branch.
+		optimizedAwayByBranch := map[int64][]parsedRow{}
+		// Track parsed indexes of subqueries that were consumed as branch-local
+		// optimized_away_subqueries, so they aren't re-emitted at the outer
+		// level (e.g. attached_subqueries or order_by_subqueries).
+		consumedParsedIdx := map[int]bool{}
+		{
+			currentBranchID := int64(-1)
+			for i := range parsed {
+				switch parsed[i].selectType {
+				case "PRIMARY", "UNION":
+					if id, ok := parsed[i].id.(int64); ok {
+						currentBranchID = id
+					}
+				case "UNION RESULT":
+					// Subqueries after this point are outer-level (e.g.
+					// ORDER BY subqueries), not branch-local.
+					currentBranchID = -1
+				case "SUBQUERY", "DEPENDENT SUBQUERY":
+					if currentBranchID > 0 {
+						extra := ""
+						if parsed[i].row[11] != nil {
+							extra = fmt.Sprintf("%v", parsed[i].row[11])
+						}
+						if strings.Contains(extra, "Not optimized, outer query is empty") {
+							optimizedAwayByBranch[currentBranchID] = append(optimizedAwayByBranch[currentBranchID], parsed[i])
+							consumedParsedIdx[i] = true
+						}
+					}
+				}
+			}
+		}
+		// Filter consumed subqueries from subqueryRows so they aren't re-emitted
+		// at the outer level.  subqueryRows is built in the same order as the
+		// SUBQUERY/DEPENDENT SUBQUERY rows appear in `parsed`, so we walk both
+		// in lock-step using `parsed`.
+		if len(consumedParsedIdx) > 0 {
+			var filtered []parsedRow
+			subIdx := 0
+			for j := range parsed {
+				if parsed[j].selectType != "SUBQUERY" && parsed[j].selectType != "DEPENDENT SUBQUERY" {
+					continue
+				}
+				if !consumedParsedIdx[j] {
+					if subIdx < len(subqueryRows) {
+						filtered = append(filtered, subqueryRows[subIdx])
+					}
+				}
+				subIdx++
+			}
+			subqueryRows = filtered
+		}
+
 		appendSpec := func(g idGroup) {
 			var qb []orderedKV
 			if len(g.rows) == 1 {
@@ -11339,6 +11403,21 @@ func (e *Executor) explainJSONDocument(query string) string {
 					nl = append(nl, []orderedKV{{"table", tblBlock}})
 				}
 				qb = append(qb, orderedKV{"nested_loop", nl})
+			}
+			// Attach optimized_away_subqueries to this branch's query_block,
+			// if any inner subqueries were classified as belonging to it.
+			if subs, ok := optimizedAwayByBranch[g.id]; ok && len(subs) > 0 {
+				var optAway []interface{}
+				for _, s := range subs {
+					innerQB := e.explainJSONQueryBlockForRow(s.row, query)
+					dependent := s.selectType == "DEPENDENT SUBQUERY"
+					optAway = append(optAway, []orderedKV{
+						{"dependent", dependent},
+						{"cacheable", !dependent},
+						{"query_block", innerQB},
+					})
+				}
+				qb = append(qb, orderedKV{"optimized_away_subqueries", optAway})
 			}
 			spec := []orderedKV{
 				{"dependent", false},

--- a/executor/explain_optimized_away_subqueries_test.go
+++ b/executor/explain_optimized_away_subqueries_test.go
@@ -1,0 +1,47 @@
+package executor
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestExplain_OptimizedAwaySubqueriesInUnionBranch_JSON verifies that when a
+// UNION branch is collapsed to "no matching row in const table" because its
+// outer table is empty, any inner subqueries in its WHERE/SELECT/HAVING are
+// emitted as `optimized_away_subqueries` nested under that branch's
+// query_block (matching MySQL's EXPLAIN FORMAT=JSON output).  Refs #264.
+func TestExplain_OptimizedAwaySubqueriesInUnionBranch_JSON(t *testing.T) {
+	e := newUnionExec(t)
+	// Mirror dolt-mysql-tests/files/suite/other/t/explain_json_none.test:
+	// disable semijoin and materialization so the IN subquery cannot be
+	// flattened and is emitted as a SUBQUERY row.
+	if _, err := e.Execute(`SET optimizer_switch='semijoin=off'`); err != nil {
+		t.Fatalf("set optimizer_switch semijoin=off: %v", err)
+	}
+	if _, err := e.Execute(`SET optimizer_switch='materialization=off'`); err != nil {
+		t.Fatalf("set optimizer_switch materialization=off: %v", err)
+	}
+	res, err := e.Execute(`EXPLAIN FORMAT=JSON (SELECT t1.i FROM t1 JOIN t2) UNION ALL (SELECT * FROM t3 WHERE i IN (SELECT i FROM t4 ORDER BY RAND()))`)
+	if err != nil {
+		t.Fatalf("EXPLAIN FORMAT=JSON failed: %v", err)
+	}
+	jsonStr, _ := res.Rows[0][0].(string)
+	if !strings.Contains(jsonStr, `"optimized_away_subqueries":`) {
+		t.Errorf("expected optimized_away_subqueries block in UNION branch with empty outer table; got:\n%s", jsonStr)
+	}
+	if !strings.Contains(jsonStr, `"message": "Not optimized, outer query is empty"`) {
+		t.Errorf("expected nested subquery message; got:\n%s", jsonStr)
+	}
+	// The optimized_away_subqueries block must be nested INSIDE the
+	// select_id=2 query_block, not at the outer union_result level.
+	idxBranch2 := strings.Index(jsonStr, `"select_id": 2`)
+	idxOptAway := strings.Index(jsonStr, `"optimized_away_subqueries"`)
+	idxBranch3 := strings.Index(jsonStr, `"select_id": 3`)
+	if idxBranch2 < 0 || idxOptAway < 0 || idxBranch3 < 0 {
+		t.Fatalf("expected select_id=2, optimized_away_subqueries, and select_id=3 markers; got:\n%s", jsonStr)
+	}
+	if !(idxBranch2 < idxOptAway && idxOptAway < idxBranch3) {
+		t.Errorf("expected order: select_id=2, optimized_away_subqueries, select_id=3; got positions %d, %d, %d:\n%s",
+			idxBranch2, idxOptAway, idxBranch3, jsonStr)
+	}
+}


### PR DESCRIPTION
## Summary
- When a UNION branch collapses to "no matching row in const table" and its WHERE has a non-flattenable subquery (semijoin/materialization off), MySQL nests the inner SUBQUERY under that branch's `query_block` as `optimized_away_subqueries`. mylite previously emitted nothing in that position, leaving the outer `query_specifications` short and causing JSON divergence.
- Walk parsed EXPLAIN rows in order: any SUBQUERY/DEPENDENT SUBQUERY whose row carries `Not optimized, outer query is empty` and falls between a UNION/PRIMARY branch row and the UNION RESULT row is now associated with the preceding branch and emitted under `optimized_away_subqueries`. The same row is removed from outer-level `subqueryRows` so it does not also appear as `attached_subqueries`/`order_by_subqueries`.
- Adds a regression test that mirrors the dolt fixture (`semijoin=off`, `materialization=off`, empty t3/t4) to lock in the structural shape.

## KPI
- `other/explain_json_none` first-diff-line: 523 -> 636 (+113)
- `other/explain_json_all`: unchanged (different upstream diff at line 622)
- No pass/fail regressions in `other` suite (104/113/53/32 head-to-head with main).

## Test plan
- [x] `go build ./...`
- [x] `go test ./... -count=1`
- [x] `go run ./cmd/mtrrun -test other/explain_format_json,other/explain_json_all,other/explain_json_none -force`
- [x] `go run ./cmd/mtrrun -suite other -j 1 -max 280 -force` head-to-head with main

Refs #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)