### PR TITLE
fix(explain): wrap semijoin pair in nested_loop for EXPLAIN JSON

### DIFF
--- a/executor/explain.go
+++ b/executor/explain.go
@@ -12132,7 +12132,11 @@ func (e *Executor) explainJSONDocument(query string) string {
 								{"query_block", qb},
 							})
 						} else {
-							attachedSubs = append(attachedSubs, qb)
+							attachedSubs = append(attachedSubs, []orderedKV{
+								{"dependent", false},
+								{"cacheable", true},
+								{"query_block", qb},
+							})
 						}
 					}
 				}
@@ -12219,6 +12223,54 @@ func (e *Executor) explainJSONDocument(query string) string {
 					}
 					queryBlock = append(queryBlock, orderedKV{"ordering_operation", orderingOp})
 					subqueryRows = residualSubs
+				} else if len(primaryRows) > 1 && isFirstmatchEnabled {
+					// Multi-primary semijoin (FirstMatch) with subqueries:
+					// MySQL emits a nested_loop wrapping all primary tables
+					// (the first-match driver + subsequent semijoin inner tables),
+					// not a single `table`.  The first table's block already has
+					// attached_condition / attached_subqueries injected above; we
+					// add it as the first nested_loop entry, then build the rest
+					// with first_match annotation.
+					var nl []interface{}
+					nl = append(nl, []orderedKV{{"table", tblBlock}})
+					firstTableName := ""
+					if primaryRows[0].row[2] != nil {
+						firstTableName = fmt.Sprintf("%v", primaryRows[0].row[2])
+					}
+					conds := semijoinAttachedConditions()
+					for _, pr := range primaryRows[1:] {
+						innerTbl := e.explainJSONTableBlock(pr.row, query)
+						accessType := ""
+						if pr.row[4] != nil {
+							accessType = fmt.Sprintf("%v", pr.row[4])
+						}
+						insertPos := len(innerTbl)
+						for i, kv := range innerTbl {
+							if kv.Key == "filtered" {
+								insertPos = i + 1
+								break
+							}
+						}
+						newBlock := make([]orderedKV, 0, len(innerTbl)+2)
+						newBlock = append(newBlock, innerTbl[:insertPos]...)
+						newBlock = append(newBlock, orderedKV{"first_match", firstTableName})
+						if accessType == "ALL" {
+							alreadyHas := false
+							for _, kv := range innerTbl {
+								if kv.Key == "using_join_buffer" {
+									alreadyHas = true
+									break
+								}
+							}
+							if !alreadyHas {
+								newBlock = append(newBlock, orderedKV{"using_join_buffer", "Block Nested Loop"})
+							}
+						}
+						newBlock = append(newBlock, innerTbl[insertPos:]...)
+						newBlock = appendAttachedCondition(newBlock, conds)
+						nl = append(nl, []orderedKV{{"table", newBlock}})
+					}
+					queryBlock = append(queryBlock, orderedKV{"nested_loop", nl})
 				} else {
 					queryBlock = append(queryBlock, orderedKV{"table", tblBlock})
 				}

