### PR TITLE
chore(mtrrun): remove stale sys_vars/net_buffer_length_basic skiplist entry

### DIFF
--- a/cmd/mtrrun/skiplist.json
+++ b/cmd/mtrrun/skiplist.json
@@ -3397,10 +3397,6 @@
       "reason": "timeout"
     },
     {
-      "test": "sys_vars/net_buffer_length_basic",
-      "reason": "output mismatch or execution error"
-    },
-    {
       "test": "innodb/innodb_bug30919",
       "reason": "failures"
     },


### PR DESCRIPTION
## Summary
- Continues the suite-by-suite stale skiplist scan from #383 (interrupted suites: perfschema, sys_vars, x).
- Scanned perfschema (159), sys_vars (102), x (222), opt_trace, sysschema, gcol, gis, parts, secondary_engine, binlog, auth_sec, collations, query_rewrite_plugins, innodb_stress, innodb_fts, innodb_gis, innodb_zip, innodb_undo, max_parts, binlog_gtid, binlog_nogtid, stress, json, funcs_1, innodb, other.
- Found exactly one stale entry: `sys_vars/net_buffer_length_basic`.

## Verification
- Verified pass with `go run ./cmd/mtrrun -test sys_vars/net_buffer_length_basic -skipped-only -force` 3 consecutive times (no flake).
- After removal, `go run ./cmd/mtrrun -test sys_vars/net_buffer_length_basic -force` passes.
- Full sys_vars suite: 509 passed / 0 failed / 141 skipped (no regressions).
- `go build ./...` and `go test ./... -count=1` clean.

## Test plan
- [x] Test passes individually after removal
- [x] Full sys_vars suite has 0 failures
- [x] `go test ./... -count=1` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)