### PR TITLE
fix(explain): nest attached_subqueries inside parent subquery's table block

### DIFF
--- a/executor/explain.go
+++ b/executor/explain.go
@@ -10207,6 +10207,50 @@ func (e *Executor) explainJSONQueryBlockForRow(row []interface{}, query string) 
 	return qb
 }
 
+// explainJSONComputeSubqueryParents walks the parsed query and assigns each
+// nested SELECT statement a textual select_id (matching MySQL's numbering),
+// returning a map from select_id -> immediate parent select_id.  The outer
+// SELECT is select_id=1 with no parent (omitted from the map).  IDs are
+// assigned in textual (depth-first) order, mirroring MySQL's optimizer.
+//
+// This is used to attach attached_subqueries to the right query_block when a
+// subquery's body itself contains nested subqueries (e.g. SOME/ANY/ALL or a
+// scalar subquery within an IN-subquery's WHERE).  Without this distinction,
+// all subqueries would flatly attach to the outermost table block.
+func (e *Executor) explainJSONComputeSubqueryParents(query string) map[int64]int64 {
+	stmt, err := e.parser().Parse(query)
+	if err != nil {
+		return nil
+	}
+	sel, ok := stmt.(*sqlparser.Select)
+	if !ok {
+		return nil
+	}
+	parents := map[int64]int64{}
+	nextID := int64(2)
+	var visit func(s *sqlparser.Select, parentID int64)
+	visit = func(s *sqlparser.Select, parentID int64) {
+		// Assign IDs to all nested SELECTs found by walking this select.
+		// We must NOT recurse INTO nested SELECTs from this Walk (we'll
+		// recurse explicitly), so we stop traversal at each Subquery boundary.
+		_ = sqlparser.Walk(func(n sqlparser.SQLNode) (bool, error) {
+			if sub, ok := n.(*sqlparser.Subquery); ok {
+				if inner, ok := sub.Select.(*sqlparser.Select); ok {
+					id := nextID
+					nextID++
+					parents[id] = parentID
+					visit(inner, id)
+				}
+				// Stop: we've handled the inner SELECT via the recursive call.
+				return false, nil
+			}
+			return true, nil
+		}, s)
+	}
+	visit(sel, 1)
+	return parents
+}
+
 // explainJSONInExistsInfo holds the per-IN-subquery markers used in EXPLAIN
 // FORMAT=JSON when MySQL rewrites `outer.col IN (SELECT ...)` into
 // `<in_optimizer>(outer.col, <exists>(SELECT 1 FROM ... WHERE <cond>))` form.
