### PR TITLE
fix: include trailing UNION text in unaliased last column header

### DIFF
--- a/executor/select.go
+++ b/executor/select.go
@@ -6395,7 +6395,8 @@ func (e *Executor) execUnion(stmt *sqlparser.Union) (*Result, error) {
 	// `AS ""` (Vitess treats empty alias as IsEmpty()=true), and we rely on the
 	// raw query text to recover explicit empty aliases for correct column names.
 	savedCurrentQueryForUnion := e.currentQuery
-	if leftRaw := extractUnionLeftRaw(savedCurrentQueryForUnion); leftRaw != "" {
+	leftRaw := extractUnionLeftRaw(savedCurrentQueryForUnion)
+	if leftRaw != "" {
 		e.currentQuery = leftRaw
 	} else {
 		e.currentQuery = sqlparser.String(stmt.Left)
@@ -6404,6 +6405,40 @@ func (e *Executor) execUnion(stmt *sqlparser.Union) (*Result, error) {
 	e.currentQuery = savedCurrentQueryForUnion
 	if err != nil {
 		return nil, err
+	}
+
+	// MySQL behavior: when the LEFT side of a UNION is an unparenthesized SELECT
+	// and its LAST column has no alias and is not a simple ColName/string-literal,
+	// the column header includes the trailing UNION text. For example:
+	//   SELECT CAST(1 AS JSON) UNION ALL SELECT CAST(1 AS JSON)
+	// produces column header "CAST(1 AS JSON) UNION ALL SELECT CAST(1 AS JSON)".
+	// The leftRaw-only extraction above produces just "CAST(1 AS JSON)"; here we
+	// fix up the last column name by re-extracting from the FULL union query.
+	if leftRaw != "" && len(leftResult.Columns) > 0 {
+		if leftSel, ok := stmt.Left.(*sqlparser.Select); ok {
+			trimmedLeftRaw := strings.TrimSpace(leftRaw)
+			if !strings.HasPrefix(trimmedLeftRaw, "(") &&
+				len(leftSel.SelectExprs.Exprs) == len(leftResult.Columns) {
+				lastIdx := len(leftSel.SelectExprs.Exprs) - 1
+				if ae, ok := leftSel.SelectExprs.Exprs[lastIdx].(*sqlparser.AliasedExpr); ok {
+					_, isLit := ae.Expr.(*sqlparser.Literal)
+					_, isCol := ae.Expr.(*sqlparser.ColName)
+					leftRawExprs := extractRawSelectExprs(leftRaw)
+					hasExplicitStrAlias := false
+					if lastIdx < len(leftRawExprs) {
+						if _, has := extractExplicitStringAlias(strings.TrimSpace(leftRawExprs[lastIdx])); has {
+							hasExplicitStrAlias = true
+						}
+					}
+					if ae.As.IsEmpty() && !isLit && !isCol && !hasExplicitStrAlias {
+						fullExprs := extractRawSelectExprs(savedCurrentQueryForUnion)
+						if lastIdx < len(fullExprs) {
+							leftResult.Columns[lastIdx] = strings.TrimSpace(fullExprs[lastIdx])
+						}
+					}
+				}
+			}
+		}
 	}
 
 	// Execute right side directly from AST.


### PR DESCRIPTION
## Summary
- For an unparenthesized SELECT on the left of a UNION, MySQL extends the last unaliased column's header with the trailing "UNION ..." text (e.g. `SELECT CAST(1 AS JSON) UNION ALL SELECT CAST(1 AS JSON)` produces column header `CAST(1 AS JSON) UNION ALL SELECT CAST(1 AS JSON)`).
- After running the LEFT side of a UNION, post-process its last column name to include the trailing UNION text when the column has no alias and is not a `ColName`/`Literal`/explicit string alias.
- Parenthesized lefts (e.g. `(SELECT ...) UNION (SELECT ...)`) and explicit empty aliases (`AS ""`) keep their existing behavior.

## Test plan
- [x] `go build ./...`
- [x] `go test ./... -count=1` (all unit tests pass, including `TestEmptyStringAlias`)
- [x] `go run ./cmd/mtrrun -test json/json_no_table` passes
- [x] Full mtrrun: 1739 -> 1740 pass (+1), 327 -> 326 fail (-1), no regressions; the only flipped test is `json/json_no_table`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)