### PR TITLE
feat(explain): wrap table in ordering_operation for ORDER BY subquery

### DIFF
--- a/executor/explain.go
+++ b/executor/explain.go
@@ -10503,12 +10503,32 @@ func (e *Executor) explainJSONDocument(query string) string {
 
 	// Detect if query has an external ORDER BY (outside window specs)
 	hasExternalOrderBy := false
+	// Detect if outer ORDER BY contains a subquery (e.g.
+	//   SELECT ... FROM t1 ORDER BY (SELECT ... FROM t2 LIMIT 1)
+	// ).  In MySQL EXPLAIN FORMAT=JSON, such non-correlated subqueries
+	// are evaluated at optimizer time, the table is wrapped in
+	// `ordering_operation` with `using_filesort: false`, and the
+	// subqueries become `optimized_away_subqueries`.
+	hasOrderBySubquery := false
 	if stmt, err := e.parser().Parse(query); err == nil {
 		if sel, ok := stmt.(*sqlparser.Select); ok {
 			if len(sel.OrderBy) > 0 && !hasWindowFuncs {
 				// ORDER BY without window funcs is handled by filesort
 			} else if len(sel.OrderBy) > 0 && hasWindowFuncs {
 				hasExternalOrderBy = true
+			}
+			// Walk ORDER BY exprs for subqueries.
+			for _, ob := range sel.OrderBy {
+				sqlparser.Walk(func(node sqlparser.SQLNode) (bool, error) {
+					if _, ok := node.(*sqlparser.Subquery); ok {
+						hasOrderBySubquery = true
+						return false, nil
+					}
+					return true, nil
+				}, ob.Expr)
+				if hasOrderBySubquery {
+					break
+				}
 			}
 		}
 	}
@@ -11711,6 +11731,10 @@ func (e *Executor) explainJSONDocument(query string) string {
 
 				// Outer query: always emit as "table" (not grouping_operation),
 				// even if the query string contains GROUP BY (which might be inside a subquery).
+				// However, when the outer ORDER BY references a non-correlated
+				// subquery (optimizer-time subquery), MySQL wraps the table in
+				// `ordering_operation` with `using_filesort: false` and emits
+				// the subqueries as `optimized_away_subqueries`.
 				if hasGroupBy && hasFilesort {
 					groupOp := []orderedKV{
 						{"using_filesort", true},
@@ -11718,6 +11742,34 @@ func (e *Executor) explainJSONDocument(query string) string {
 						{"table", tblBlock},
 					}
 					queryBlock = append(queryBlock, orderedKV{"grouping_operation", groupOp})
+				} else if hasOrderBySubquery && !hasFilesort && len(subqueryRows) > 0 {
+					// Build optimized_away_subqueries from the (non-dependent)
+					// subqueries.  Dependent subqueries continue to use the
+					// existing inline embedding above.
+					var optAway []interface{}
+					var residualSubs []parsedRow
+					for _, s := range subqueryRows {
+						qb := e.explainJSONQueryBlockForRow(s.row, query)
+						dependent := s.selectType == "DEPENDENT SUBQUERY"
+						if dependent {
+							residualSubs = append(residualSubs, s)
+							continue
+						}
+						optAway = append(optAway, []orderedKV{
+							{"dependent", false},
+							{"cacheable", true},
+							{"query_block", qb},
+						})
+					}
+					orderingOp := []orderedKV{
+						{"using_filesort", false},
+						{"table", tblBlock},
+					}
+					if len(optAway) > 0 {
+						orderingOp = append(orderingOp, orderedKV{"optimized_away_subqueries", optAway})
+					}
+					queryBlock = append(queryBlock, orderedKV{"ordering_operation", orderingOp})
+					subqueryRows = residualSubs
 				} else {
 					queryBlock = append(queryBlock, orderedKV{"table", tblBlock})
 				}

--- a/executor/explain_order_by_subquery_test.go
+++ b/executor/explain_order_by_subquery_test.go
@@ -1,0 +1,45 @@
+package executor
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestExplain_OrderBySubquery_OptimizedAway verifies that when the outer
+// ORDER BY references a non-correlated subquery (an "optimizer-time"
+// subquery), MySQL EXPLAIN FORMAT=JSON wraps the table block in
+// `ordering_operation` with `using_filesort: false` and emits the
+// subquery as `optimized_away_subqueries` (instead of
+// `attached_subqueries`).  Refs #264.
+func TestExplain_OrderBySubquery_OptimizedAway(t *testing.T) {
+	e := newUnionExec(t)
+	res, err := e.Execute(`EXPLAIN FORMAT=JSON SELECT * FROM t1 ORDER BY (SELECT LENGTH(1) FROM t2 LIMIT 1)`)
+	if err != nil {
+		t.Fatalf("EXPLAIN FORMAT=JSON failed: %v", err)
+	}
+	jsonStr, _ := res.Rows[0][0].(string)
+	if !strings.Contains(jsonStr, `"ordering_operation":`) {
+		t.Errorf("expected ordering_operation block; got:\n%s", jsonStr)
+	}
+	if !strings.Contains(jsonStr, `"using_filesort": false`) {
+		t.Errorf("expected using_filesort: false; got:\n%s", jsonStr)
+	}
+	if !strings.Contains(jsonStr, `"optimized_away_subqueries":`) {
+		t.Errorf("expected optimized_away_subqueries; got:\n%s", jsonStr)
+	}
+	if strings.Contains(jsonStr, `"attached_subqueries":`) {
+		t.Errorf("did not expect attached_subqueries (subquery should be optimized_away); got:\n%s", jsonStr)
+	}
+	// The ordering_operation must wrap both the table and the subqueries,
+	// with subqueries appearing after the table.
+	idxOrder := strings.Index(jsonStr, `"ordering_operation"`)
+	idxTable := strings.Index(jsonStr, `"table":`)
+	idxOptAway := strings.Index(jsonStr, `"optimized_away_subqueries"`)
+	if idxOrder < 0 || idxTable < 0 || idxOptAway < 0 {
+		t.Fatalf("expected ordering_operation, table, optimized_away_subqueries; got:\n%s", jsonStr)
+	}
+	if !(idxOrder < idxTable && idxTable < idxOptAway) {
+		t.Errorf("expected order ordering_operation, table, optimized_away_subqueries; got positions %d, %d, %d",
+			idxOrder, idxTable, idxOptAway)
+	}
+}


### PR DESCRIPTION
## Summary

When the outer ORDER BY references a non-correlated subquery (an "optimizer-time" subquery), e.g.

```sql
SELECT * FROM t1 ORDER BY (SELECT LENGTH(1) FROM t2 LIMIT 1)
```

MySQL EXPLAIN FORMAT=JSON wraps the primary table in an `ordering_operation` block with `using_filesort: false` and emits the inner subquery as `optimized_away_subqueries` (instead of the outer `attached_subqueries`).

Detection walks the parsed ORDER BY exprs for any `*sqlparser.Subquery`. In the simple-table-with-subqueries branch we build the `ordering_operation` wrapper when:
- the outer ORDER BY contains a subquery,
- there is no `Using filesort` on the primary,
- there are non-dependent SUBQUERY rows.

Dependent subqueries continue to fall through to the existing inline `attached_subqueries` embedding.

## KPI delta

testdata/dolt-mysql-tests/files/suite/other:
- `explain_json_all`  first-diff-line: 622 -> 695 (+73)
- `explain_json_none` first-diff-line: 636 -> 709 (+73)

## Test plan
- [x] go build ./...
- [x] go test ./... -count=1
- [x] New unit test `TestExplain_OrderBySubquery_OptimizedAway`
- [x] No regressions on `other` suite (j=1 max=280): identical totals to main (104 pass / 113 fail / 53 skip / 32 err)

Refs #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)