### PR TITLE
feat(explain): collapse mergeable derived table over empty base to SIMPLE row

### DIFF
--- a/executor/explain.go
+++ b/executor/explain.go
@@ -2460,6 +2460,31 @@ func (e *Executor) explainSelect(sel *sqlparser.Select, idCounter *int64, select
 		for _, te := range sel.From {
 			e.collectDerivedSelects(te, &derivedSelects)
 		}
+		// "Derived table optimized out": when the outer FROM consists of a single
+		// mergeable derived table whose inner SELECT scans a single empty base
+		// table, MySQL merges the derived table away and emits a single
+		// "1 SIMPLE NULL ... no matching row in const table" row in EXPLAIN
+		// (regardless of FORMAT). The inner DERIVED row is suppressed because
+		// after merging there is no separate derived select.
+		// Example: `EXPLAIN SELECT 1 FROM (SELECT 1 AS x FROM t1) tt WHERE x`
+		// where t1 is empty.
+		if numDerived == 1 && len(derivedSelects) == 1 &&
+			e.derivedSelectIsMergeable(sel, derivedSelects[0]) &&
+			e.derivedInnerHasOnlyEmptyTable(derivedSelects[0]) {
+			// Consume the derived id assignment that explainFromExpr would have
+			// produced, so subsequent ids stay aligned with the rest of the plan.
+			*idCounter++
+			result = append(result, explainSelectType{
+				id:         int64(1),
+				selectType: "SIMPLE",
+				table:      nil,
+				extra:      "no matching row in const table",
+				rows:       nil,
+				filtered:   nil,
+				accessType: nil,
+			})
+			return result
+		}
 		for i := 0; i < numDerived; i++ {
 			derivedRef := fmt.Sprintf("<derived%d>", nextID)
 			// Check if this derived table would produce 0 rows (e.g., cross-table NULL comparison).
@@ -5235,6 +5260,87 @@ func (e *Executor) collectDerivedSelects(te sqlparser.TableExpr, selects *[]*sql
 			e.collectDerivedSelects(expr, selects)
 		}
 	}
+}
+
+// derivedSelectIsMergeable returns true if a FROM-clause derived table is
+// eligible for derived_merge: no aggregation, GROUP BY, DISTINCT, HAVING,
+// LIMIT, window functions, or set operations. The outer SELECT must also be
+// simple enough that merging yields a single combined query block (no GROUP
+// BY / aggregation / DISTINCT in the outer either, since merging would
+// otherwise require pulling those constructs through the derived projection).
+func (e *Executor) derivedSelectIsMergeable(outer *sqlparser.Select, inner *sqlparser.Select) bool {
+	if inner == nil {
+		return false
+	}
+	if !e.isOptimizerSwitchEnabled("derived_merge") {
+		return false
+	}
+	if (inner.GroupBy != nil && len(inner.GroupBy.Exprs) > 0) || inner.Having != nil || inner.Distinct {
+		return false
+	}
+	if inner.Limit != nil {
+		return false
+	}
+	// Reject aggregate or window functions anywhere in the inner select list.
+	hasAgg := false
+	_ = sqlparser.Walk(func(n sqlparser.SQLNode) (bool, error) {
+		if expr, ok := n.(sqlparser.Expr); ok {
+			if isAggregateExpr(expr) {
+				hasAgg = true
+				return false, nil
+			}
+		}
+		if oc, ok := n.(*sqlparser.OverClause); ok {
+			_ = oc
+			hasAgg = true
+			return false, nil
+		}
+		return true, nil
+	}, inner.SelectExprs)
+	if hasAgg {
+		return false
+	}
+	if outer != nil {
+		if (outer.GroupBy != nil && len(outer.GroupBy.Exprs) > 0) || outer.Having != nil || outer.Distinct {
+			return false
+		}
+		if outer.Limit != nil {
+			return false
+		}
+	}
+	return true
+}
+
+// derivedInnerHasOnlyEmptyTable returns true when the derived table's inner
+// SELECT is a single-table scan (no JOINs, no further derived tables) over a
+// real base table that currently has zero rows. This corresponds to MySQL's
+// "derived table that is optimized out" case: after const-table elimination
+// the merged outer query reduces to a scan of an empty table, producing the
+// "no matching row in const table" message.
+func (e *Executor) derivedInnerHasOnlyEmptyTable(inner *sqlparser.Select) bool {
+	if inner == nil || e.Storage == nil {
+		return false
+	}
+	if len(inner.From) != 1 {
+		return false
+	}
+	at, ok := inner.From[0].(*sqlparser.AliasedTableExpr)
+	if !ok {
+		return false
+	}
+	tn, ok := at.Expr.(sqlparser.TableName)
+	if !ok {
+		return false
+	}
+	tblName := tn.Name.String()
+	if tblName == "" || strings.EqualFold(tblName, "dual") {
+		return false
+	}
+	tbl, err := e.Storage.GetTable(e.CurrentDB, tblName)
+	if err != nil || tbl == nil {
+		return false
+	}
+	return len(tbl.Rows) == 0
 }
 
 // explainDerivedTableHasZeroRows returns true if the inner SELECT of a derived table would

