### PR TITLE
chore(mtrrun): unblock 2 passing innodb_gis tests

### DIFF
--- a/cmd/mtrrun/skiplist.json
+++ b/cmd/mtrrun/skiplist.json
@@ -1925,10 +1925,6 @@
       "reason": "=== encryption suite === === large_tests suite === === binlog_nogtid suite === === innodb_undo suite === === innodb_zip suite === === gcol_ndb suite === === innodb_gis suite ==="
     },
     {
-      "test": "innodb_gis/row_format",
-      "reason": "=== encryption suite === === large_tests suite === === binlog_nogtid suite === === innodb_undo suite === === innodb_zip suite === === gcol_ndb suite === === innodb_gis suite ==="
-    },
-    {
       "test": "innodb_gis/rtree",
       "reason": "=== encryption suite === === large_tests suite === === binlog_nogtid suite === === innodb_undo suite === === innodb_zip suite === === gcol_ndb suite === === innodb_gis suite ==="
     },
@@ -4245,10 +4241,6 @@
       "reason": "out of scope: binary log not needed for embedded test DB"
     },
     {
-      "test": "innodb_gis/*",
-      "reason": "out of scope: GIS/spatial features not needed for test DB"
-    },
-    {
       "test": "secondary_engine/*",
       "reason": "out of scope: secondary engine not needed for embedded test DB"
     },
@@ -4335,6 +4327,18 @@
     {
       "test": "innodb/autoinc_persist",
       "reason": "remaining: auto warning emission + ROLLBACK restoration semantics (Refs #255)"
+    },
+    {
+      "test": "innodb_gis/rtree_compress",
+      "reason": "spatial/rtree feature not implemented"
+    },
+    {
+      "test": "innodb_gis/rtree_compress2",
+      "reason": "spatial/rtree feature not implemented"
+    },
+    {
+      "test": "innodb_gis/rtree_purge",
+      "reason": "spatial/rtree feature not implemented"
     }
   ]
 }


### PR DESCRIPTION
## Summary

Continuing the stale-skiplist-cleanup work from #375 and #377. Scanned 22 suites with `-skipped-only -force` to find tests that were skipped but actually pass.

Most remaining suites had 0 unexpected passes (innodb, parts, max_parts, gcol, funcs_1/2, json, innodb_zip, innodb_undo, collations, engine_funcs, engine_iuds, gis, innodb_fts, jp, large_tests, opt_trace, secondary_engine, x, binlog, binlog_gtid, binlog_nogtid, auth_sec, rpl, rpl_gtid, rpl_nogtid, group_replication, query_rewrite_plugins, encryption, innodb_stress, stress, gcol_ndb).

The only finds: 2 tests in `innodb_gis` (`row_format`, `rtree_recovery`) actually pass.

These were blocked by an `innodb_gis/*` wildcard. Restructured by:
- Removing the `innodb_gis/*` wildcard
- Removing the explicit `innodb_gis/row_format` entry (now passes)
- Adding explicit entries for the 3 tests previously only blocked by the wildcard (`rtree_compress`, `rtree_compress2`, `rtree_purge`)

`rtree_recovery` had no explicit entry (only the wildcard) so removing the wildcard unblocked it.

## Verification

Full mtrrun head-to-head on this worktree:

```
Before: Suites 29, Total 3345, Passed 1799, Failed 327, Skipped 1093, Errors 125, Timeouts 1
After:  Suites 29, Total 3345, Passed 1801, Failed 327, Skipped 1091, Errors 125, Timeouts 1
```

Delta: **+2 passes**, 0 failures, 0 errors. No regressions.

innodb_gis suite alone:
```
Total 17, Passed 2, Failed 0, Skipped 15, Errors 0, Timeouts 0
```

## Test plan

- [x] `go build ./...` succeeds
- [x] `go test ./... -count=1` passes
- [x] Full `go run ./cmd/mtrrun` shows +2 passes vs baseline, 0 regressions
- [x] Verified via `-skipped-only -force` that both row_format and rtree_recovery pass

## Removed entries

- `innodb_gis/*` (wildcard)
- `innodb_gis/row_format` (now passes)

## Added entries (previously covered only by wildcard)

- `innodb_gis/rtree_compress` (skip)
- `innodb_gis/rtree_compress2` (fail)
- `innodb_gis/rtree_purge` (skip)

🤖 Generated with [Claude Code](https://claude.com/claude-code)