### PR TITLE
chore(mtrrun): re-enable big_packets and sp-fib (no longer timeout)

### DIFF
--- a/cmd/mtrrun/skiplist.json
+++ b/cmd/mtrrun/skiplist.json
@@ -2793,10 +2793,6 @@
       "reason": "timeout in mtrrun"
     },
     {
-      "test": "other/big_packets",
-      "reason": "timeout in mtrrun"
-    },
-    {
       "test": "other/locking_part",
       "reason": "timeout in mtrrun"
     },
@@ -3195,10 +3191,6 @@
     {
       "test": "sys_vars/max_join_size_func",
       "reason": "output mismatch"
-    },
-    {
-      "test": "other/sp-fib",
-      "reason": "timeout"
     },
     {
       "test": "other/func_math",


### PR DESCRIPTION
## Summary
- Both tests were skiplisted with reason `timeout`/`timeout in mtrrun`, but they now finish well under the suite timeout (~16s combined for the two of them on this machine).
- Removing the entries gives us two additional passing tests with no code changes required.

## Test plan
- [x] `go run ./cmd/mtrrun -test other/big_packets,other/sp-fib` -> 2/2 pass
- [x] `go test ./... -count=1` -> all packages pass
- [x] Full `go run ./cmd/mtrrun` -> Passed 1740 -> 1742, no other regressions vs the prior baseline (sp-threads flakes between fail/error independent of this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)