### PR TITLE
fix(explain): keep ALL access_type for explicit InnoDB single-row tables

### DIFF
--- a/executor/explain.go
+++ b/executor/explain.go
@@ -2785,8 +2785,20 @@ func (e *Executor) explainSelect(sel *sqlparser.Select, idCounter *int64, select
 			// references the table — the single row is read once and treated as a constant.
 			// Restrict to len(allTableNames) == 1 to avoid disturbing multi-table joins
 			// where mylite's optimizer ordering may not match MySQL's.
+			//
+			// Skip when the table was created with an explicit ENGINE=InnoDB clause:
+			// InnoDB row counts come from probabilistic statistics that are never exact
+			// at compile time, so MySQL's optimizer cannot prove the table has exactly
+			// one row and keeps `ALL`.  When the user did not specify an engine the
+			// default in MySQL's mtr environment is MyISAM (force_myisam_default.inc),
+			// for which the row count is exact and the promotion matches.
+			engineExplicitInnoDB := false
+			if td := e.explainGetTableDef(tblName); td != nil &&
+				strings.EqualFold(td.Engine, "InnoDB") {
+				engineExplicitInnoDB = true
+			}
 			if accessType == "ALL" && len(allTableNames) == 1 && idx == 0 && !rangeCheckedForEachRecord &&
-				!tableIsEmpty && rowCount == int64(1) {
+				!tableIsEmpty && rowCount == int64(1) && !engineExplicitInnoDB {
 				accessType = "system"
 				possibleKeys = nil
 				key = nil

--- a/executor/explain_innodb_no_system_test.go
+++ b/executor/explain_innodb_no_system_test.go
@@ -1,0 +1,97 @@
+package executor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/myuon/mylite/catalog"
+	"github.com/myuon/mylite/storage"
+)
+
+// TestExplain_InnoDBSingleRowKeepsALL: when a sole-table SELECT scans an
+// explicitly InnoDB table that happens to hold a single row, MySQL keeps
+// access_type "ALL" rather than promoting to "system". InnoDB row counts
+// come from probabilistic statistics that the optimizer does not treat as
+// exact at compile time; the "system" optimization is reserved for engines
+// (e.g. MyISAM) where the row count is known exactly.
+//
+// Reproduces the EXISTS scenario at explain_json_all line 1297+: t1 was
+// created with an explicit `ENGINE=InnoDB` clause and contains one row;
+// MySQL emits access_type=ALL for it.  Without this exception mylite
+// promotes ALL→system and the JSON shape diverges (the "attached_condition"
+// and any "attached_subqueries" the optimizer would attach to the table
+// disappear).
+func TestExplain_InnoDBSingleRowKeepsALL(t *testing.T) {
+	cat := catalog.New()
+	store := storage.NewEngine()
+	e := New(cat, store)
+	if _, err := e.Execute("CREATE DATABASE IF NOT EXISTS test"); err != nil {
+		t.Fatalf("create db: %v", err)
+	}
+	e.CurrentDB = "test"
+	for _, q := range []string{
+		"CREATE TABLE t1 (i1 INTEGER NOT NULL, c1 VARCHAR(1) NOT NULL) charset latin1 ENGINE=InnoDB",
+		"INSERT INTO t1 VALUES (2,'w')",
+		"CREATE TABLE t3 (c1 VARCHAR(1) NOT NULL) charset latin1 ENGINE=InnoDB",
+		"INSERT INTO t3 VALUES ('v')",
+	} {
+		if _, err := e.Execute(q); err != nil {
+			t.Fatalf("setup %q: %v", q, err)
+		}
+	}
+	res, err := e.Execute(`EXPLAIN FORMAT=JSON SELECT i1 FROM t1 WHERE c1 = (SELECT MIN(c1) FROM t3)`)
+	if err != nil {
+		t.Fatalf("EXPLAIN failed: %v", err)
+	}
+	js, _ := res.Rows[0][0].(string)
+	// Find t1's table block and assert access_type:"ALL", not "system".
+	t1Idx := strings.Index(js, `"table_name": "t1"`)
+	if t1Idx < 0 {
+		t.Fatalf("expected t1 in EXPLAIN JSON; got:\n%s", js)
+	}
+	end := t1Idx + 200
+	if end > len(js) {
+		end = len(js)
+	}
+	t1Block := js[t1Idx:end]
+	if strings.Contains(t1Block, `"access_type": "system"`) {
+		t.Errorf("t1 (InnoDB, 1 row) should keep access_type ALL, got 'system'; block:\n%s", t1Block)
+	}
+	if !strings.Contains(t1Block, `"access_type": "ALL"`) {
+		t.Errorf("t1 (InnoDB, 1 row) should have access_type ALL; block:\n%s", t1Block)
+	}
+}
+
+// TestExplain_NonInnoDBSingleRowPromotesSystem: when the resolved engine is
+// MyISAM (e.g. force_myisam_default.inc has set default_storage_engine=MyISAM
+// for the session) ALL→system promotion still applies.  MyISAM keeps an
+// exact row count so MySQL's optimizer treats the single-row table as
+// effectively constant.
+func TestExplain_NonInnoDBSingleRowPromotesSystem(t *testing.T) {
+	cat := catalog.New()
+	store := storage.NewEngine()
+	e := New(cat, store)
+	if _, err := e.Execute("CREATE DATABASE IF NOT EXISTS test"); err != nil {
+		t.Fatalf("create db: %v", err)
+	}
+	e.CurrentDB = "test"
+	for _, q := range []string{
+		// Mirror force_myisam_default.inc so the implicit engine resolves to
+		// MyISAM rather than mylite's process-default InnoDB.
+		"SET @@SESSION.default_storage_engine = MyISAM",
+		"CREATE TABLE t1 (i INT)",
+		"INSERT INTO t1 VALUES (1)",
+	} {
+		if _, err := e.Execute(q); err != nil {
+			t.Fatalf("setup %q: %v", q, err)
+		}
+	}
+	res, err := e.Execute(`EXPLAIN FORMAT=JSON SELECT i FROM t1`)
+	if err != nil {
+		t.Fatalf("EXPLAIN failed: %v", err)
+	}
+	js, _ := res.Rows[0][0].(string)
+	if !strings.Contains(js, `"access_type": "system"`) {
+		t.Errorf("t1 (MyISAM, 1 row) should be promoted to system; got:\n%s", js)
+	}
+}


### PR DESCRIPTION
## Summary

When a sole-table SELECT scans an explicitly InnoDB table that holds one
row, MySQL keeps `access_type: ALL` rather than promoting to `system`.
InnoDB row counts come from probabilistic statistics that the optimizer
does not treat as exact at compile time, so the `system` shortcut is
reserved for engines (e.g. MyISAM, MEMORY) where the row count is exact.

mylite was unconditionally promoting `ALL`->`system` whenever the sole
table happened to hold one row. With `force_myisam_default.inc` in
`other/explain_json.inc` this matches MySQL for the implicit-engine
tables, but it diverges at the EXISTS scenario at line 1297+ where the
test explicitly requests `ENGINE=InnoDB` -- MySQL emits `ALL` there and
we emitted `system`, which then dropped the t1 row's `attached_condition`
and `attached_subqueries` from the JSON, cascading subsequent diffs.

This is the next blocker on `other/explain_json_all` after #381 (the
"different scenario (small-table optimization)" the prior PR called out).

## Changes

- `executor/explain.go`: skip the `ALL`->`system` promotion when
  `Def.Engine` resolves to `InnoDB` (case-insensitive). Keep the
  promotion for every other engine -- in particular the `MYISAM` session
  default that mtrrun applies via `force_myisam_default.inc`.
- New `TestExplain_InnoDBSingleRowKeepsALL` covering the EXISTS
  pattern from `explain_json.inc` (explicit `ENGINE=InnoDB` + 1 row +
  correlated subquery), and `TestExplain_NonInnoDBSingleRowPromotesSystem`
  guarding the MyISAM-default path so we still emit `system` there.

## KPI

- `other/explain_json_all` first-diff-line **1211 -> 1224 (+13)**
- `other/explain_json_none` unchanged at 1104 (the EXISTS InnoDB query
  later in the file does not move the first-diff there; the `_none`
  variant disables semijoin/materialization which dominates earlier)
- `other` suite head-to-head with main: 105 pass / 113 fail / 32 error,
  zero per-test status regressions; only `explain_json_all` first-diff
  moved forward.

## Test plan

- [x] `go build ./...`
- [x] `go test ./... -count=1`
- [x] `go run ./cmd/mtrrun -test other/explain_json_all,other/explain_json_none -force` -- KPI improved as above
- [x] `go run ./cmd/mtrrun -suite other -j 1 -max 280 -force` head-to-head with main: zero status regressions

Refs #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)