--- a/executor/explain_nested_some_json_test.go
+++ b/executor/explain_nested_some_json_test.go
@@ -1,0 +1,55 @@
+package executor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/myuon/mylite/catalog"
+	"github.com/myuon/mylite/storage"
+)
+
+// Verifies that EXPLAIN FORMAT=JSON for a semijoin (IN→FirstMatch) with
+// nested subqueries emits a `nested_loop` wrapping all primary tables and
+// keeps `attached_subqueries` (with proper dependent/cacheable flags) on the
+// driving table block.  Reproduces the structure mismatch around line 942
+// of explain_json_all / line 997 of explain_json_none.
+func TestExplain_NestedSomeInSemijoin_JSON(t *testing.T) {
+	cat := catalog.New()
+	store := storage.NewEngine()
+	e := New(cat, store)
+	if _, err := e.Execute("CREATE DATABASE IF NOT EXISTS test"); err != nil {
+		t.Fatalf("create db: %v", err)
+	}
+	e.CurrentDB = "test"
+	for _, q := range []string{
+		"SET optimizer_switch='semijoin=on,materialization=on,firstmatch=on,loosescan=on,index_condition_pushdown=on,mrr=on'",
+		"CREATE TABLE t1 (a INT, b INT)",
+		"CREATE TABLE t2 (c INT, d INT)",
+		"CREATE TABLE t3 (e INT)",
+		"INSERT INTO t1 VALUES (1,10), (2,10)",
+		"INSERT INTO t2 VALUES (2,10), (2,20)",
+		"INSERT INTO t3 VALUES (10), (30)",
+	} {
+		if _, err := e.Execute(q); err != nil {
+			t.Fatalf("setup %q: %v", q, err)
+		}
+	}
+	res, err := e.Execute(`EXPLAIN FORMAT=JSON SELECT * FROM t1 WHERE t1.a IN (SELECT c FROM t2 WHERE (SELECT e FROM t3) < SOME(SELECT e FROM t3 WHERE t1.b))`)
+	if err != nil {
+		t.Fatalf("EXPLAIN failed: %v", err)
+	}
+	if len(res.Rows) != 1 {
+		t.Fatalf("expected 1 EXPLAIN row, got %d", len(res.Rows))
+	}
+	js, _ := res.Rows[0][0].(string)
+	if !strings.Contains(js, `"nested_loop"`) {
+		t.Errorf("expected nested_loop in JSON output, got:\n%s", js)
+	}
+	if !strings.Contains(js, `"first_match": "t1"`) {
+		t.Errorf("expected first_match: t1 in JSON output, got:\n%s", js)
+	}
+	// Both attached subqueries must be wrapped with dependent/cacheable.
+	if strings.Count(js, `"dependent":`) < 2 {
+		t.Errorf("expected at least 2 dependent flags (one per attached_subquery), got:\n%s", js)
+	}
+}


### PR DESCRIPTION
## Summary

When `EXPLAIN FORMAT=JSON` runs over a semijoin (IN subquery rewritten as FirstMatch) whose body itself contains nested subqueries, mylite was emitting only a single `table` block for the driving table while still attaching the nested SUBQUERY / DEPENDENT SUBQUERY rows.  MySQL's actual output is a `nested_loop` wrapping **all** primary tables (driver + semijoin inner tables annotated with `first_match` and `using_join_buffer`).

For example, given

```sql
EXPLAIN FORMAT=JSON SELECT * FROM t1
 WHERE t1.a IN (SELECT c FROM t2
                  WHERE (SELECT e FROM t3) < SOME (SELECT e FROM t3 WHERE t1.b))
```

mylite now emits a `nested_loop: [t1, t2]` block where `t1` carries the attached `select#3 / select#4` subqueries and `t2` carries `first_match: t1` + `using_join_buffer: Block Nested Loop`, mirroring MySQL.

### Changes

- In the EXPLAIN-JSON complex-query path, when `len(primaryRows) > 1` and FirstMatch is enabled, wrap the driving-table block (already decorated with `attached_condition` / `attached_subqueries`) plus the remaining primary tables (with `first_match: <driver>` and `using_join_buffer: Block Nested Loop` for ALL-access) in a `nested_loop` array.
- Within the inline `attached_subqueries` list attached to a primary table block, wrap **non**-DEPENDENT siblings in `{ dependent: false, cacheable: true, query_block: ... }` to match MySQL.  Previously only the DEPENDENT entries were wrapped, so a raw `query_block` leaked next to a wrapped one when both kinds appeared side-by-side (as is the case here for the `(SELECT e FROM t3)` cacheable subquery vs. the `WHERE t1.b` correlated one).

## KPI

- `other/explain_json_all`: first-diff-line **942 -> 984** (+42)
- `other/explain_json_none`: first-diff-line stays at 997, but later diff content shifts forward in lockstep with the new structure (the test eventually diverges at the deeper nested attached_subqueries case which is a follow-up).
- `other` suite full pass/fail counts unchanged (no status regressions; one extra `big_packets` flake-pass).

## Test plan

- [x] `go build ./...`
- [x] `go test ./... -count=1`
- [x] New `TestExplain_NestedSomeInSemijoin_JSON` asserts the JSON structure (presence of `nested_loop`, `first_match: t1`, and at least two `dependent` flags)
- [x] `go run ./cmd/mtrrun -test other/explain_json_all,other/explain_json_none -force` — KPI improved as above
- [x] `go run ./cmd/mtrrun -suite other -j 1 -max 280 -force` head-to-head with main: no regressions

Refs #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)