### PR TITLE
fix(explain): reorder nested IN-semijoin tables inside materialized subquery

### DIFF
--- a/executor/explain.go
+++ b/executor/explain.go
@@ -10854,6 +10854,274 @@ func (e *Executor) explainJSONCollectMaterializedINColumns(query string) map[str
 	return result
 }
 
+// extractAllINSubquerySQLs returns the SELECT body of every `IN (SELECT ...)`
+// subquery that appears at any nesting depth in the query string. Each entry
+// is a substring like "SELECT t2.a FROM t2 WHERE t2.a > 0". Order is by
+// position in the source. Used to map materialized <subqueryN> placeholders to
+// the original IN-subquery SQL when multiple sibling IN-subqueries exist.
+func (e *Executor) extractAllINSubquerySQLs(query string) []string {
+	upper := strings.ToUpper(query)
+	var results []string
+	// Walk the string character by character, looking for " IN " or "\nIN "
+	// followed by an opening parenthesis whose first non-whitespace token is
+	// SELECT. We extract everything between SELECT and the matching ')'.
+	i := 0
+	for i < len(query) {
+		// Find next "IN" keyword preceded by whitespace and followed by '(' or whitespace then '('.
+		idx := strings.Index(upper[i:], "IN")
+		if idx < 0 {
+			break
+		}
+		pos := i + idx
+		// Require previous char to be whitespace (word boundary).
+		if pos == 0 || !isExplainSpace(query[pos-1]) {
+			i = pos + 2
+			continue
+		}
+		// Require next char to be whitespace or '(' (followed by '(' eventually).
+		after := pos + 2
+		if after >= len(query) {
+			break
+		}
+		// Skip whitespace after IN.
+		j := after
+		for j < len(query) && isExplainSpace(query[j]) {
+			j++
+		}
+		if j >= len(query) || query[j] != '(' {
+			i = after
+			continue
+		}
+		// Inside the paren, skip whitespace and look for SELECT.
+		k := j + 1
+		for k < len(query) && isExplainSpace(query[k]) {
+			k++
+		}
+		if k+6 > len(query) || !strings.EqualFold(query[k:k+6], "SELECT") {
+			i = after
+			continue
+		}
+		// Find the matching ')'.
+		depth := 1
+		end := -1
+		for m := j + 1; m < len(query); m++ {
+			switch query[m] {
+			case '(':
+				depth++
+			case ')':
+				depth--
+				if depth == 0 {
+					end = m
+				}
+			}
+			if end >= 0 {
+				break
+			}
+		}
+		if end < 0 {
+			break
+		}
+		results = append(results, query[k:end])
+		// Continue scanning AFTER the IN to catch nested INs inside the body too.
+		i = k
+	}
+	return results
+}
+
+func isExplainSpace(b byte) bool {
+	return b == ' ' || b == '\t' || b == '\n' || b == '\r'
+}
+
+// explainJSONNestedINJoinInfo describes the equality condition that joins the
+// outer-IN table to the inner-IN table after MySQL flattens a nested
+//
+//	WHERE outer_t.col IN (SELECT inner_t.col FROM inner_t WHERE ...)
+//
+// inside a materialized subquery body. The "second" table in the inner
+// nested_loop receives `using_join_buffer: Block Nested Loop` and an
+// `attached_condition` of `(db.outer_t.col = db.inner_t.col)`.
+type explainJSONNestedINJoinInfo struct {
+	dbName   string
+	outerTbl string
+	outerCol string
+	innerTbl string
+	innerCol string
+	// innerSQL is the SELECT body of the nested IN subquery (e.g.
+	// "SELECT t4.a FROM t4 WHERE a > 0").  Used as the query string for the
+	// inner_t (driver) table block so its attached_condition reflects the
+	// nested filter rather than the surrounding outer IN expression.
+	innerSQL string
+}
+
+// explainJSONReorderNestedINMatRows detects the nested-IN semijoin pattern
+// inside a materialized subquery and, when matched, swaps the row order so the
+// inner-IN table (the driver after semijoin flattening) comes first.  Returns
+// the (possibly reordered) rows and a non-nil join info struct describing the
+// equality condition between outer_t.col and inner_t.col.  When the pattern is
+// not detected, returns the rows unchanged and nil.
+func (e *Executor) explainJSONReorderNestedINMatRows(rows [][]interface{}, innerSQL string) ([][]interface{}, *explainJSONNestedINJoinInfo) {
+	if len(rows) != 2 {
+		return rows, nil
+	}
+	stmt, err := e.parser().Parse(innerSQL)
+	if err != nil {
+		return rows, nil
+	}
+	sel, ok := stmt.(*sqlparser.Select)
+	if !ok || sel.Where == nil {
+		return rows, nil
+	}
+	// Look for `outerCol IN (SELECT innerCol FROM innerTbl ...)` at the top level
+	// of the WHERE clause.  Walk both sides of any AND nodes.
+	var outerCol *sqlparser.ColName
+	var innerSel *sqlparser.Select
+	var walk func(expr sqlparser.Expr)
+	walk = func(expr sqlparser.Expr) {
+		if outerCol != nil && innerSel != nil {
+			return
+		}
+		switch x := expr.(type) {
+		case *sqlparser.AndExpr:
+			walk(x.Left)
+			walk(x.Right)
+		case *sqlparser.ComparisonExpr:
+			if x.Operator != sqlparser.InOp {
+				return
+			}
+			lhs, lok := x.Left.(*sqlparser.ColName)
+			if !lok {
+				return
+			}
+			sub, sok := x.Right.(*sqlparser.Subquery)
+			if !sok {
+				return
+			}
+			s, sselok := sub.Select.(*sqlparser.Select)
+			if !sselok {
+				return
+			}
+			outerCol = lhs
+			innerSel = s
+		}
+	}
+	walk(sel.Where.Expr)
+	if outerCol == nil || innerSel == nil {
+		return rows, nil
+	}
+	// Identify outer table from the outer SELECT's FROM list.
+	outerTbl := ""
+	for _, te := range sel.From {
+		for _, n := range e.extractAllTableNames(te) {
+			outerTbl = n
+			break
+		}
+		if outerTbl != "" {
+			break
+		}
+	}
+	// Identify inner SELECT's first SELECT-list ColName for innerCol; identify
+	// inner table from the inner SELECT's FROM list.
+	innerTbl := ""
+	for _, te := range innerSel.From {
+		for _, n := range e.extractAllTableNames(te) {
+			innerTbl = n
+			break
+		}
+		if innerTbl != "" {
+			break
+		}
+	}
+	if outerTbl == "" || innerTbl == "" {
+		return rows, nil
+	}
+	// Inner col: prefer the SELECT-list ColName of the inner SELECT.
+	var innerCol *sqlparser.ColName
+	if innerSel.SelectExprs != nil && len(innerSel.SelectExprs.Exprs) > 0 {
+		if ae, aok := innerSel.SelectExprs.Exprs[0].(*sqlparser.AliasedExpr); aok {
+			if cn, cok := ae.Expr.(*sqlparser.ColName); cok {
+				innerCol = cn
+			}
+		}
+	}
+	if innerCol == nil {
+		return rows, nil
+	}
+	dbName := e.CurrentDB
+	if dbName == "" {
+		dbName = "test"
+	}
+	innerSQLStr := sqlparser.String(innerSel)
+	info := &explainJSONNestedINJoinInfo{
+		dbName:   dbName,
+		outerTbl: outerTbl,
+		outerCol: outerCol.Name.String(),
+		innerTbl: innerTbl,
+		innerCol: innerCol.Name.String(),
+		innerSQL: innerSQLStr,
+	}
+	// Find which row corresponds to outer_t and inner_t and reorder so inner_t
+	// comes first.
+	rowName := func(r []interface{}) string {
+		if r[2] == nil {
+			return ""
+		}
+		return strings.ToLower(fmt.Sprintf("%v", r[2]))
+	}
+	outerLower := strings.ToLower(outerTbl)
+	innerLower := strings.ToLower(innerTbl)
+	r0 := rowName(rows[0])
+	r1 := rowName(rows[1])
+	if r0 == outerLower && r1 == innerLower {
+		return [][]interface{}{rows[1], rows[0]}, info
+	}
+	if r0 == innerLower && r1 == outerLower {
+		// Already in MySQL order; still attach join info for the second row.
+		return rows, info
+	}
+	// Could not match by name; bail out without rewriting.
+	return rows, nil
+}
+
+// explainJSONInjectBNLEqJoin rewrites a table block to add
+// `using_join_buffer: "Block Nested Loop"` (after `filtered`, before
+// `cost_info`) and to replace any existing `attached_condition` with
+// `(db.outerTbl.outerCol = db.innerTbl.innerCol)` reflecting the semijoin
+// equality after the nested-IN flattening.  This matches MySQL's JSON shape
+// for the second table inside a materialized subquery's nested IN.
+func explainJSONInjectBNLEqJoin(block []orderedKV, info *explainJSONNestedINJoinInfo) []orderedKV {
+	if info == nil {
+		return block
+	}
+	cond := fmt.Sprintf("(`%s`.`%s`.`%s` = `%s`.`%s`.`%s`)",
+		info.dbName, info.outerTbl, info.outerCol,
+		info.dbName, info.innerTbl, info.innerCol)
+	out := make([]orderedKV, 0, len(block)+2)
+	hasJoinBuf := false
+	hasAttached := false
+	for _, kv := range block {
+		switch kv.Key {
+		case "using_join_buffer":
+			hasJoinBuf = true
+			out = append(out, orderedKV{"using_join_buffer", "Block Nested Loop"})
+		case "attached_condition":
+			hasAttached = true
+			out = append(out, orderedKV{"attached_condition", cond})
+		case "cost_info":
+			if !hasJoinBuf {
+				out = append(out, orderedKV{"using_join_buffer", "Block Nested Loop"})
+				hasJoinBuf = true
+			}
+			out = append(out, kv)
+		default:
+			out = append(out, kv)
+		}
+	}
+	if !hasAttached {
+		out = append(out, orderedKV{"attached_condition", cond})
+	}
+	return out
+}
+
 // extractFirstINSubquerySQL extracts the first IN (SELECT ...) subquery from a SQL query string.
 // Returns the SELECT part (e.g., "SELECT a FROM t11") for use in analyzing which columns
 // are referenced in the subquery (for used_columns in EXPLAIN FORMAT=JSON).
