### PR TITLE
fix(cte): report N+1 iterations in ER_CTE_MAX_RECURSION_DEPTH

### DIFF
--- a/cmd/mtrrun/skiplist.json
+++ b/cmd/mtrrun/skiplist.json
@@ -3157,10 +3157,6 @@
       "reason": "still failing"
     },
     {
-      "test": "sys_vars/cte_max_recursion_depth_func",
-      "reason": "still failing"
-    },
-    {
       "test": "sys_vars/identity_func",
       "reason": "still failing"
     },

--- a/executor/select.go
+++ b/executor/select.go
@@ -6991,8 +6991,13 @@ func (e *Executor) execRecursiveCTE(cteName string, subquery sqlparser.TableStat
 	// iterations are exhausted without the recursion terminating on its own.
 	// We detect this by checking whether the loop completed all maxDepth iterations
 	// AND the last working table was non-empty (i.e., recursion did not terminate).
+	// MySQL counts the iteration that triggered the abort, so the reported count is
+	// maxDepth + 1 (e.g. cte_max_recursion_depth=1000 reports "after 1001 iterations").
+	// When maxDepth=0, even a single recursive step is disallowed: the loop body never
+	// runs, but the anchor's working table is non-empty so the same condition fires
+	// and reports "after 1 iterations".
 	if depth == maxDepth && len(cteMap[cteName].rows) > 0 {
-		return nil, mysqlError(3636, "HY000", fmt.Sprintf("Recursive query aborted after %d iterations. Try increasing @@cte_max_recursion_depth to a larger value.", maxDepth))
+		return nil, mysqlError(3636, "HY000", fmt.Sprintf("Recursive query aborted after %d iterations. Try increasing @@cte_max_recursion_depth to a larger value.", maxDepth+1))
 	}
 
 	return &Result{


### PR DESCRIPTION
## Summary
- MySQL counts the iteration that triggered the abort, so the error reports `cte_max_recursion_depth + 1` (e.g. default 1000 -> "after 1001 iterations"). Our implementation was reporting the completed iteration count, off by one.
- With `cte_max_recursion_depth=0`, MySQL disallows any recursive step at all. Our loop body never runs, but the anchor's working table is non-empty so the existing `depth==maxDepth` guard fires and now correctly reports "after 1 iterations".
- Removes `sys_vars/cte_max_recursion_depth_func` from the skiplist (was marked "still failing").

## Test plan
- [x] `go build ./...`
- [x] `go test ./... -count=1`
- [x] Targeted: `go run ./cmd/mtrrun -test sys_vars/cte_max_recursion_depth_func` -> pass
- [x] Full mtrrun: passed 1741 -> 1742 (+1), no regressions

Generated with Claude Code