### PR TITLE
fix(explain): emit (outer.col is not null) for materialized IN-subquery

### DIFF
--- a/executor/explain.go
+++ b/executor/explain.go
@@ -10742,6 +10742,79 @@ func explainJSONInjectAttachedSubqueriesIntoTable(qb []orderedKV, children []int
 	return qb
 }
 
+// explainJSONCollectMaterializedINColumns walks the outer query's WHERE clause
+// and returns a map of lower-cased outer-table-name -> ordered, deduplicated
+// list of columns that appear as the LHS of any `col IN (SELECT ...)` predicate.
+// Used to inject `(col is not null)` into the outer table's attached_condition
+// when MySQL materializes the IN-subquery into `<subqueryN>` and probes via
+// eq_ref on `<auto_key>`.  Only top-level IN-subqueries (combined with AND) are
+// considered; OR / nested-subquery IN predicates are ignored to avoid emitting
+// spurious not-null conditions.
+func (e *Executor) explainJSONCollectMaterializedINColumns(query string) map[string][]string {
+	stmt, err := e.parser().Parse(query)
+	if err != nil {
+		return nil
+	}
+	sel, ok := stmt.(*sqlparser.Select)
+	if !ok || sel.Where == nil {
+		return nil
+	}
+	defaultTbl := ""
+	for _, te := range sel.From {
+		for _, tn := range e.extractAllTableNames(te) {
+			if !strings.EqualFold(tn, "dual") {
+				defaultTbl = strings.ToLower(tn)
+				break
+			}
+		}
+		if defaultTbl != "" {
+			break
+		}
+	}
+	result := map[string][]string{}
+	seen := map[string]bool{}
+	var walk func(expr sqlparser.Expr)
+	walk = func(expr sqlparser.Expr) {
+		switch ex := expr.(type) {
+		case *sqlparser.AndExpr:
+			walk(ex.Left)
+			walk(ex.Right)
+		case *sqlparser.ComparisonExpr:
+			if ex.Operator != sqlparser.InOp {
+				return
+			}
+			// RHS must be a SELECT subquery (not a value list).
+			if _, ok := ex.Right.(*sqlparser.Subquery); !ok {
+				return
+			}
+			col, ok := ex.Left.(*sqlparser.ColName)
+			if !ok {
+				return
+			}
+			tbl := col.Qualifier.Name.String()
+			if tbl == "" {
+				tbl = defaultTbl
+			}
+			tbl = strings.ToLower(tbl)
+			if tbl == "" {
+				return
+			}
+			colName := col.Name.String()
+			key := tbl + "." + strings.ToLower(colName)
+			if seen[key] {
+				return
+			}
+			seen[key] = true
+			result[tbl] = append(result[tbl], colName)
+		}
+	}
+	walk(sel.Where.Expr)
+	if len(result) == 0 {
+		return nil
+	}
+	return result
+}
+
 // extractFirstINSubquerySQL extracts the first IN (SELECT ...) subquery from a SQL query string.
 // Returns the SELECT part (e.g., "SELECT a FROM t11") for use in analyzing which columns
 // are referenced in the subquery (for used_columns in EXPLAIN FORMAT=JSON).
@@ -11582,6 +11655,38 @@ func (e *Executor) explainJSONDocument(query string) string {
 			subqueryIsDriving[name] = isDriver
 		}
 
+		// Collect (table, column) pairs that appear as the LHS of any
+		// `col IN (SELECT ...)` predicate in the outer query.  When MySQL
+		// materializes such an IN-subquery into `<subqueryN>` and probes via
+		// eq_ref on `<auto_key>`, the outer table block carries an
+		// `attached_condition: (col is not null)` because the eq_ref probe
+		// drops NULL outer values.
+		matINCols := e.explainJSONCollectMaterializedINColumns(query)
+		matDBName := e.CurrentDB
+		if matDBName == "" {
+			matDBName = "test"
+		}
+		injectMatINNotNull := func(tblName string, tblBlock []orderedKV) []orderedKV {
+			cols := matINCols[strings.ToLower(tblName)]
+			if len(cols) == 0 {
+				return tblBlock
+			}
+			for _, kv := range tblBlock {
+				if kv.Key == "attached_condition" {
+					return tblBlock
+				}
+			}
+			parts := make([]string, 0, len(cols))
+			for _, c := range cols {
+				parts = append(parts, fmt.Sprintf("(`%s`.`%s`.`%s` is not null)", matDBName, tblName, c))
+			}
+			cond := parts[0]
+			for i := 1; i < len(parts); i++ {
+				cond = fmt.Sprintf("(%s and %s)", cond, parts[i])
+			}
+			return append(tblBlock, orderedKV{"attached_condition", cond})
+		}
+
 		// Collect non-subquery primary table blocks.
 		var outerTableBlocks []interface{}
 		for _, p := range primaryRows {
@@ -11593,6 +11698,7 @@ func (e *Executor) explainJSONDocument(query string) string {
 				continue
 			}
 			tblBlock := e.explainJSONTableBlock(p.row, query)
+			tblBlock = injectMatINNotNull(tblName, tblBlock)
 			outerTableBlocks = append(outerTableBlocks, []orderedKV{{"table", tblBlock}})
 		}
 
