### PR TITLE
fix(schema): emit prefix length in SUB_PART; block RENAME under FTWRL

### DIFF
--- a/executor/ddl.go
+++ b/executor/ddl.go
@@ -234,6 +234,13 @@ func (e *Executor) isLogTableLoggingEnabled(tableName string) bool {
 }
 
 func (e *Executor) execRenameTable(stmt *sqlparser.RenameTable) (*Result, error) {
+	// MySQL: RENAME TABLE is blocked while another connection holds
+	// FLUSH TABLES WITH READ LOCK (FTWRL). Wait until the lock is released.
+	if e.globalReadLock != nil {
+		if err := e.globalReadLock.WaitIfHeldByOther(e.connectionID, 31536000); err != nil {
+			return nil, err
+		}
+	}
 	// RENAME TABLE is atomic: validate all pairs before executing any rename.
 	// We simulate the rename chain to validate that each source exists and each
 	// target doesn't conflict, accounting for intermediate renames.

--- a/executor/information_schema.go
+++ b/executor/information_schema.go
@@ -46,6 +46,25 @@ func normalizeIndexColumnName(col string) string {
 	return strings.TrimSpace(col)
 }
 
+// indexColumnPrefixLen extracts the prefix length from an index column
+// specification like "a(3)". Returns 0 if no explicit prefix length is set.
+func indexColumnPrefixLen(col string) int64 {
+	open := strings.Index(col, "(")
+	if open < 0 {
+		return 0
+	}
+	close := strings.Index(col[open:], ")")
+	if close < 0 {
+		return 0
+	}
+	inner := strings.TrimSpace(col[open+1 : open+close])
+	n, err := strconv.ParseInt(inner, 10, 64)
+	if err != nil || n <= 0 {
+		return 0
+	}
+	return n
+}
+
 func (e *Executor) informationSchemaStatsExpiryZero() bool {
 	v, ok := e.getSysVar("information_schema_stats_expiry")
 	if !ok {
@@ -3323,10 +3342,13 @@ func (e *Executor) infoSchemaStatistics() []storage.Row {
 					if (tblEngine == "MEMORY" || tblEngine == "HEAP") && indexTypeStr == "BTREE" {
 						cardinality = nil
 					}
-					// SPATIAL indexes use a 32-byte MBR key prefix
+					// SPATIAL indexes use a 32-byte MBR key prefix.
+					// Other indexes may have an explicit prefix length declared as col(N).
 					var subPart interface{}
 					if idxType == "SPATIAL" {
 						subPart = int64(32)
+					} else if pl := indexColumnPrefixLen(col); pl > 0 {
+						subPart = pl
 					}
 					rows = append(rows, storage.Row{
 						"TABLE_CATALOG": "def",


### PR DESCRIPTION
## Summary

Two small, orthogonal correctness fixes that move several MTR tests forward without flipping any to fail.

- **I_S.STATISTICS / SHOW INDEX `Sub_part`**: when an index column is declared with a prefix length (e.g. `KEY key_a (a(3))`), report the prefix length in `Sub_part` instead of `NULL`. SPATIAL indexes still report 32 as before. This matches the MySQL reference behavior described in [INFORMATION_SCHEMA.STATISTICS](https://dev.mysql.com/doc/refman/8.0/en/information-schema-statistics-table.html).
- **RENAME TABLE waits for FTWRL**: `RENAME TABLE` now calls `globalReadLock.WaitIfHeldByOther` before validating the rename, mirroring the wait already done by COMMIT. Without this, a `RENAME` issued from connection A would silently succeed even while connection B held `FLUSH TABLES WITH READ LOCK`, breaking `other/rename`'s multi-connection scenario.

## Test plan

- [x] `go build ./...`
- [x] `go test ./... -count=1` — all unit tests pass
- [x] `go run ./cmd/mtrrun` — pass count unchanged at 1806 (no regressions)
- [x] `other/rename` first-diff-line advances from line 47 -> line 106 in isolation (the multi-connection RENAME-under-FTWRL block now works; remaining diffs are unrelated lock-wait-timeout semantics)
- [x] `other/ctype_mb` line 35+ Sub_part diffs are eliminated (test still fails on an earlier unrelated string-truncation issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)