### PR TITLE
fix(sys_vars): freeze SESSION value of max_allowed_packet/net_buffer_length

### DIFF
--- a/cmd/mtrrun/skiplist.json
+++ b/cmd/mtrrun/skiplist.json
@@ -4433,10 +4433,6 @@
       "reason": "needs special session tracking behavior"
     },
     {
-      "test": "sys_vars/max_allowed_packet_basic",
-      "reason": "single-line diff at comparison query"
-    },
-    {
       "test": "sys_vars/binlog_row_event_max_size_basic",
       "reason": "needs persist support"
     },

--- a/executor/variables.go
+++ b/executor/variables.go
@@ -2814,6 +2814,16 @@ var sysVarSessionReadOnly = map[string]bool{
 	"max_allowed_packet":   true,
 }
 
+// sysVarSessionInit contains system variables whose SESSION value is fixed at
+// connection time (MySQL "Session, Init" scope).  Subsequent SET GLOBAL changes
+// do not affect the SESSION value of an existing connection.  This is a strict
+// subset of sysVarSessionReadOnly: e.g. max_user_connections is read-only at
+// SESSION but its session value still tracks the current global value.
+var sysVarSessionInit = map[string]bool{
+	"max_allowed_packet": true,
+	"net_buffer_length":  true,
+}
+
 // sysVarDeprecated maps deprecated system variable names to their deprecation warning message.
 // When these variables are read (SELECT @@var), a deprecation warning (code 1287) is emitted.
 var sysVarDeprecated = map[string]string{
@@ -4476,6 +4486,15 @@ func (e *Executor) buildVariablesMapScoped(globalOnly bool) map[string]string {
 			continue
 		}
 		if !globalOnly && !sysVarGlobalOnly[name] && !sysVarBothScope[name] {
+			continue
+		}
+		// For session-init variables (e.g. max_allowed_packet, net_buffer_length),
+		// the SESSION value is fixed at connection time and is unaffected by subsequent
+		// SET GLOBAL changes.  performance_schema.session_variables must therefore show
+		// the connection-time value (the compiled-in default), not the current global.
+		// Note: not all session-read-only variables are session-init; max_user_connections
+		// is read-only at SESSION but its session value tracks the global value.
+		if !globalOnly && sysVarSessionInit[name] {
 			continue
 		}
 		if name == "innodb_stats_transient_sample_pages" || name == "innodb_stats_persistent_sample_pages" {


### PR DESCRIPTION
## Summary

In MySQL, `max_allowed_packet` and `net_buffer_length` are "Session, Init" scope: their SESSION value is captured at connection time and is unaffected by subsequent `SET GLOBAL` changes. `performance_schema.session_variables` must therefore reflect the connection-time value, not the current global.

Previously `buildVariablesMapScoped` applied the latest global override to the session map for any `sysVarBothScope` variable, causing `@@session.max_allowed_packet = VARIABLE_VALUE FROM session_variables` to return `0` (mismatch) after `SET GLOBAL`: the `@@session` read returns the frozen default while `VARIABLE_VALUE` incorrectly tracked the changed global.

This PR introduces `sysVarSessionInit` (a strict subset of `sysVarSessionReadOnly`) and skips the global override in `session_variables` for these vars. Note: `max_user_connections` is also session-read-only but its session value DOES track global, so it is not in this set.

Removes `sys_vars/max_allowed_packet_basic` from the skiplist.

## KPI

- Before: 1742 passed, 327 failed, 1150 skipped, 125 errors
- After: 1743 passed, 327 failed, 1149 skipped, 125 errors
- Net: +1 pass (sys_vars/max_allowed_packet_basic: skip -> pass), 0 regressions

## Test plan

- [x] `go build ./...`
- [x] `go test ./executor/... ./harness/... -count=1`
- [x] `go run ./cmd/mtrrun -test sys_vars/max_allowed_packet_basic -force -skipped-only` -> passes
- [x] `go run ./cmd/mtrrun -suite sys_vars` -> 506 passed (up from 505), 0 failed
- [x] Full `go run ./cmd/mtrrun` regression check: only sys_vars/max_allowed_packet_basic flipped (skip -> pass), no other test changed status

🤖 Generated with [Claude Code](https://claude.com/claude-code)