@@ -11674,6 +11780,7 @@ func (e *Executor) explainJSONDocument(query string) string {
 				// In the non-BNL (eq_ref probe) case: all outer tables come BEFORE the subquery
 				isDependent := anySubqueryBNL && (accessType == "ref" || accessType == "eq_ref" || accessType == "const")
 				tblBlock := e.explainJSONTableBlock(p.row, query)
+				tblBlock = injectMatINNotNull(tblName, tblBlock)
 				if isDependent {
 					dependentTables = append(dependentTables, []orderedKV{{"table", tblBlock}})
 				} else {

--- a/executor/explain_outer_mat_in_notnull_test.go
+++ b/executor/explain_outer_mat_in_notnull_test.go
@@ -1,0 +1,104 @@
+package executor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/myuon/mylite/catalog"
+	"github.com/myuon/mylite/storage"
+)
+
+// TestExplain_OuterTableMaterializedINNotNull_JSON: when MySQL materializes an
+// IN-subquery into `<subqueryN>` and probes via eq_ref on `<auto_key>`, the
+// outer table block carries `attached_condition: (col is not null)` because the
+// eq_ref probe on the materialized table never matches NULL outer values.
+//
+// Reproduces the missing-attached_condition gap on the t1 outer table block of
+// the "semi-join materialization" query in explain_json.inc:
+//
+//	EXPLAIN FORMAT=JSON SELECT * FROM t1
+//	WHERE t1.a IN (SELECT t2.a FROM t2 WHERE t2.a >  0) AND
+//	      t1.a IN (SELECT t3.a FROM t3 WHERE t3.a IN
+//	                  (SELECT t4.a FROM t4 WHERE a > 0));
+func TestExplain_OuterTableMaterializedINNotNull_JSON(t *testing.T) {
+	cat := catalog.New()
+	store := storage.NewEngine()
+	e := New(cat, store)
+	if _, err := e.Execute("CREATE DATABASE IF NOT EXISTS test"); err != nil {
+		t.Fatalf("create db: %v", err)
+	}
+	e.CurrentDB = "test"
+	for _, q := range []string{
+		"SET optimizer_switch='semijoin=on,materialization=on,firstmatch=on,loosescan=on,index_condition_pushdown=on,mrr=on'",
+		"CREATE TABLE t1 (a INT)",
+		"INSERT INTO t1 VALUES (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1)",
+		"CREATE TABLE t2 (a INT) SELECT * FROM t1",
+		"CREATE TABLE t3 (a INT) SELECT * FROM t1",
+		"CREATE TABLE t4 (a INT) SELECT * FROM t1",
+	} {
+		if _, err := e.Execute(q); err != nil {
+			t.Fatalf("setup %q: %v", q, err)
+		}
+	}
+	res, err := e.Execute(`EXPLAIN FORMAT=JSON SELECT * FROM t1 WHERE t1.a IN (SELECT t2.a FROM t2 WHERE t2.a > 0) AND t1.a IN (SELECT t3.a FROM t3 WHERE t3.a IN (SELECT t4.a FROM t4 WHERE a > 0))`)
+	if err != nil {
+		t.Fatalf("EXPLAIN failed: %v", err)
+	}
+	if len(res.Rows) != 1 {
+		t.Fatalf("expected 1 EXPLAIN row, got %d", len(res.Rows))
+	}
+	js, _ := res.Rows[0][0].(string)
+	// At least one <subqueryN> placeholder must be present (semijoin
+	// materialization produced a materialized inner table).
+	if !strings.Contains(js, `"<subquery`) {
+		t.Fatalf("expected at least one <subqueryN> placeholder in JSON:\n%s", js)
+	}
+	// Locate the outer t1 table block and ensure it carries the not-null
+	// attached_condition added for the materialized IN-subquery probe.
+	idx := strings.Index(js, `"table_name": "t1"`)
+	if idx < 0 {
+		t.Fatalf("missing t1 table_name in JSON:\n%s", js)
+	}
+	// Look ahead through the t1 block (up to the next table_name or end).
+	end := strings.Index(js[idx+1:], `"table_name"`)
+	if end < 0 {
+		end = len(js) - idx
+	}
+	segment := js[idx : idx+1+end]
+	if !strings.Contains(segment, "(`test`.`t1`.`a` is not null)") {
+		t.Errorf("expected outer t1 block to carry attached_condition `(test.t1.a is not null)`; segment:\n%s", segment)
+	}
+}
+
+// TestExplain_NoMaterializedSubquery_NoOuterNotNull: when there is no
+// materialized IN-subquery in the query, the outer table must NOT receive the
+// `(col is not null)` attached_condition.  This guards against regressing
+// simpler queries that only use FirstMatch / non-semijoin plans.
+func TestExplain_NoMaterializedSubquery_NoOuterNotNull(t *testing.T) {
+	cat := catalog.New()
+	store := storage.NewEngine()
+	e := New(cat, store)
+	if _, err := e.Execute("CREATE DATABASE IF NOT EXISTS test"); err != nil {
+		t.Fatalf("create db: %v", err)
+	}
+	e.CurrentDB = "test"
+	for _, q := range []string{
+		"CREATE TABLE t1 (a INT)",
+		"INSERT INTO t1 VALUES (1), (2), (3)",
+	} {
+		if _, err := e.Execute(q); err != nil {
+			t.Fatalf("setup %q: %v", q, err)
+		}
+	}
+	res, err := e.Execute(`EXPLAIN FORMAT=JSON SELECT a FROM t1 WHERE a > 0`)
+	if err != nil {
+		t.Fatalf("EXPLAIN failed: %v", err)
+	}
+	if len(res.Rows) != 1 {
+		t.Fatalf("expected 1 EXPLAIN row, got %d", len(res.Rows))
+	}
+	js, _ := res.Rows[0][0].(string)
+	if strings.Contains(js, "(`test`.`t1`.`a` is not null)") {
+		t.Errorf("did not expect not-null attached_condition for non-materialized query:\n%s", js)
+	}
+}


### PR DESCRIPTION
## Summary

When MySQL materializes an IN-subquery into `<subqueryN>` and probes via eq_ref on `<auto_key>`, the outer table block carries an `attached_condition: (test.outer.col is not null)` because the eq_ref probe on the materialized table never matches NULL outer values. mylite was emitting the outer table block without any `attached_condition` for this case.

This is the next blocker on `other/explain_json_all` after #376: the missing not-null condition on the outer t1 in the "semi-join materialization (if enabled)" query in `explain_json.inc`.

## Changes

- New helper `explainJSONCollectMaterializedINColumns` walks the outer query's WHERE clause and returns the set of `(outer_table, col)` pairs that appear as the LHS of any `col IN (SELECT ...)` predicate combined under top-level AND.
- After building each outer table block in the materialized-semijoin path (both the `anySubqueryDriving` and `else` branches), when the table has at least one such column and the block does not yet carry an `attached_condition`, we inject `(test.tbl.col is not null)` (combined with `and` for multiple columns).
- Restricting to top-level AND-combined IN-subqueries with a SELECT subquery RHS avoids emitting spurious not-null conditions for OR-joined or nested-subquery IN predicates.
- Added `TestExplain_OuterTableMaterializedINNotNull_JSON` covering the exact "semi-join materialization (if enabled)" pattern from `explain_json.inc`, and `TestExplain_NoMaterializedSubquery_NoOuterNotNull` guarding against spurious injection on plain queries.

## KPI

- `other/explain_json_all`: first-diff-line **1076 -> 1082 (+6)**
- `other/explain_json_none`: unchanged at 1104 (semijoin disabled, no materialization happens, so the path is not hit).
- `other` suite full pass/fail counts unchanged (105 pass / 113 fail / 32 error head-to-head with main; no per-test status regressions; only `explain_json_all` first-diff-line moved forward).

## Test plan

- [x] `go build ./...`
- [x] `go test ./... -count=1`
- [x] `go run ./cmd/mtrrun -test other/explain_json_all,other/explain_json_none -force` -- KPI improved as above
- [x] `go run ./cmd/mtrrun -suite other -j 1 -max 280 -force` head-to-head with main: no status regressions, single first-diff-line improvement on `explain_json_all`

Refs #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)