@@ -11532,9 +11800,34 @@ func (e *Executor) explainJSONDocument(query string) string {
 		// <subqueryN> placeholder rows with their materialized subquery blocks in-place.
 		// This preserves MySQL's join order (as shown in the tabular EXPLAIN).
 
-		// Extract the IN-subquery SQL for used_columns analysis (so we only show
-		// the columns referenced in the subquery, not all columns from outer SELECT *).
+		// Extract every IN-subquery body in the outer query so we can pick the
+		// matching one per materialized id (used for used_columns and condition
+		// extraction). Falls back to the first IN-subquery for legacy callers.
+		allINSubSQLs := e.extractAllINSubquerySQLs(query)
 		inSubquerySQL := e.extractFirstINSubquerySQL(query)
+
+		// pickInnerSQL returns the IN-subquery SQL whose FROM clause contains the
+		// given table name. If none match, returns the first IN-subquery SQL or
+		// (if there are no IN-subqueries) the outer query itself.
+		pickInnerSQL := func(tblName string) string {
+			lower := strings.ToLower(tblName)
+			for _, s := range allINSubSQLs {
+				us := strings.ToLower(s)
+				// Quick word-boundary check for "from <tbl>" or "from `<tbl>`".
+				if strings.Contains(us, " "+lower+" ") ||
+					strings.Contains(us, " "+lower+",") ||
+					strings.Contains(us, " "+lower+"\n") ||
+					strings.Contains(us, " "+lower+"\t") ||
+					strings.Contains(us, "`"+lower+"`") ||
+					strings.HasSuffix(us, " "+lower) {
+					return s
+				}
+			}
+			if inSubquerySQL != "" {
+				return inSubquerySQL
+			}
+			return query
+		}
 
 		// First, build a map from subquery name -> materialized block ([]orderedKV)
 		matBlockByName := make(map[string][]orderedKV)
@@ -11543,9 +11836,14 @@ func (e *Executor) explainJSONDocument(query string) string {
 				continue
 			}
 			// Use the subquery SQL (if available) for used_columns analysis in inner tables.
+			// Prefer per-id inner SQL based on the first row's table name.
 			innerQuery := query
-			if inSubquerySQL != "" {
-				innerQuery = inSubquerySQL
+			if len(matRows) > 0 {
+				if firstTbl, ok := matRows[0].row[2].(string); ok && firstTbl != "" {
+					innerQuery = pickInnerSQL(firstTbl)
+				} else if inSubquerySQL != "" {
+					innerQuery = inSubquerySQL
+				}
 			}
 			// Build the inner query_block for the materialized subquery
 			var innerQB []orderedKV
@@ -11555,10 +11853,37 @@ func (e *Executor) explainJSONDocument(query string) string {
 				innerTblBlock := e.explainJSONTableBlock(m.row, innerQuery)
 				innerQB = append(innerQB, orderedKV{"table", innerTblBlock})
 			} else {
-				// Multiple tables: nested_loop in inner query_block
-				var innerLoop []interface{}
+				// Multiple tables: nested_loop in inner query_block.
+				// Detect the nested-IN semijoin pattern: when the inner SQL is
+				//   SELECT outer_t.col FROM outer_t WHERE outer_t.col IN (
+				//       SELECT inner_t.col FROM inner_t WHERE ...
+				//   )
+				// MySQL's optimizer flattens the inner IN via semijoin and emits
+				// the inner_t row first (driver, with the inner-WHERE filter as
+				// attached_condition), followed by outer_t with
+				//   using_join_buffer: Block Nested Loop
+				//   attached_condition: (outer_t.col = inner_t.col)
+				// The tabular EXPLAIN lists outer_t first, inner_t second; we
+				// must reorder to match MySQL's JSON output.
+				rawRows := make([][]interface{}, 0, len(matRows))
 				for _, m := range matRows {
-					innerTblBlock := e.explainJSONTableBlock(m.row, innerQuery)
+					rawRows = append(rawRows, m.row)
+				}
+				orderedRowsRaw, joinInfo := e.explainJSONReorderNestedINMatRows(rawRows, innerQuery)
+				var innerLoop []interface{}
+				for idx, r := range orderedRowsRaw {
+					rowQuery := innerQuery
+					if joinInfo != nil && idx == 0 && joinInfo.innerSQL != "" {
+						// Driver row in a nested-IN semijoin: use the nested
+						// SELECT's SQL so attached_condition reflects its own
+						// WHERE filter (e.g. "(t4.a > 0)") rather than the
+						// surrounding outer IN expression.
+						rowQuery = joinInfo.innerSQL
+					}
+					innerTblBlock := e.explainJSONTableBlock(r, rowQuery)
+					if joinInfo != nil && idx == 1 {
+						innerTblBlock = explainJSONInjectBNLEqJoin(innerTblBlock, joinInfo)
+					}
 					innerLoop = append(innerLoop, []orderedKV{{"table", innerTblBlock}})
 				}
 				innerQB = append(innerQB, orderedKV{"nested_loop", innerLoop})

--- a/executor/explain_nested_in_mat_test.go
+++ b/executor/explain_nested_in_mat_test.go
@@ -1,0 +1,79 @@
+package executor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/myuon/mylite/catalog"
+	"github.com/myuon/mylite/storage"
+)
+
+// TestExplain_NestedINInMaterializedSubqueryReorder: when a materialized
+// IN-subquery body itself contains a nested `outer.col IN (SELECT inner.col
+// FROM inner_t WHERE ...)`, MySQL flattens the inner IN via semijoin and
+// emits the inner_t row first inside the materialized subquery's
+// `nested_loop`, with the outer_t row second carrying
+// `using_join_buffer: Block Nested Loop` and
+// `attached_condition: (outer_t.col = inner_t.col)`.
+//
+// Reproduces the `<subquery3>` body in the "semi-join materialization (if
+// enabled)" query of `other/explain_json.inc` (explain_json_all line 1096+).
+//
+// Without this handling, the rows appear in tabular order (outer_t first,
+// inner_t second) which does not match MySQL's JSON shape.
+func TestExplain_NestedINInMaterializedSubqueryReorder(t *testing.T) {
+	cat := catalog.New()
+	store := storage.NewEngine()
+	e := New(cat, store)
+	if _, err := e.Execute("CREATE DATABASE IF NOT EXISTS test"); err != nil {
+		t.Fatalf("create db: %v", err)
+	}
+	e.CurrentDB = "test"
+	for _, q := range []string{
+		"SET optimizer_switch='semijoin=on,materialization=on,firstmatch=on,loosescan=on,index_condition_pushdown=on,mrr=on'",
+		"CREATE TABLE t1 (a INT)",
+		"INSERT INTO t1 VALUES (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1), (1)",
+		"CREATE TABLE t2 (a INT) SELECT * FROM t1",
+		"CREATE TABLE t3 (a INT) SELECT * FROM t1",
+		"CREATE TABLE t4 (a INT) SELECT * FROM t1",
+	} {
+		if _, err := e.Execute(q); err != nil {
+			t.Fatalf("setup %q: %v", q, err)
+		}
+	}
+	res, err := e.Execute(`EXPLAIN FORMAT=JSON SELECT * FROM t1 WHERE t1.a IN (SELECT t2.a FROM t2 WHERE t2.a > 0) AND t1.a IN (SELECT t3.a FROM t3 WHERE t3.a IN (SELECT t4.a FROM t4 WHERE a > 0))`)
+	if err != nil {
+		t.Fatalf("EXPLAIN failed: %v", err)
+	}
+	js, _ := res.Rows[0][0].(string)
+
+	// Inside <subquery3>'s nested_loop, t4 must appear before t3.
+	sub3 := strings.Index(js, `"<subquery3>"`)
+	if sub3 < 0 {
+		t.Fatalf("expected <subquery3> placeholder; got:\n%s", js)
+	}
+	// Restrict search to the <subquery3> body (up to the next placeholder).
+	sub2 := strings.Index(js[sub3+1:], `"<subquery2>"`)
+	body := js[sub3:]
+	if sub2 > 0 {
+		body = js[sub3 : sub3+1+sub2]
+	}
+	idxT4 := strings.Index(body, `"table_name": "t4"`)
+	idxT3 := strings.Index(body, `"table_name": "t3"`)
+	if idxT4 < 0 || idxT3 < 0 || idxT4 > idxT3 {
+		t.Errorf("expected t4 before t3 inside <subquery3> nested_loop; idxT4=%d idxT3=%d body:\n%s", idxT4, idxT3, body)
+	}
+	// The second table (t3) must carry using_join_buffer: Block Nested Loop
+	// and attached_condition: (test.t3.a = test.t4.a).
+	if !strings.Contains(body, `"using_join_buffer": "Block Nested Loop"`) {
+		t.Errorf("expected `using_join_buffer: Block Nested Loop` in <subquery3> body; got:\n%s", body)
+	}
+	if !strings.Contains(body, "(`test`.`t3`.`a` = `test`.`t4`.`a`)") {
+		t.Errorf("expected `(test.t3.a = test.t4.a)` attached_condition in <subquery3> body; got:\n%s", body)
+	}
+	// The driver row (t4) must keep the inner-WHERE filter as its
+	// attached_condition, not the surrounding outer IN expression.
+	if !strings.Contains(body, "(`test`.`t4`.`a` > 0)") {
+		t.Errorf("expected `(test.t4.a > 0)` attached_condition for t4 driver in <subquery3>; got:\n%s", body)
+	}
+}


### PR DESCRIPTION
## Summary

When a materialized IN-subquery body itself contains a nested
`outer.col IN (SELECT inner.col FROM inner_t WHERE ...)`, MySQL flattens the
inner IN via semijoin and emits the inner_t row first inside the materialized
subquery's `nested_loop` (driver carrying the inner WHERE filter), with the
outer_t row second carrying `using_join_buffer: Block Nested Loop` and
`attached_condition: (outer_t.col = inner_t.col)`.

mylite was emitting rows in the tabular EXPLAIN order (outer_t first, inner_t
second). Additionally, the per-id inner SQL passed to `explainJSONTableBlock`
was always the *first* IN-subquery body, so used_columns and attached_condition
were wrong for every materialized id beyond the first. This is the next
blocker on `other/explain_json_all` after #380 (the `<subquery3>` body in the
"semi-join materialization (if enabled)" query).

## Changes

- New helper `extractAllINSubquerySQLs` extracts every `IN (SELECT ...)` body
  from the outer query string so we can pick the matching one per materialized
  id (`pickInnerSQL` looks up by the row's table name).
- New helper `explainJSONReorderNestedINMatRows` parses the per-id inner SQL,
  detects the nested-IN semijoin pattern (top-level `outer.col IN (SELECT
  inner.col FROM inner_t)` in the WHERE clause), and returns the rows in
  MySQL JSON order (inner_t first, outer_t second) plus a struct describing
  the equality join condition.
- New helper `explainJSONInjectBNLEqJoin` rewrites the second table's block to
  add `using_join_buffer: "Block Nested Loop"` and replaces any existing
  `attached_condition` with `(outer_t.col = inner_t.col)`.
- The driver row's table block is built using the nested SELECT's SQL (e.g.
  `SELECT t4.a FROM t4 WHERE a > 0`) so its `attached_condition` reflects the
  inner filter rather than the surrounding outer IN expression.
- Added `TestExplain_NestedINInMaterializedSubqueryReorder` covering the exact
  pattern from `explain_json.inc`: the t3-and-nested-t4 IN materializes, t4
  must appear first, t3 must carry BNL + the equality condition.

## KPI

- `other/explain_json_all` first-diff-line **1096 -> 1211 (+115)**
- `other/explain_json_none` unchanged at 1104 (semijoin/materialization off,
  path not hit)
- `other` suite head-to-head with main: 105 pass / 113 fail / 32 error, zero
  per-test status regressions; only `explain_json_all` first-diff-line moved
  forward.

## Test plan

- [x] `go build ./...`
- [x] `go test ./... -count=1`
- [x] `go run ./cmd/mtrrun -test other/explain_json_all,other/explain_json_none -force` -- KPI improved as above
- [x] `go run ./cmd/mtrrun -suite other -j 1 -max 280 -force` head-to-head with main: zero status regressions; `explain_json_all` 1096 -> 1211

Refs #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)