--- a/executor/explain_select_type_test.go
+++ b/executor/explain_select_type_test.go
@@ -108,6 +108,12 @@ func TestExplainSelectType_SubqueryInSelect(t *testing.T) {
 
 func TestExplainSelectType_DerivedTable(t *testing.T) {
 	e := newTestExecutor(t)
+	// Insert a row so t1 is not empty: an empty single-table inner select
+	// triggers the "derived table optimized out" collapse and would emit a
+	// single SIMPLE row, which is a separate code path covered elsewhere.
+	if _, err := e.Execute("INSERT INTO t1 (id, val) VALUES (1, 'a')"); err != nil {
+		t.Fatalf("insert t1: %v", err)
+	}
 	res, err := e.Execute("EXPLAIN SELECT * FROM (SELECT id FROM t1) AS dt")
 	if err != nil {
 		t.Fatalf("EXPLAIN failed: %v", err)
@@ -128,6 +134,33 @@ func TestExplainSelectType_DerivedTable(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("expected a DERIVED row, got types: %v", types)
+	}
+}
+
+// TestExplainSelectType_DerivedTableOptimizedOut covers the case where a
+// FROM-clause derived table is mergeable and its inner SELECT scans a single
+// empty base table. MySQL collapses the plan to a single SIMPLE row with
+// "no matching row in const table" and suppresses the inner DERIVED row.
+func TestExplainSelectType_DerivedTableOptimizedOut(t *testing.T) {
+	e := newTestExecutor(t)
+	// t1 is empty by default in the test executor.
+	res, err := e.Execute("EXPLAIN SELECT 1 FROM (SELECT 1 AS x FROM t1) tt WHERE x")
+	if err != nil {
+		t.Fatalf("EXPLAIN failed: %v", err)
+	}
+	if len(res.Rows) != 1 {
+		t.Fatalf("expected 1 row, got %d: %+v", len(res.Rows), res.Rows)
+	}
+	row := res.Rows[0]
+	if row[1] != "SIMPLE" {
+		t.Errorf("expected select_type=SIMPLE, got %v", row[1])
+	}
+	if row[2] != nil {
+		t.Errorf("expected table=NULL, got %v", row[2])
+	}
+	extra, _ := row[11].(string)
+	if extra != "no matching row in const table" {
+		t.Errorf("expected extra=\"no matching row in const table\", got %q", extra)
 	}
 }
 


### PR DESCRIPTION
## Summary
- When the outer FROM is a single mergeable derived table whose inner SELECT scans a single empty base table, collapse the EXPLAIN plan to one `SIMPLE NULL ... no matching row in const table` row instead of emitting `PRIMARY <derivedN>` plus the inner `DERIVED` row.
- Add `derivedSelectIsMergeable` and `derivedInnerHasOnlyEmptyTable` helpers in `executor/explain.go`, short-circuit in the FROM-derived-only branch of `explainSelect`, and add a unit test for the optimized-out shape.
- Update the existing `TestExplainSelectType_DerivedTable` to insert a row so it still exercises the non-collapsed PRIMARY+DERIVED path.

## KPI delta (Refs #264)
- `other/explain_json_all`: first-diff-line 910 -> 930 (+20)
- `other/explain_json_none`: first-diff-line 924 -> 946 (+22)
- `other` suite head-to-head: 104 / 113 / 32 / 53 (pass / fail / error / skip), identical to main; per-test status diff is empty.

## Test plan
- [x] `go build ./...`
- [x] `go test ./... -count=1`
- [x] `go run ./cmd/mtrrun -test other/explain_json_all,other/explain_json_none -force` (first-diff-lines advance)
- [x] `go run ./cmd/mtrrun -suite other -j 1 -max 280 -force` head-to-head against main (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)