### PR TITLE
feat(sys_vars): add MySQL 8.0 replica_*/log_replica_updates/source_* aliases

### DIFF
--- a/executor/variables.go
+++ b/executor/variables.go
@@ -2270,6 +2270,21 @@ var sysVarGlobalOnly = map[string]bool{
 	"temptable_use_mmap":                       true,
 	"partial_revokes":                          true,
 	"innodb_default_row_format":                true,
+	// Replication: replica_* / log_replica_updates / source_verify_checksum aliases (MySQL 8.0)
+	"log_replica_updates":           true,
+	"log_slave_updates":             true,
+	"replica_allow_batching":        true,
+	"replica_compressed_protocol":   true,
+	"replica_exec_mode":             true,
+	"replica_load_tmpdir":           true,
+	"replica_max_allowed_packet":    true,
+	"replica_pending_jobs_size_max": true,
+	"replica_preserve_commit_order": true,
+	"replica_sql_verify_checksum":   true,
+	"replica_transaction_retries":   true,
+	"rpl_stop_replica_timeout":      true,
+	"slave_load_tmpdir":             true,
+	"source_verify_checksum":        true,
 }
 
 // sysVarEnumSet contains system variables that are ENUM types where ON/OFF
@@ -4472,6 +4487,23 @@ func (e *Executor) buildVariablesMapScoped(globalOnly bool) map[string]string {
 		"slave_sql_verify_checksum":              "ON",
 		"slave_transaction_retries":              "10",
 		"slave_type_conversions":                 "",
+		"slave_load_tmpdir":                      "/tmp",
+
+		// Replication: replica_* / source_* / log_replica_updates aliases
+		// (MySQL 8.0 introduced replica_* names alongside slave_*)
+		"log_replica_updates":          "ON",
+		"log_slave_updates":            "ON",
+		"replica_allow_batching":       "OFF",
+		"replica_compressed_protocol":  "OFF",
+		"replica_exec_mode":            "STRICT",
+		"replica_load_tmpdir":          "/tmp",
+		"replica_max_allowed_packet":   "1073741824",
+		"replica_pending_jobs_size_max": "134217728",
+		"replica_preserve_commit_order": "ON",
+		"replica_sql_verify_checksum":  "ON",
+		"replica_transaction_retries":  "10",
+		"rpl_stop_replica_timeout":     "31536000",
+		"source_verify_checksum":       "OFF",
 		"slow_launch_time":                       "2",
 		"sql_log_off":                            "OFF",
 		"sql_slave_skip_counter":                 "0",

--- a/mtrrunner/runner.go
+++ b/mtrrunner/runner.go
@@ -225,6 +225,7 @@ func (r *Runner) RunFile(testPath string) TestResult {
 			return map[string]string{
 				"$ENGINE":             "InnoDB",
 				"$MYSQLTEST_VARDIR":   tmpDir,
+				"$MYSQLTEST_FILE":     testPath,
 				"$MYSQL_TMP_DIR":      filepath.Join(tmpDir, "tmp"),
 				"$MYSQL_TEST_DIR":     tmpDir,
 				"$MYSQLD_DATADIR":     filepath.Join(tmpDir, "data", "inner") + "/",


### PR DESCRIPTION
## Summary
- Add 14 missing replication/binlog system variables (replica_*, log_replica_updates, log_slave_updates, source_verify_checksum, slave_load_tmpdir, rpl_stop_replica_timeout) so they appear in SHOW GLOBAL VARIABLES and information_schema.global_variables with sane MySQL 8.0 defaults
- Mark the new vars as global-only via sysVarGlobalOnly so SET semantics match the slave_*/master_* counterparts
- Pass MYSQLTEST_FILE env var to mtrrunner perl blocks; sys_vars/all_vars.test uses dirname(\$ENV{MYSQLTEST_FILE}) to find the directory of *_basic.test files. Without this the perl block silently fails to produce the temp file and \"load data infile\" errors out

## Notes
- Partial implementation of #391 (~14 of ~30 listed; the rest were already present in our system_variables map; the full sys_vars/all_vars test still does not pass because of unrelated missing vars listed in #268)
- No regressions in full mtrrun; the only delta is one flaky timeout in other/filter_single_col_idx_big_myisam (passes when re-run alone)

## Test plan
- [x] go build ./... passes
- [x] go test ./... -count=1 passes
- [x] go run ./cmd/mtrrun -test sys_vars/all_vars -force -skipped-only runs (still fails diff, but no longer errors on missing temp file)
- [x] go run ./cmd/mtrrun -suite sys_vars -j 1 -force: 512 pass / 0 fail before and after
- [x] Full mtrrun: 1810 pass after vs 1811 pass before (1 flaky timeout, not a real regression)

Refs #391

🤖 Generated with [Claude Code](https://claude.com/claude-code)