### PR TITLE
fix: PK equality lookup misses BIGINT values near MaxInt64

### DIFF
--- a/executor/partition_int_repro_test.go
+++ b/executor/partition_int_repro_test.go
@@ -1,0 +1,73 @@
+package executor
+
+import (
+	"testing"
+
+	"github.com/myuon/mylite/catalog"
+	"github.com/myuon/mylite/storage"
+)
+
+// TestPartitionIntInnodbBigintPKLookupMaxRow guards the fix for the
+// parts/partition_int_innodb regression where a primary-key lookup for a
+// BIGINT value near math.MaxInt64 missed its row.
+//
+// The underlying bug was in storage.valuesEqualLoose, which routed equality
+// through float64. float64 cannot distinguish 9223372036854775806 from
+// 9223372036854775807, so SELECT/DELETE WHERE a=9223372036854775806 either
+// matched the wrong row or returned nothing.
+func TestPartitionIntInnodbBigintPKLookupMaxRow(t *testing.T) {
+	stor := storage.NewEngine()
+	cat := catalog.New()
+	exec := New(cat, stor)
+
+	must := func(sql string) {
+		if _, err := exec.Execute(sql); err != nil {
+			t.Fatalf("Error in %q: %v", sql, err)
+		}
+	}
+
+	must("CREATE DATABASE IF NOT EXISTS test")
+	must("USE test")
+	must(`CREATE TABLE t3 (a bigint NOT NULL, primary key(a))
+ENGINE='InnoDB' partition by key (a) partitions 7`)
+	must(`insert into t3 values (9223372036854775807), (9223372036854775806),
+(9223372036854775805), (9223372036854775804), (-9223372036854775808),
+(-9223372036854775807), (1), (-1), (0)`)
+
+	// All 9 rows must be present, including MaxInt64-1.
+	if res, err := exec.Execute("select * from t3"); err != nil {
+		t.Fatalf("select error: %v", err)
+	} else if len(res.Rows) != 9 {
+		t.Errorf("expected 9 rows after insert, got %d", len(res.Rows))
+	}
+
+	// PK equality lookup for MaxInt64-1 must return exactly one row.
+	res, err := exec.Execute("select * from t3 where a=9223372036854775806")
+	if err != nil {
+		t.Fatalf("select where error: %v", err)
+	}
+	if len(res.Rows) != 1 {
+		t.Errorf("select where a=MaxInt64-1: expected 1 row, got %d", len(res.Rows))
+	}
+
+	// Same query for MaxInt64 must independently match exactly one row,
+	// proving the two adjacent values are no longer aliased.
+	if res, err := exec.Execute("select * from t3 where a=9223372036854775807"); err != nil {
+		t.Fatalf("select error: %v", err)
+	} else if len(res.Rows) != 1 {
+		t.Errorf("select where a=MaxInt64: expected 1 row, got %d", len(res.Rows))
+	}
+
+	// Delete-by-PK on MaxInt64-1 should remove exactly that row.
+	must("delete from t3 where a=9223372036854775806")
+	if res, err := exec.Execute("select * from t3 where a=9223372036854775806"); err != nil {
+		t.Fatalf("select error: %v", err)
+	} else if len(res.Rows) != 0 {
+		t.Errorf("after delete, expected 0 rows for MaxInt64-1, got %d", len(res.Rows))
+	}
+	if res, err := exec.Execute("select * from t3 where a=9223372036854775807"); err != nil {
+		t.Fatalf("select error: %v", err)
+	} else if len(res.Rows) != 1 {
+		t.Errorf("after delete, MaxInt64 row should still exist, got %d rows", len(res.Rows))
+	}
+}

--- a/storage/index_access.go
+++ b/storage/index_access.go
@@ -2,7 +2,9 @@ package storage
 
 import (
 	"fmt"
+	"math"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/myuon/mylite/catalog"
@@ -86,6 +88,15 @@ func valuesEqualLoose(a, b interface{}) bool {
 	if a == nil || b == nil {
 		return false
 	}
+	// Prefer exact integer comparison when both values are integral. Float
+	// conversion loses precision near the int64/uint64 limits — e.g.
+	// float64(MaxInt64-1) == float64(MaxInt64), causing PK lookups for
+	// large BIGINT values to either miss or alias their neighbour.
+	if ai, aok := toComparableInt64(a); aok {
+		if bi, bok := toComparableInt64(b); bok {
+			return ai == bi
+		}
+	}
 	// Try numeric comparison first to avoid 1 vs "1" mismatches caused
 	// by literal-vs-stored type differences.
 	if af, ok := toComparableFloat(a); ok {
@@ -94,6 +105,43 @@ func valuesEqualLoose(a, b interface{}) bool {
 		}
 	}
 	return fmt.Sprintf("%v", a) == fmt.Sprintf("%v", b)
+}
+
+// toComparableInt64 returns the int64 value when v is an integer
+// (signed or unsigned, or a string holding an integer literal). Floats
+// are rejected because they may not round-trip exactly.
+func toComparableInt64(v interface{}) (int64, bool) {
+	switch n := v.(type) {
+	case int:
+		return int64(n), true
+	case int8:
+		return int64(n), true
+	case int16:
+		return int64(n), true
+	case int32:
+		return int64(n), true
+	case int64:
+		return n, true
+	case uint:
+		if n <= math.MaxInt64 {
+			return int64(n), true
+		}
+	case uint8:
+		return int64(n), true
+	case uint16:
+		return int64(n), true
+	case uint32:
+		return int64(n), true
+	case uint64:
+		if n <= math.MaxInt64 {
+			return int64(n), true
+		}
+	case string:
+		if i, err := strconv.ParseInt(strings.TrimSpace(n), 10, 64); err == nil {
+			return i, true
+		}
+	}
+	return 0, false
 }
 
 // resolveIndexColumns returns the column list for the given index name,


### PR DESCRIPTION
## Summary

`storage.valuesEqualLoose` routed equality through `float64`. `float64` cannot represent `9223372036854775806` and `9223372036854775807` as distinct values — both round to `9223372036854775808` — so a primary key lookup like

```sql
SELECT * FROM t WHERE a = 9223372036854775806
```

either matched the wrong row (`MaxInt64` instead of `MaxInt64-1`) or returned nothing at all once both values were present in the table. The same issue affected `DELETE WHERE a = …` on the affected values.

The fix is to prefer exact `int64` comparison when both operands are integral, and only fall back to the existing `float64` / string paths for cross-type cases (e.g. an `int64` row value vs. a string literal). The new helper `toComparableInt64` mirrors `toComparableFloat` but rejects floats, since they may not round-trip exactly.

## Result

| | passed | failed |
|---|---|---|
| before | 1735 | 331 |
| after  | 1739 | 327 |

Tests that now pass on top of `main` and were not passing before:

- `parts/partition_int_innodb` (the bug-finder)
- `funcs_1/innodb_cursors`, `funcs_1/innodb_trig_frkey`, `other/multi_update_innodb` — previously passing in newer runs but had been flaky on the reference run

No regressions (`comm -23 before_pass.txt after_pass.txt` is empty).

## Test plan

- [x] `go build ./...`
- [x] `go test ./... -count=1` — all pass
- [x] `go run ./cmd/mtrrun -test parts/partition_int_innodb` — pass
- [x] full `go run ./cmd/mtrrun` — +4 / -0 vs the reference run
- [x] new regression test `executor.TestPartitionIntInnodbBigintPKLookupMaxRow` exercises both the missing-row and adjacent-row cases plus a `DELETE` round-trip