### PR TITLE
chore(mtrrun): remove stale sys_vars/{auto_increment_increment,innodb_autoinc_lock_mode}_func from skiplist

### DIFF
--- a/cmd/mtrrun/skiplist.json
+++ b/cmd/mtrrun/skiplist.json
@@ -3465,10 +3465,6 @@
       "reason": "log file not found"
     },
     {
-      "test": "sys_vars/innodb_autoinc_lock_mode_func",
-      "reason": "auto_increment value wrong"
-    },
-    {
       "test": "sys_vars/key_buffer_size_basic",
       "reason": "failures"
     },
@@ -3607,10 +3603,6 @@
     {
       "test": "json/json_conversions",
       "reason": "stack overrun on complex expression"
-    },
-    {
-      "test": "sys_vars/auto_increment_increment_func",
-      "reason": "auto_increment_increment not affecting IDs correctly"
     },
     {
       "test": "sys_vars/autocommit_func",


### PR DESCRIPTION
## Summary
- Both `sys_vars/auto_increment_increment_func` and `sys_vars/innodb_autoinc_lock_mode_func` were marked as skipped with reasons "output mismatch or execution error" / "auto_increment value wrong"
- Re-running these tests with `-skipped-only -force` confirms they now pass cleanly
- Stale skiplist hygiene only; no code changes

## Test plan
- [x] `go build ./...`
- [x] `go test ./... -count=1`
- [x] `go run ./cmd/mtrrun -test sys_vars/auto_increment_increment_func,sys_vars/innodb_autoinc_lock_mode_func` -> 2/2 pass
- [x] No regression in `sys_vars` suite (the only sys_vars failure observed locally is `max_allowed_packet_basic`, which is unrelated to this change and reproduces with the original skiplist)

Found via the two-pronged stale-skiplist search:
```
go run ./cmd/mtrrun -suite sys_vars -skipped-only -force
# -> 2 unexpected passes
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)