### PR TITLE
fix(explain): keep sibling IN-subqueries materialized, order by table count

### DIFF
--- a/executor/explain.go
+++ b/executor/explain.go
@@ -3618,6 +3618,33 @@ func (e *Executor) collectAllTablesForDuplicateWeedout(inner *sqlparser.Select) 
 	return result
 }
 
+// countTopLevelINSubqueries returns the number of top-level `col IN (SELECT ...)`
+// predicates in the given expression, considering only AND-combined predicates
+// (not OR or nested subqueries).  Tuple IN subqueries are also counted.
+//
+// Used to detect when the outer query combines multiple sibling IN subqueries
+// via AND.  In that case MySQL's planner cannot use DuplicateWeedout for an
+// individual sibling because DW would force flattening all tables into id=1,
+// which is incompatible with multiple `<subqueryN>` placeholders coexisting at
+// the outer query level (each sibling needs its own materialized placeholder).
+func countTopLevelINSubqueries(expr sqlparser.Expr) int {
+	if expr == nil {
+		return 0
+	}
+	switch ex := expr.(type) {
+	case *sqlparser.AndExpr:
+		return countTopLevelINSubqueries(ex.Left) + countTopLevelINSubqueries(ex.Right)
+	case *sqlparser.ComparisonExpr:
+		if ex.Operator != sqlparser.InOp {
+			return 0
+		}
+		if _, ok := ex.Right.(*sqlparser.Subquery); ok {
+			return 1
+		}
+	}
+	return 0
+}
+
 // shouldUseDuplicateWeedout returns true when the inner SELECT has nested IN subqueries
 // (i.e., its WHERE has an IN subquery), which triggers MySQL's DuplicateWeedout semijoin strategy.
 // When DuplicateWeedout is used, MySQL flattens all tables from all nesting levels into a
