### PR TITLE
fix: CONVERT_TZ returns NULL with warning for invalid calendar dates

### DIFF
--- a/executor/func_datetime.go
+++ b/executor/func_datetime.go
@@ -1365,7 +1365,20 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr, row *stor
 		if ctzToLoc == nil {
 			return nil, true, nil
 		}
-		ctzT, ctzParseErr := parseDateTimeValue(toString(ctzVal))
+		ctzInputStr := toString(ctzVal)
+		// Validate date components for YYYY-MM-DD form to reject invalid calendar
+		// dates like "2004-11-31" (Nov has only 30 days). MySQL returns NULL with
+		// a warning instead of normalizing to the next month.
+		if len(ctzInputStr) >= 10 && ctzInputStr[4] == '-' && ctzInputStr[7] == '-' {
+			cy, eyErr := strconv.Atoi(ctzInputStr[:4])
+			cm, emErr := strconv.Atoi(ctzInputStr[5:7])
+			cd, edErr := strconv.Atoi(ctzInputStr[8:10])
+			if eyErr == nil && emErr == nil && edErr == nil && !isValidDate(cy, cm, cd) {
+				e.addWarning("Warning", 1292, "Incorrect datetime value: '"+ctzInputStr+"'")
+				return nil, true, nil
+			}
+		}
+		ctzT, ctzParseErr := parseDateTimeValue(ctzInputStr)
 		if ctzParseErr != nil {
 			return nil, true, nil
 		}


### PR DESCRIPTION
## Summary
- Validate calendar dates (e.g. Nov 31 is invalid) inside `CONVERT_TZ` before parsing, returning NULL plus warning 1292 (`Incorrect datetime value`) instead of silently normalizing through Go's `time.Date` arithmetic to the next month
- Brings `convert_tz('2004-11-31 12:00:00', 'Europe/Moscow', 'UTC')` in line with MySQL: previously it returned `2004-12-01 09:00:00`, now it returns `NULL` with the expected warning

## Result
- `other/timezone_grant` first-diff-line advances from 43 -> 77 (KPI improvement); remaining diff is unrelated CREATE VIEW privilege check
- Full mtrrun: 1742 passed (+3) / 326 failed (-1) / 125 errors (no change) / 1152 skipped vs baseline `result-20260502-214615.json` (1739 / 327 / 125 / 1154); the +3 passes come from earlier merges (json_no_table, big_packets, sp-fib) — no regressions introduced
- 3 first-diff-line improvements (`other/timezone_grant`, `other/explain_json_all`, `other/explain_json_none`), 0 regressions

## Test plan
- [x] `go build ./...`
- [x] `go test ./... -count=1`
- [x] Targeted `go run ./cmd/mtrrun -test other/timezone_grant` shows mismatch at line 43 disappears
- [x] Smoke test on convert_tz-using suites (parser_bug21114_innodb, timezone2, events_2, view, partition_error, rpl_timezone): no regressions
- [x] Full `go run ./cmd/mtrrun`: head-to-head pass-set diff confirms no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)