### PR TITLE
fix: accept ':' as date delimiter when coercing into DATE column

### DIFF
--- a/executor/coerce.go
+++ b/executor/coerce.go
@@ -98,6 +98,18 @@ func coerceDateTimeValueWithSessionEx(colType string, v interface{}, sessionTime
 		if parsed != "" {
 			return parsed
 		}
+		// MySQL accepts ':' as a date delimiter when the value is being stored
+		// into a DATE/DATETIME column (e.g. INSERT INTO t (d DATE) VALUES ('97:02:03')
+		// is parsed as 1997-02-03). This is a DATE-context-only behaviour: outside
+		// of a DATE column, '97:02:03' would be parsed as a TIME value. Try again
+		// with colons replaced by dashes to handle this case.
+		if strings.Contains(s, ":") {
+			altered := strings.ReplaceAll(s, ":", "-")
+			parsed = parseMySQLDateValue(altered)
+			if parsed != "" {
+				return parsed
+			}
+		}
 		// Invalid date value -> zero date
 		return "0000-00-00"
 	case "TIME":


### PR DESCRIPTION
## Summary
- MySQL accepts `:` as a date delimiter when the value is stored into a DATE/DATETIME column (e.g. `INSERT INTO t (d DATE) VALUES ('97:02:03')` is parsed as `1997-02-03`).
- Previously, `coerceDateTimeValueWithSessionEx` only accepted `/`, `.`, `@` as alternative date delimiters via `normalizeDateDelimiters`, so `'97:02:03'` was rejected and stored as `0000-00-00`.
- Apply the `:` -> `-` normalization only in the DATE-column coercion fallback. Doing this globally in `parseMySQLDateValue` (or in `normalizeDateDelimiters`) caused regressions because TIME-only strings like `25:01:01` returned by `parseMySQLTimeValueRaw` would be parsed as `2025-01-01` when later run through `parseDateTimeValue` (e.g. inside `TIMEDIFF`).

## Impact
- Improves first-diff-line for `other/keywords` (line 7 -> 17). The remaining failure in that test is the `events` keyword as a table name, which is out of scope here.
- Full mtrrun: 1739 passed -> 1739 passed (no regressions, no flips). The change is gated to the `DATE` branch, so TIME/TIMEDIFF behaviour is unchanged.

## Test plan
- [x] `go build ./...`
- [x] `go test ./... -count=1`
- [x] `go run ./cmd/mtrrun -test other/keywords -force` (first-diff advances 7 -> 17)
- [x] `go run ./cmd/mtrrun -test other/func_sapdb -force` (passes)
- [x] Full `go run ./cmd/mtrrun` shows no status flips vs. baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)