@@ -10634,6 +10678,41 @@ func explainJSONInjectInnerAttachedCondition(qb []orderedKV, cond string) []orde
 		}
 		if !replaced {
 			tbl = append(tbl, orderedKV{"attached_condition", cond})
+		}
+		qb[i] = orderedKV{"table", tbl}
+		return qb
+	}
+	return qb
+}
+
+// explainJSONInjectAttachedSubqueriesIntoTable rewrites a query_block's table
+// sub-block to append an attached_subqueries entry containing the supplied
+// child blocks.  Used when subqueries are nested inside another subquery's
+// body (e.g. SOME/ANY/ALL or scalar subquery within an IN-subquery's WHERE).
+// The returned slice is the modified query_block.
+func explainJSONInjectAttachedSubqueriesIntoTable(qb []orderedKV, children []interface{}) []orderedKV {
+	if len(children) == 0 {
+		return qb
+	}
+	for i, kv := range qb {
+		if kv.Key != "table" {
+			continue
+		}
+		tbl, ok := kv.Value.([]orderedKV)
+		if !ok {
+			continue
+		}
+		// Replace existing attached_subqueries or append at end of table block.
+		replaced := false
+		for j, sub := range tbl {
+			if sub.Key == "attached_subqueries" {
+				tbl[j] = orderedKV{"attached_subqueries", children}
+				replaced = true
+				break
+			}
+		}
+		if !replaced {
+			tbl = append(tbl, orderedKV{"attached_subqueries", children})
 		}
 		qb[i] = orderedKV{"table", tbl}
 		return qb
@@ -12112,11 +12191,22 @@ func (e *Executor) explainJSONDocument(query string) string {
 				var attachedSubs []interface{}
 				hasDependentSubs := false
 				if !hasHavingSubquery && !hasGroupBySubquery {
+					// Compute parent select_id for each subquery; subqueries
+					// nested inside another subquery's body must attach to the
+					// parent subquery's table block, not the outer t1 block.
+					parentByID := e.explainJSONComputeSubqueryParents(query)
+					// Build qb for each subquery first (in textual order) so
+					// children can be merged into their parents.
+					type subEntry struct {
+						id        int64
+						selectID  int64
+						parentID  int64
+						dependent bool
+						qb        []orderedKV
+					}
+					entries := make([]subEntry, 0, len(subqueryRows))
 					for _, s := range subqueryRows {
 						qb := e.explainJSONQueryBlockForRow(s.row, query)
-						// If we have IN→EXISTS marker info and this row is a
-						// DEPENDENT SUBQUERY, inject the inner attached_condition
-						// into the inner table's block (if present).
 						if inExistsInfo != nil && s.selectType == "DEPENDENT SUBQUERY" {
 							if id, ok := s.row[0].(int64); ok {
 								if cond, found := inExistsInfo.InnerCondBySelectID[id]; found && cond != "" {
@@ -12124,20 +12214,90 @@ func (e *Executor) explainJSONDocument(query string) string {
 								}
 							}
 						}
-						if s.selectType == "DEPENDENT SUBQUERY" {
-							hasDependentSubs = true
-							attachedSubs = append(attachedSubs, []orderedKV{
+						selID := int64(0)
+						if id, ok := s.row[0].(int64); ok {
+							selID = id
+						}
+						entries = append(entries, subEntry{
+							selectID:  selID,
+							parentID:  parentByID[selID],
+							dependent: s.selectType == "DEPENDENT SUBQUERY",
+							qb:        qb,
+						})
+					}
+					// Build a wrap-helper that mirrors what we do for top-level.
+					wrap := func(en subEntry) []orderedKV {
+						if en.dependent {
+							return []orderedKV{
 								{"dependent", true},
 								{"cacheable", false},
-								{"query_block", qb},
-							})
-						} else {
-							attachedSubs = append(attachedSubs, []orderedKV{
-								{"dependent", false},
-								{"cacheable", true},
-								{"query_block", qb},
-							})
+								{"query_block", en.qb},
+							}
 						}
+						return []orderedKV{
+							{"dependent", false},
+							{"cacheable", true},
+							{"query_block", en.qb},
+						}
+					}
+					// Group children by parent select_id.  A subquery is
+					// "nested" only if its parent is itself a subquery row
+					// (still present as DEPENDENT SUBQUERY/SUBQUERY at this
+					// level).  When the parent has been flattened (e.g. by
+					// semijoin into PRIMARY), its children re-attach to the
+					// outer table block instead.
+					existsByID := map[int64]bool{}
+					for _, en := range entries {
+						if en.selectID > 0 {
+							existsByID[en.selectID] = true
+						}
+					}
+					childrenByParent := map[int64][]int{}
+					for i, en := range entries {
+						if en.parentID > 1 && existsByID[en.parentID] {
+							childrenByParent[en.parentID] = append(childrenByParent[en.parentID], i)
+						}
+					}
+					// For parents that have nested children, inject those into
+					// the parent qb's table block as attached_subqueries.
+					for pid, childIdxs := range childrenByParent {
+						// Find the entry index for the parent select_id.
+						parentIdx := -1
+						for i, en := range entries {
+							if en.selectID == pid {
+								parentIdx = i
+								break
+							}
+						}
+						if parentIdx == -1 {
+							continue
+						}
+						// Order children: DEPENDENT first, then non-DEPENDENT
+						// (matches MySQL's display order for nested attached_subqueries).
+						var depChildren, nondepChildren []interface{}
+						for _, ci := range childIdxs {
+							if entries[ci].dependent {
+								depChildren = append(depChildren, wrap(entries[ci]))
+							} else {
+								nondepChildren = append(nondepChildren, wrap(entries[ci]))
+							}
+						}
+						childWrapped := append(depChildren, nondepChildren...)
+						entries[parentIdx].qb = explainJSONInjectAttachedSubqueriesIntoTable(entries[parentIdx].qb, childWrapped)
+					}
+					// Now build attachedSubs from top-level entries only:
+					// either parent==1 (direct child of outer) or parent
+					// flattened (not in subqueryRows, e.g. semijoin'd into
+					// PRIMARY, in which case the child attaches to outer too).
+					// Preserve textual order from subqueryRows.
+					for _, en := range entries {
+						if en.parentID > 1 && existsByID[en.parentID] {
+							continue
+						}
+						if en.dependent {
+							hasDependentSubs = true
+						}
+						attachedSubs = append(attachedSubs, wrap(en))
 					}
 				}
 				// When the subqueries are dependent (IN/EXISTS attached to this table's

--- a/executor/explain_nested_some_no_semijoin_test.go
+++ b/executor/explain_nested_some_no_semijoin_test.go
@@ -1,0 +1,81 @@
+package executor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/myuon/mylite/catalog"
+	"github.com/myuon/mylite/storage"
+)
+
+// Verifies that EXPLAIN FORMAT=JSON for a query whose IN-subquery body itself
+// contains nested scalar subqueries (here `(SELECT e FROM t3)` and
+// `SOME(SELECT e FROM t3 WHERE t1.b)`) places those nested subqueries inside
+// the outer IN-subquery's table block as `attached_subqueries`, rather than
+// flattening them all under the outermost table block.
+//
+// Reproduces the structure mismatch in explain_json_none around line 1015 of
+// the normalized output.  When semijoin/firstmatch are off, the outer plan is
+// a single table (t1) with attached_subqueries: [select#2 t2], and select#2
+// itself carries attached_subqueries: [select#4 dep, select#3 cacheable].
+func TestExplain_NestedSomeNoSemijoin_JSON(t *testing.T) {
+	cat := catalog.New()
+	store := storage.NewEngine()
+	e := New(cat, store)
+	if _, err := e.Execute("CREATE DATABASE IF NOT EXISTS test"); err != nil {
+		t.Fatalf("create db: %v", err)
+	}
+	e.CurrentDB = "test"
+	for _, q := range []string{
+		"SET optimizer_switch='semijoin=off,materialization=off,index_condition_pushdown=off,mrr=off'",
+		"CREATE TABLE t1 (a INT, b INT)",
+		"CREATE TABLE t2 (c INT, d INT)",
+		"CREATE TABLE t3 (e INT)",
+		"INSERT INTO t1 VALUES (1,10), (2,10)",
+		"INSERT INTO t2 VALUES (2,10), (2,20)",
+		"INSERT INTO t3 VALUES (10), (30)",
+	} {
+		if _, err := e.Execute(q); err != nil {
+			t.Fatalf("setup %q: %v", q, err)
+		}
+	}
+	res, err := e.Execute(`EXPLAIN FORMAT=JSON SELECT * FROM t1 WHERE t1.a IN (SELECT c FROM t2 WHERE (SELECT e FROM t3) < SOME(SELECT e FROM t3 WHERE t1.b))`)
+	if err != nil {
+		t.Fatalf("EXPLAIN failed: %v", err)
+	}
+	if len(res.Rows) != 1 {
+		t.Fatalf("expected 1 EXPLAIN row, got %d", len(res.Rows))
+	}
+	js, _ := res.Rows[0][0].(string)
+	// There should be NO nested_loop (no semijoin/firstmatch).
+	if strings.Contains(js, `"nested_loop"`) {
+		t.Errorf("did not expect nested_loop with semijoin off, got:\n%s", js)
+	}
+	// Outer t1 has attached_subqueries with select_id=2.
+	if !strings.Contains(js, `"select_id": 2`) {
+		t.Errorf("expected select_id=2 in attached_subqueries, got:\n%s", js)
+	}
+	// select#2's t2 block must carry its own nested attached_subqueries
+	// containing select#3 and select#4.  We check that the substring
+	// `"select_id": 4` appears AFTER `"select_id": 2` in the JSON, and
+	// that the JSON contains at least two `"attached_subqueries"` keys
+	// (one on t1, one on t2).
+	if strings.Count(js, `"attached_subqueries"`) < 2 {
+		t.Errorf("expected nested attached_subqueries on t2's block, got:\n%s", js)
+	}
+	idx2 := strings.Index(js, `"select_id": 2`)
+	idx3 := strings.Index(js, `"select_id": 3`)
+	idx4 := strings.Index(js, `"select_id": 4`)
+	if idx2 < 0 || idx3 < 0 || idx4 < 0 {
+		t.Fatalf("missing select_ids 2/3/4 in JSON: %s", js)
+	}
+	if !(idx2 < idx4 && idx2 < idx3) {
+		t.Errorf("expected select#3 and select#4 to appear after select#2, got positions 2=%d 3=%d 4=%d", idx2, idx3, idx4)
+	}
+	// MySQL's display order: DEPENDENT first, then non-DEPENDENT.
+	// select#4 is the DEPENDENT (correlated SOME), select#3 is the cacheable
+	// (uncorrelated `(SELECT e FROM t3)`).
+	if !(idx4 < idx3) {
+		t.Errorf("expected DEPENDENT select#4 to appear before cacheable select#3 in attached_subqueries, got 3=%d 4=%d", idx3, idx4)
+	}
+}


### PR DESCRIPTION
## Summary

When an IN-subquery's body itself contains nested subqueries (e.g. a scalar `(SELECT ...)` and a `<op> SOME(SELECT ... WHERE outer.col)`), MySQL emits those nested subqueries as `attached_subqueries` *inside* the parent subquery's table block, not flattened under the outermost query's table block.  Previously mylite attached them all as siblings under the outer table, producing a structurally incorrect JSON tree.

For example, given

```sql
EXPLAIN FORMAT=JSON SELECT * FROM t1
 WHERE t1.a IN (SELECT c FROM t2
                  WHERE (SELECT e FROM t3) < SOME (SELECT e FROM t3 WHERE t1.b))
```

mylite now emits select#3 / select#4 inside select#2's t2 table block (DEPENDENT first, cacheable second), mirroring MySQL.

## Changes

- New `explainJSONComputeSubqueryParents` walks the parsed query in textual depth-first order, assigning select_ids and recording each subquery's immediate parent.
- The `attachedSubs` build loop now groups subqueries by parent.  Subqueries whose parent is itself a subquery row get injected into that parent's `query_block.table` via a new `explainJSONInjectAttachedSubqueriesIntoTable` helper; the rest attach to the outer (PRIMARY) table block as before.
- When a parent has been flattened (e.g. semijoin'd into PRIMARY), its children re-attach to the outer block instead — preserving the existing FirstMatch JSON shape from #369.
- Within a nested block the children are ordered DEPENDENT-first then cacheable, matching MySQL's display order.

## KPI

- `other/explain_json_none`: first-diff-line **997 -> 1021** (+24)
- `other/explain_json_all`: first-diff-line stays at 984 — the next divergence is the missing `attached_condition` on select#4's t3 block (follow-up).
- `other` suite full pass/fail counts unchanged (105 pass vs main's 104, +1 `big_packets` flake-pass; identical fail/error counts; no regressions).

## Test plan

- [x] `go build ./...`
- [x] `go test ./... -count=1`
- [x] New `TestExplain_NestedSomeNoSemijoin_JSON` asserts: no nested_loop with semijoin off; two `attached_subqueries` blocks; select#4 (DEPENDENT) precedes select#3 (cacheable) in the nested list.
- [x] Existing `TestExplain_NestedSomeInSemijoin_JSON` still passes (FirstMatch shape preserved).
- [x] `go run ./cmd/mtrrun -test other/explain_json_all,other/explain_json_none -force` — KPI improved as above.
- [x] `go run ./cmd/mtrrun -suite other -j 1 -max 280 -force` head-to-head with main: no status regressions.

Refs #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)