### PR TITLE
fix(explain): keep sibling nested subqueries on distinct ids

### DIFF
--- a/executor/explain.go
+++ b/executor/explain.go
@@ -194,6 +194,14 @@ func (e *Executor) explainMultiRows(query string) [][]interface{} {
 							r.selectType = "SUBQUERY"
 							simpleRows = append(simpleRows, r)
 							hasNestedSubquery = true
+						} else if r.selectType == "NESTED_DEPENDENT_SUBQUERY" {
+							// Same as NESTED_SUBQUERY, but the original row was a
+							// DEPENDENT SUBQUERY (correlated) — restore that distinction
+							// so MySQL's "DEPENDENT SUBQUERY" select_type label is preserved
+							// rather than collapsed to plain SUBQUERY.
+							r.selectType = "DEPENDENT SUBQUERY"
+							simpleRows = append(simpleRows, r)
+							hasNestedSubquery = true
 						} else if r.selectType != "SIMPLE" {
 							// Non-SIMPLE, non-MATERIALIZED, non-DERIVED rows (e.g. DEPENDENT SUBQUERY for EXISTS)
 							// become id=1, SIMPLE (anti-join / FirstMatch strategy)
@@ -6222,17 +6230,32 @@ func (e *Executor) explainSubqueries(sel *sqlparser.Select, idCounter *int64, re
 		e.walkForSubqueries(node, idCounter, result, outerTables, outerCanSemijoin, outerHasOnlyDerived, sel, outerST)
 		// MySQL displays DEPENDENT SUBQUERY rows from the WHERE clause in reverse order
 		// (higher ids first) because it processes them in reverse during optimization.
-		// Reverse the newly-added rows if they are all DEPENDENT SUBQUERY.
+		// Reverse the newly-added rows if they are all DEPENDENT SUBQUERY, or — when
+		// processing the body of an IN-subquery (outerST == "DEPENDENT SUBQUERY")
+		// whose WHERE has multiple direct subqueries — when at least one of the
+		// nested rows is DEPENDENT SUBQUERY and the rest are plain SUBQUERY.
+		// MySQL emits the DEPENDENT (correlated) block first, then the cacheable
+		// SUBQUERY block.  This covers queries such as
+		//   t1.a IN (SELECT c FROM t2 WHERE (SELECT e FROM t3) < SOME(SELECT e FROM t3 WHERE t1.b))
+		// where the SOME subquery (DEPENDENT SUBQUERY) appears before the scalar
+		// SUBQUERY in MySQL's EXPLAIN output.
 		newRows := (*result)[startIdx:]
 		if len(newRows) > 1 {
 			allDependent := true
+			allSubqueryFamily := true
+			anyDependent := false
 			for _, r := range newRows {
 				if r.selectType != "DEPENDENT SUBQUERY" {
 					allDependent = false
-					break
+				}
+				if r.selectType == "DEPENDENT SUBQUERY" {
+					anyDependent = true
+				}
+				if r.selectType != "DEPENDENT SUBQUERY" && r.selectType != "SUBQUERY" {
+					allSubqueryFamily = false
 				}
 			}
-			if allDependent {
+			if allDependent || (outerST == "DEPENDENT SUBQUERY" && allSubqueryFamily && anyDependent) {
 				for i, j := 0, len(newRows)-1; i < j; i, j = i+1, j-1 {
 					newRows[i], newRows[j] = newRows[j], newRows[i]
 				}
@@ -7155,7 +7178,20 @@ func (e *Executor) walkForSubqueries(node sqlparser.SQLNode, idCounter *int64, r
 					// transitively dependent (selectType = "DEPENDENT SUBQUERY" from the merged-level
 					// path above), MySQL merges its tables into the outer subquery's id level rather
 					// than creating a new subquery id. Use outerIDBeforeIncrement instead.
-					mergedDependent := selectType == "DEPENDENT SUBQUERY" && outerSelectTypeOuter == "DEPENDENT SUBQUERY" && inContext
+					//
+					// However, the merge must only happen when this Subquery is the FIRST nested
+					// subquery at the current level — i.e., outerIDBeforeIncrement still equals
+					// the parent IN-subquery's id (captured as outerQueryID at function entry).
+					// If a previous SIBLING subquery has already consumed an id slot at this
+					// level, outerIDBeforeIncrement points to that sibling, not the parent.
+					// In that case the nested IN deserves its own freshly allocated id, exactly
+					// like MySQL does for queries such as
+					//   t1.a IN (SELECT c FROM t2 WHERE (SELECT e FROM t3) < SOME(SELECT e FROM t3 WHERE t1.b))
+					// where MySQL emits id=4 DEPENDENT SUBQUERY t3 (the SOME subquery) and
+					// id=3 SUBQUERY t3 (the scalar subquery) as separate blocks instead of
+					// collapsing them onto the same id.
+					mergedDependent := selectType == "DEPENDENT SUBQUERY" && outerSelectTypeOuter == "DEPENDENT SUBQUERY" && inContext &&
+						outerIDBeforeIncrement == outerQueryID
 					// MATERIALIZED merge: when the parent context is itself MATERIALIZED and the
 					// nested IN subquery also chooses MATERIALIZED, MySQL absorbs the nested
 					// subquery's tables into the parent's MATERIALIZED block (same id),
@@ -7213,7 +7249,11 @@ func (e *Executor) walkForSubqueries(node sqlparser.SQLNode, idCounter *int64, r
 							}
 							if id, ok := subRows[i].id.(int64); ok {
 								if firstID, ok2 := subRows[0].id.(int64); !ok2 || id != firstID {
-									subRows[i].selectType = "NESTED_SUBQUERY"
+									if st == "DEPENDENT SUBQUERY" {
+										subRows[i].selectType = "NESTED_DEPENDENT_SUBQUERY"
+									} else {
+										subRows[i].selectType = "NESTED_SUBQUERY"
+									}
 								}
 							}
 						}

--- a/executor/explain_nested_some_test.go
+++ b/executor/explain_nested_some_test.go
@@ -1,0 +1,76 @@
+package executor
+
+import (
+	"testing"
+
+	"github.com/myuon/mylite/catalog"
+	"github.com/myuon/mylite/storage"
+)
+
+// TestExplain_NestedSomeInSemijoin reproduces the failing case from
+// other/explain_json_all/none around line 1015:
+//
+//	EXPLAIN SELECT * FROM t1
+//	 WHERE t1.a IN (SELECT c FROM t2
+//	                  WHERE (SELECT e FROM t3) < SOME (SELECT e FROM t3 WHERE t1.b))
+//
+// MySQL emits:
+//
+//	1 PRIMARY t1
+//	1 PRIMARY t2
+//	4 DEPENDENT SUBQUERY t3
+//	3 SUBQUERY t3
+//
+// Before this fix, mylite emitted both nested SUBQUERY rows with id=3
+// because mergedDependent collapsed the second sibling subquery's id onto
+// the first sibling's allocated id (instead of the parent IN-subquery's id).
+// After the fix, the two nested subqueries get distinct ids and MySQL's
+// DEPENDENT-first display order is reproduced.
+func TestExplain_NestedSomeInSemijoin(t *testing.T) {
+	cat := catalog.New()
+	store := storage.NewEngine()
+	e := New(cat, store)
+	if _, err := e.Execute("CREATE DATABASE IF NOT EXISTS test"); err != nil {
+		t.Fatalf("create db: %v", err)
+	}
+	e.CurrentDB = "test"
+	for _, q := range []string{
+		"CREATE TABLE t1 (a INT, b INT)",
+		"CREATE TABLE t2 (c INT, d INT)",
+		"CREATE TABLE t3 (e INT)",
+		"INSERT INTO t1 VALUES (1,10), (2,10)",
+		"INSERT INTO t2 VALUES (2,10), (2,20)",
+		"INSERT INTO t3 VALUES (10), (30)",
+	} {
+		if _, err := e.Execute(q); err != nil {
+			t.Fatalf("setup %q: %v", q, err)
+		}
+	}
+	res, err := e.Execute(`EXPLAIN SELECT * FROM t1 WHERE t1.a IN (SELECT c FROM t2 WHERE (SELECT e FROM t3) < SOME(SELECT e FROM t3 WHERE t1.b))`)
+	if err != nil {
+		t.Fatalf("EXPLAIN failed: %v", err)
+	}
+	type want struct {
+		id    int64
+		st    string
+		table interface{}
+	}
+	expected := []want{
+		{1, "PRIMARY", "t1"},
+		{1, "PRIMARY", "t2"},
+		{4, "DEPENDENT SUBQUERY", "t3"},
+		{3, "SUBQUERY", "t3"},
+	}
+	if len(res.Rows) != len(expected) {
+		t.Fatalf("expected %d rows, got %d: %v", len(expected), len(res.Rows), res.Rows)
+	}
+	for i, w := range expected {
+		r := res.Rows[i]
+		id, _ := r[0].(int64)
+		st, _ := r[1].(string)
+		if id != w.id || st != w.st || r[2] != w.table {
+			t.Errorf("row %d: want (id=%d st=%q table=%v), got (id=%v st=%q table=%v)",
+				i, w.id, w.st, w.table, r[0], r[1], r[2])
+		}
+	}
+}


### PR DESCRIPTION
## Summary

When an outer IN subquery is internally classified as `DEPENDENT SUBQUERY` (because its body has a deeper correlated reference) and its body itself contains **two** direct subqueries — say a non-correlated scalar followed by a `SOME`-quantified correlated subquery — mylite's `mergedDependent` path collapsed the second sibling onto the first sibling's already-allocated id. The follow-up to #366 (and to the gap noted in its description).

For

```sql
EXPLAIN SELECT * FROM t1
 WHERE t1.a IN (SELECT c FROM t2
                  WHERE (SELECT e FROM t3) < SOME (SELECT e FROM t3 WHERE t1.b))
```

mylite previously emitted both nested t3 rows with `id=3`. After this PR it emits MySQL's

```
1 PRIMARY t1
1 PRIMARY t2
4 DEPENDENT SUBQUERY t3
3 SUBQUERY t3
```

### Changes

- `mergedDependent` now also requires `outerIDBeforeIncrement == outerQueryID` so the merge only fires when the nested IN is the **first** child at the current walk-level (i.e. its parent IN-subquery's id hasn't been bumped past by a previous sibling). The existing single-child mergedDependent flow (covered by `TestExplainSemijoinMaterialization_Deterministic` and the `subquery_sj_mat` fixtures) is preserved.
- A new internal `NESTED_DEPENDENT_SUBQUERY` marker mirrors the existing `NESTED_SUBQUERY` tag but restores the row to `DEPENDENT SUBQUERY` in `explainMultiRows` post-processing — the correlated-vs-cacheable distinction now survives the semijoin merge.
- `explainSubqueries` reverse-on-all-DEPENDENT is extended to the "outer is `DEPENDENT SUBQUERY`, mixed `SUBQUERY`/`DEPENDENT SUBQUERY`" family so the dependent block prints first, matching MySQL.

## KPI

- `other/explain_json_all`: first-diff-line **932 → 942** (+10)
- `other/explain_json_none`: first-diff-line **946 → 997** (+51)
- `other` suite full pass/fail counts unchanged.
- Full mtrrun: no status regressions attributable to this change. (One full-suite run showed `other/big_packets` timing out under load; the test is known timeout-flaky and passes in isolation across repeated direct runs.)

## Test plan

- [x] `go build ./...`
- [x] `go test ./... -count=1`
- [x] `go run ./cmd/mtrrun -test other/explain_json_all,other/explain_json_none -force`
- [x] `go run ./cmd/mtrrun -suite other -j 1 -max 280 -force` head-to-head with main: 0 status regressions, 2 first-diff-line improvements.
- [x] `go run ./cmd/mtrrun` full suite head-to-head: no real regressions.
- [x] New unit test `TestExplain_NestedSomeInSemijoin` locks in the four-row layout end-to-end.

Refs #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)