@@ -7079,7 +7106,19 @@ func (e *Executor) walkForSubqueries(node sqlparser.SQLNode, idCounter *int64, r
 				// DuplicateWeedout (which weeds duplicates by primary key) would discard them.
 				notInLeftJoinBlocksWeedout := selectType == "MATERIALIZED" &&
 					isSubqueryInNotInContext(node, sub) && nestedINSubqueryHasLeftJoin(inner)
-				if selectType == "MATERIALIZED" && !notInLeftJoinBlocksWeedout && (e.shouldUseDuplicateWeedout(inner) || tablePulloutWeedout) {
+				// Sibling-IN exception: when the outer query's WHERE combines multiple
+				// top-level `col IN (SELECT ...)` predicates via AND, MySQL keeps each
+				// IN subquery as its own materialized `<subqueryN>` placeholder rather
+				// than flattening one of them via DuplicateWeedout (which would force
+				// all tables onto id=1 SIMPLE rows, incompatible with multiple sibling
+				// placeholders).  Detect this via the outer SELECT's WHERE expression.
+				multipleSiblingINs := false
+				if outerSel != nil && outerSel.Where != nil {
+					if countTopLevelINSubqueries(outerSel.Where.Expr) >= 2 {
+						multipleSiblingINs = true
+					}
+				}
+				if selectType == "MATERIALIZED" && !notInLeftJoinBlocksWeedout && !multipleSiblingINs && (e.shouldUseDuplicateWeedout(inner) || tablePulloutWeedout) {
 					// Collect all tables from the nested IN chain (or the inner FROM list
 					// when the trigger is table-pullout rather than nested IN).
 					var allTables []string
@@ -11572,7 +11611,18 @@ func (e *Executor) explainJSONDocument(query string) string {
 						parts := strings.Split(refStr, ",")
 						arr := make([]interface{}, len(parts))
 						for i, pp := range parts {
-							arr[i] = strings.TrimSpace(pp)
+							s := strings.TrimSpace(pp)
+							// JSON EXPLAIN renders ref entries fully qualified
+							// with the database name (e.g. "test.t1.a") when the
+							// ref is "table.col" without a leading database.
+							// Special tokens like "func" or "const" are kept as-is.
+							if s != "" && s != "func" && s != "const" && e.CurrentDB != "" {
+								dotCount := strings.Count(s, ".")
+								if dotCount == 1 && !strings.HasPrefix(s, "<") {
+									s = e.CurrentDB + "." + s
+								}
+							}
+							arr[i] = s
 						}
 						subqueryTblBlock = append(subqueryTblBlock, orderedKV{"ref", arr})
 					}
@@ -11787,15 +11837,44 @@ func (e *Executor) explainJSONDocument(query string) string {
 					driverTables = append(driverTables, []orderedKV{{"table", tblBlock}})
 				}
 			}
-			// Build: driver tables, then subqueries (sorted by ID), then dependent tables
+			// Build: driver tables, then subqueries, then dependent tables.
+			// Subquery ordering: when there are multiple sibling materialized
+			// subqueries, MySQL's optimizer chooses the join order based on
+			// cost.  As a coarse cost proxy we order by descending number of
+			// tables inside each materialization (multi-table subqueries first,
+			// matching MySQL's choice of joining the most selective subquery
+			// earliest).  Single-table-only subqueries fall back to ID order.
 			nestedLoop = append(nestedLoop, driverTables...)
 			var matIDs []int64
 			for matID := range materializedRowsByID {
 				matIDs = append(matIDs, matID)
 			}
+			// Compute per-id table count from materializedRowsByID.
+			matTableCount := make(map[int64]int, len(matIDs))
+			for matID, rows := range materializedRowsByID {
+				matTableCount[matID] = len(rows)
+			}
+			anyMultiTable := false
+			for _, c := range matTableCount {
+				if c > 1 {
+					anyMultiTable = true
+					break
+				}
+			}
 			for i := 0; i < len(matIDs); i++ {
 				for j := i + 1; j < len(matIDs); j++ {
-					if matIDs[i] > matIDs[j] {
+					less := false
+					if anyMultiTable {
+						// Sort by descending table count, then ascending ID.
+						if matTableCount[matIDs[i]] != matTableCount[matIDs[j]] {
+							less = matTableCount[matIDs[i]] < matTableCount[matIDs[j]]
+						} else {
+							less = matIDs[i] > matIDs[j]
+						}
+					} else {
+						less = matIDs[i] > matIDs[j]
+					}
+					if less {
 						matIDs[i], matIDs[j] = matIDs[j], matIDs[i]
 					}
 				}

--- a/executor/explain_sibling_in_mat_test.go
+++ b/executor/explain_sibling_in_mat_test.go
@@ -1,0 +1,80 @@
+package executor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/myuon/mylite/catalog"
+	"github.com/myuon/mylite/storage"
+)
+
+// TestExplain_SiblingINSubqueriesBothMaterialized: when the outer WHERE has
+// multiple sibling top-level `col IN (SELECT ...)` predicates combined with
+// AND, MySQL keeps each one as its own materialized `<subqueryN>` placeholder
+// rather than flattening one of them via DuplicateWeedout (which would force
+// all tables onto id=1 SIMPLE rows, incompatible with multiple sibling
+// `<subqueryN>` placeholders).
+//
+// Reproduces the "semi-join materialization (if enabled)" query from
+// explain_json.inc:
+//
+//	EXPLAIN FORMAT=JSON SELECT * FROM t1
+//	WHERE t1.a IN (SELECT t2.a FROM t2 WHERE t2.a > 0) AND
+//	      t1.a IN (SELECT t3.a FROM t3 WHERE t3.a IN
+//	                  (SELECT t4.a FROM t4 WHERE a > 0));
+//
+// Expected: TWO `<subqueryN>` placeholders (`<subquery2>` for t2, `<subquery3>`
+// for t3+t4), both with `materialized_from_subquery`.
+func TestExplain_SiblingINSubqueriesBothMaterialized(t *testing.T) {
+	cat := catalog.New()
+	store := storage.NewEngine()
+	e := New(cat, store)
+	if _, err := e.Execute("CREATE DATABASE IF NOT EXISTS test"); err != nil {
+		t.Fatalf("create db: %v", err)
+	}
+	e.CurrentDB = "test"
+	for _, q := range []string{
+		"SET optimizer_switch='semijoin=on,materialization=on,firstmatch=on,loosescan=on,index_condition_pushdown=on,mrr=on'",
+		"CREATE TABLE t1 (a INT)",
+		"INSERT INTO t1 VALUES (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1)",
+		"CREATE TABLE t2 (a INT) SELECT * FROM t1",
+		"CREATE TABLE t3 (a INT) SELECT * FROM t1",
+		"CREATE TABLE t4 (a INT) SELECT * FROM t1",
+	} {
+		if _, err := e.Execute(q); err != nil {
+			t.Fatalf("setup %q: %v", q, err)
+		}
+	}
+	res, err := e.Execute(`EXPLAIN FORMAT=JSON SELECT * FROM t1 WHERE t1.a IN (SELECT t2.a FROM t2 WHERE t2.a > 0) AND t1.a IN (SELECT t3.a FROM t3 WHERE t3.a IN (SELECT t4.a FROM t4 WHERE a > 0))`)
+	if err != nil {
+		t.Fatalf("EXPLAIN failed: %v", err)
+	}
+	if len(res.Rows) != 1 {
+		t.Fatalf("expected 1 EXPLAIN row, got %d", len(res.Rows))
+	}
+	js, _ := res.Rows[0][0].(string)
+	// Both sibling subqueries must materialize and survive as <subqueryN>
+	// placeholders -- DuplicateWeedout flattening must NOT consume one of them.
+	if !strings.Contains(js, `"<subquery2>"`) {
+		t.Errorf("expected <subquery2> placeholder; got:\n%s", js)
+	}
+	if !strings.Contains(js, `"<subquery3>"`) {
+		t.Errorf("expected <subquery3> placeholder; got:\n%s", js)
+	}
+	// Each placeholder block must carry materialized_from_subquery.
+	if strings.Count(js, "materialized_from_subquery") < 2 {
+		t.Errorf("expected 2+ materialized_from_subquery blocks; got:\n%s", js)
+	}
+	// Multi-table materialization (<subquery3> contains t3+t4) should appear
+	// before the single-table <subquery2> in the outer nested_loop.
+	idx3 := strings.Index(js, `"<subquery3>"`)
+	idx2 := strings.Index(js, `"<subquery2>"`)
+	if idx3 < 0 || idx2 < 0 || idx3 > idx2 {
+		t.Errorf("expected <subquery3> to appear before <subquery2> (cost-based ordering); idx2=%d idx3=%d\n%s", idx2, idx3, js)
+	}
+	// JSON ref entries must be fully qualified with the database name
+	// (`test.t1.a`), not the bare `t1.a` form used in tabular EXPLAIN.
+	if !strings.Contains(js, `"test.t1.a"`) {
+		t.Errorf("expected fully qualified ref `test.t1.a` in <subqueryN> placeholder; got:\n%s", js)
+	}
+}


### PR DESCRIPTION
## Summary

When the outer WHERE combines multiple top-level `col IN (SELECT ...)` predicates with AND, MySQL keeps each one as its own materialized `<subqueryN>` placeholder rather than flattening one via DuplicateWeedout. mylite was collapsing both placeholders into a single id=1 SIMPLE flat join, producing a tabular plan that bears little resemblance to MySQL's materialized output.

This is the next blocker on `other/explain_json_all` after #378 -- the second IN subquery in the "semi-join materialization (if enabled)" query of `explain_json.inc` needs to materialize as `<subquery3>` (containing the t4+t3 nested-IN body) instead of being flattened.

## Changes

- New helper `countTopLevelINSubqueries` walks the outer WHERE counting AND-combined `col IN (SELECT ...)` predicates. When 2+ siblings exist, the DuplicateWeedout flatten path is skipped so each materialized subquery survives as its own placeholder.
- The outer-block subquery placeholder ordering now sorts by descending inner-table count (multi-table materializations before single-table ones) when any materialization has 2+ tables. This matches MySQL's cost-based ordering for the `t1.a IN (SELECT t3.a FROM t3 WHERE t3.a IN (SELECT t4.a))` case where `<subquery3>` (t4+t3) precedes `<subquery2>` (t2 only). Single-table-only sibling sets still use the legacy ID-ascending order.
- `buildSubqueryBlock` now fully qualifies bare `table.col` ref entries with the current database name (e.g. `test.t1.a`), matching MySQL's EXPLAIN FORMAT=JSON convention. Special tokens (`func`, `const`) and pseudo-tables (`<subqueryN>`, `<derivedN>`) are left untouched.
- Added `TestExplain_SiblingINSubqueriesBothMaterialized` covering the exact pattern from `explain_json.inc`: two sibling IN subqueries, the second with a nested IN. The test asserts both `<subquery2>` and `<subquery3>` materialize, `<subquery3>` precedes `<subquery2>`, and the ref is fully qualified.

## KPI

- `other/explain_json_all` first-diff-line **1082 -> 1096 (+14)**
- `other/explain_json_none` unchanged at 1104 (semijoin/materialization off, the path is not hit).
- `other` suite head-to-head with main: 105 pass / 113 fail / 32 error, no per-test status regressions; only `explain_json_all` first-diff-line moved forward.

## Test plan

- [x] `go build ./...`
- [x] `go test ./... -count=1`
- [x] `go run ./cmd/mtrrun -test other/explain_json_all,other/explain_json_none -force` -- KPI improved as above
- [x] `go run ./cmd/mtrrun -suite other -j 1 -max 280 -force` head-to-head with main: no status regressions, single first-diff-line improvement on `explain_json_all`

Refs #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)