### PR TITLE
chore(mtrrun): remove 4 stale skiplist entries (now passing)

### DIFF
--- a/cmd/mtrrun/skiplist.json
+++ b/cmd/mtrrun/skiplist.json
@@ -2345,10 +2345,6 @@
       "reason": "=== encryption suite === === large_tests suite === === binlog_nogtid suite === === innodb_undo suite === === innodb_zip suite === === gcol_ndb suite === === innodb_gis suite === === innodb_stress suite === === max_parts suite === === opt_trace suite === === auth_sec suite === === binlog suite === collations suite: partially supported via Vitess UCA 0900 weight tables Remaining failures require multi-character contraction tie-breaking === query_rewrite_plugins suite === (requires rewriter plugin)"
     },
     {
-      "test": "funcs_1/myisam_cursors",
-      "reason": "FK/SP feature gaps remaining"
-    },
-    {
       "test": "funcs_1/myisam_storedproc_02",
       "reason": "FK/SP feature gaps remaining"
     },
@@ -3173,10 +3169,6 @@
       "reason": "complex query failures"
     },
     {
-      "test": "gcol/gcol_view_myisam",
-      "reason": "view update failures"
-    },
-    {
       "test": "gcol/gcol_keys_innodb",
       "reason": "failures"
     },
@@ -3282,10 +3274,6 @@
     },
     {
       "test": "funcs_1/is_tables_myisam",
-      "reason": "failures"
-    },
-    {
-      "test": "funcs_1/myisam_bitdata",
       "reason": "failures"
     },
     {
@@ -4263,10 +4251,6 @@
     {
       "test": "funcs_1/charset_collation",
       "reason": "column order mismatch in collation result - flaky in full suite"
-    },
-    {
-      "test": "other/filter_single_col_idx_big_myisam",
-      "reason": "MyISAM force-default test with FULLTEXT, times out due to MyISAM/FULLTEXT not pursued"
     },
     {
       "test": "gis/srs",


### PR DESCRIPTION
## Summary
- Removes 4 skiplist entries for tests that now pass when un-skipped
- Verified via `go run ./cmd/mtrrun -skipped-only` per suite
- Pass count: 1801 -> 1805 (no regressions)

Removed entries:
- `funcs_1/myisam_bitdata` (was: "failures")
- `funcs_1/myisam_cursors` (was: "FK/SP feature gaps remaining")
- `gcol/gcol_view_myisam` (was: "view update failures")
- `other/filter_single_col_idx_big_myisam` (was: "MyISAM force-default test with FULLTEXT, times out due to MyISAM/FULLTEXT not pursued")

## Test plan
- [x] `go build ./...` succeeds
- [x] `go test ./... -count=1` passes
- [x] `go run ./cmd/mtrrun -test funcs_1/myisam_bitdata,funcs_1/myisam_cursors,gcol/gcol_view_myisam,other/filter_single_col_idx_big_myisam -force -skipped-only` => 4/4 pass
- [x] Full mtrrun: 1801 -> 1805 passes; 0 new failures (only `other/big_packets` shows pass->timeout, but that test passes when re-run alone in 16s vs the 20s timeout — pre-existing flakiness, not caused by this change)

Generated with [Claude Code](https://claude.com/claude-code)