### PR TITLE
feat(sys_vars): add misc server GLOBAL variables (plugin/keyring/auth/protocol)

### DIFF
--- a/executor/variables.go
+++ b/executor/variables.go
@@ -2285,6 +2285,23 @@ var sysVarGlobalOnly = map[string]bool{
 	"rpl_stop_replica_timeout":      true,
 	"slave_load_tmpdir":             true,
 	"source_verify_checksum":        true,
+	// Misc server vars (issue #393): plugin loading, keyring, protocol, auth, group replication
+	"plugin_load":                         true,
+	"plugin_load_add":                     true,
+	"keyring_operations":                  true,
+	"protocol_compression_algorithms":     true,
+	"xa_detach_on_prepare":                true,
+	"activate_all_roles_on_login":         true,
+	"group_replication_consistency":       true,
+	"mandatory_roles":                     true,
+	"sql_require_primary_key":             true,
+	"caching_sha2_password_digest_rounds": true,
+	"authentication_policy":               true,
+	"binlog_expire_logs_auto_purge":       true,
+	"terminology_use_previous":            true,
+	"init_replica":                        true,
+	"ssl_session_cache_mode":              true,
+	"ssl_session_cache_timeout":           true,
 }
 
 // sysVarEnumSet contains system variables that are ENUM types where ON/OFF
@@ -2925,6 +2942,7 @@ var sysVarSessionOnly = map[string]bool{
 	"immediate_server_version":   true,
 	"timestamp":                  true,
 	"rbr_exec_mode":              true,
+	"resultset_metadata":         true,
 }
 
 // sysVarBothScope contains system variables that exist at both SESSION and GLOBAL scope.
@@ -4504,6 +4522,26 @@ func (e *Executor) buildVariablesMapScoped(globalOnly bool) map[string]string {
 		"replica_transaction_retries":  "10",
 		"rpl_stop_replica_timeout":     "31536000",
 		"source_verify_checksum":       "OFF",
+
+		// Misc server vars (issue #393): plugin loading, keyring, protocol, auth, group replication
+		"plugin_load":                         "",
+		"plugin_load_add":                     "",
+		"keyring_operations":                  "ON",
+		"protocol_compression_algorithms":     "zlib,zstd,uncompressed",
+		"xa_detach_on_prepare":                "ON",
+		"activate_all_roles_on_login":         "OFF",
+		"group_replication_consistency":       "EVENTUAL",
+		"mandatory_roles":                     "",
+		"sql_require_primary_key":             "OFF",
+		"caching_sha2_password_digest_rounds": "5000",
+		"authentication_policy":               "*,,",
+		"binlog_expire_logs_auto_purge":       "ON",
+		"terminology_use_previous":            "NONE",
+		"init_replica":                        "",
+		"ssl_session_cache_mode":              "ON",
+		"ssl_session_cache_timeout":           "300",
+		"resultset_metadata":                  "FULL",
+
 		"slow_launch_time":                       "2",
 		"sql_log_off":                            "OFF",
 		"sql_slave_skip_counter":                 "0",


### PR DESCRIPTION
## Summary
- Add 17 missing MySQL 8.0 misc server system variables to `executor/variables.go` so they appear in `SHOW GLOBAL VARIABLES` and `information_schema.global_variables` with sane defaults
- 16 variables are marked GLOBAL-only via `sysVarGlobalOnly`; `resultset_metadata` is SESSION-only
- Closes the gap from the issue's listed vars (plugin_load, plugin_load_add, keyring_operations, protocol_compression_algorithms, xa_detach_on_prepare were missing) plus several more related misc server vars surfaced by `sys_vars/all_vars` (activate_all_roles_on_login, group_replication_consistency, mandatory_roles, sql_require_primary_key, etc.)

## Vars added
GLOBAL-only (16): plugin_load, plugin_load_add, keyring_operations, protocol_compression_algorithms, xa_detach_on_prepare, activate_all_roles_on_login, group_replication_consistency, mandatory_roles, sql_require_primary_key, caching_sha2_password_digest_rounds, authentication_policy, binlog_expire_logs_auto_purge, terminology_use_previous, init_replica, ssl_session_cache_mode, ssl_session_cache_timeout

SESSION-only (1): resultset_metadata

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./... -count=1` passes
- [x] `go run ./cmd/mtrrun -test sys_vars/all_vars -force -skipped-only` runs (still fails diff because the dolt test fixture lacks `*_basic.test` files for many of our vars; first-diff-line unchanged because diff truncates at first 20 mismatches and our extras sort before the new vars)
- [x] `go run ./cmd/mtrrun -suite sys_vars -j 1 -force`: 512 pass / 0 fail (matches main baseline)

Closes #393

🤖 Generated with [Claude Code](https://claude.com/claude-code)