### PR TITLE
chore(mtrrun): remove sys_vars/group_concat_max_len_func from skiplist

### DIFF
--- a/cmd/mtrrun/skiplist.json
+++ b/cmd/mtrrun/skiplist.json
@@ -3153,10 +3153,6 @@
       "reason": "still failing"
     },
     {
-      "test": "sys_vars/group_concat_max_len_func",
-      "reason": "still failing"
-    },
-    {
       "test": "sys_vars/completion_type_func",
       "reason": "still failing"
     },


### PR DESCRIPTION
## Summary
- Removes stale skiplist entry for `sys_vars/group_concat_max_len_func` (was marked "still failing")
- The test now passes when un-skipped

## Verification
- Verified pass via `go run ./cmd/mtrrun -test sys_vars/group_concat_max_len_func -skipped-only -force`
- Re-verified after removal via `go run ./cmd/mtrrun -test sys_vars/group_concat_max_len_func` -> 1 passed
- Full mtrrun pass count: 1739 -> 1741 (+2; the other +1 came from a previously merged unrelated fix; the lost `other/subselect_innodb` and new `other/big_packets` timeout reproduce regardless of this change and are pre-existing flakes/regressions)

## Test plan
- [x] `go build ./...`
- [x] `go test ./... -count=1`
- [x] `go run ./cmd/mtrrun` regression check