### PR TITLE
fix(executor): tolerate extra whitespace in fallback prefix-match

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -1149,6 +1149,33 @@ func (e *Executor) parser() *sqlparser.Parser {
 	return e.sqlParser
 }
 
+// collapseUpperWhitespace collapses runs of ASCII whitespace (space, tab,
+// newline, carriage return) into a single space. Used on the UPPER-cased
+// query so that prefix-based fallbacks tolerate "ALTER  USER" (multiple
+// spaces) the same as "ALTER USER". MySQL is tokenized at whitespace, so
+// arbitrary whitespace between keywords is semantically identical.
+func collapseUpperWhitespace(s string) string {
+	if !strings.ContainsAny(s, "\t\n\r") && !strings.Contains(s, "  ") {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s))
+	prevWS := false
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c == ' ' || c == '\t' || c == '\n' || c == '\r' {
+			if !prevWS {
+				b.WriteByte(' ')
+				prevWS = true
+			}
+			continue
+		}
+		b.WriteByte(c)
+		prevWS = false
+	}
+	return b.String()
+}
+
 func New(cat *catalog.Catalog, store *storage.Engine) *Executor {
 	// MySQL test suite (MTR) defaults to timezone GMT-3 (= UTC+3).
 	// We mirror this so SET TIMESTAMP + CURRENT_TIME() match expected results.
@@ -2084,6 +2111,11 @@ func (e *Executor) Execute(query string) (res *Result, retErr error) {
 
 	stmt, err := e.parser().Parse(query)
 	if err != nil {
+		// Normalize whitespace runs inside `upper` so that statements with extra
+		// whitespace (e.g. "ALTER  USER ...") still match prefix-based fallbacks.
+		// MySQL accepts arbitrary whitespace between keywords, so the prefix-match
+		// table below should be tolerant of repeated spaces/tabs/newlines.
+		upper = collapseUpperWhitespace(upper)
 		// Accept statements that Vitess parser doesn't support
 		if strings.HasPrefix(upper, "EXPLAIN ") || strings.HasPrefix(upper, "DESC ") || strings.HasPrefix(upper, "DESCRIBE ") {
 			explainType := sqlparser.TraditionalType

--- a/executor/whitespace_prefix_test.go
+++ b/executor/whitespace_prefix_test.go
@@ -1,0 +1,78 @@
+package executor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/myuon/mylite/catalog"
+	"github.com/myuon/mylite/storage"
+)
+
+func TestCollapseUpperWhitespace(t *testing.T) {
+	tests := []struct {
+		in, want string
+	}{
+		{"ALTER USER foo", "ALTER USER foo"},
+		{"ALTER  USER foo", "ALTER USER foo"},
+		{"ALTER\tUSER foo", "ALTER USER foo"},
+		{"ALTER\nUSER foo", "ALTER USER foo"},
+		{"ALTER \t\nUSER foo", "ALTER USER foo"},
+		{"FLUSH PRIVILEGES", "FLUSH PRIVILEGES"},
+		{"", ""},
+	}
+	for _, tc := range tests {
+		got := collapseUpperWhitespace(tc.in)
+		if got != tc.want {
+			t.Errorf("collapseUpperWhitespace(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// TestAlterUserDoubleSpace verifies that ALTER USER with multiple internal
+// spaces (which Vitess parser doesn't accept) is still recognized by the
+// fallback prefix-match path and treated as a no-op.
+func TestAlterUserDoubleSpace(t *testing.T) {
+	cat := catalog.New()
+	stor := storage.NewEngine()
+	exec := New(cat, stor)
+
+	// First create the user (this should work without issue).
+	if _, err := exec.Execute("CREATE USER test_user_dbl IDENTIFIED BY 'pwd'"); err != nil {
+		t.Fatalf("CREATE USER failed: %v", err)
+	}
+
+	// Single-space variant should succeed (baseline).
+	if _, err := exec.Execute("ALTER USER test_user_dbl IDENTIFIED BY 'newpwd'"); err != nil {
+		t.Fatalf("ALTER USER (single space) failed: %v", err)
+	}
+
+	// Double-space variant should also succeed via the fallback prefix-match.
+	if _, err := exec.Execute("ALTER  USER test_user_dbl IDENTIFIED BY 'newerpwd'"); err != nil {
+		t.Fatalf("ALTER  USER (double space) failed: %v", err)
+	}
+
+	// Tab and newline variants should also succeed.
+	if _, err := exec.Execute("ALTER\tUSER test_user_dbl IDENTIFIED BY 'tabpwd'"); err != nil {
+		t.Fatalf("ALTER\\tUSER failed: %v", err)
+	}
+	if _, err := exec.Execute("ALTER\nUSER test_user_dbl IDENTIFIED BY 'nlpwd'"); err != nil {
+		t.Fatalf("ALTER\\nUSER failed: %v", err)
+	}
+}
+
+// TestCollapsePerformance verifies the fast path works (no allocation when
+// the input has no extra whitespace runs).
+func TestCollapseUpperWhitespaceFastPath(t *testing.T) {
+	// Strings with no double-space and no tab/newline should not allocate
+	// (returned unchanged). This is checked by reference equality on the
+	// underlying data via strings.Builder behavior; we approximate by length.
+	in := "SELECT * FROM t WHERE a = 1"
+	out := collapseUpperWhitespace(in)
+	if out != in || len(out) != len(in) {
+		t.Errorf("expected fast-path passthrough; got %q -> %q", in, out)
+	}
+	// Sanity: no leading/trailing spaces collapsed (caller's responsibility).
+	if strings.HasPrefix(out, " ") || strings.HasSuffix(out, " ") {
+		t.Errorf("unexpected leading/trailing whitespace in %q", out)
+	}
+}


### PR DESCRIPTION
## Summary
- The Vitess parser doesn't accept some valid MySQL constructs (HELP, ALTER USER, LOAD INDEX, etc.). When parsing fails, the executor falls back to a prefix-match table that decides how to handle them. The table compared against the raw upper-cased query, so `ALTER  USER` (with double space) — accepted by MySQL — failed to match and surfaced ER_PARSE_ERROR.
- Collapse runs of whitespace in `upper` once on entry to the parser-failure fallback so the prefix table tolerates arbitrary whitespace between keywords, matching how real MySQL tokenizes the input. The active query string handed to downstream extractors is left unchanged.
- Unblocks `other/rewrite_general_log` past line 83 (`ALTER  USER ...`) and removes ER_PARSE_ERROR from `other/opt_hints_join_order` and `other/opt_hints_join_order_myisam` (those tests now FAIL on a different cause, which is progress).

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./...` passes (no regressions in unit tests)
- [x] New unit tests `TestCollapseUpperWhitespace`, `TestCollapseUpperWhitespaceFastPath`, `TestAlterUserDoubleSpace` cover the helper and the end-to-end ALTER USER path
- [x] Full mtrrun shows ERROR count 125 -> 123 with no PASS regressions; two timeouts on `other/func_str` and `other/filter_single_col_idx_big_myisam` are flaky tests (~16-19s elapsed previously, hitting the 20s deadline under concurrent load) and unrelated to this change (string functions and MyISAM index tests don't go through the parser-failure fallback)

🤖 Generated with [Claude Code](https://claude.com/claude-code)