### PR TITLE
feat(explain): promote EXISTS body inner tables ALL → ref via JOIN ON equi-join (Closes #406)

### DIFF
--- a/executor/exists_ref_promote_test.go
+++ b/executor/exists_ref_promote_test.go
@@ -1,0 +1,74 @@
+package executor
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/myuon/mylite/catalog"
+	"github.com/myuon/mylite/storage"
+)
+
+// TestExistsBodyRefPromote covers issue #406: when an EXISTS body's inner
+// table can be probed via a key prefix match driven by an equi-join condition
+// in the body's JOIN ON clause, MySQL promotes that inner table from ALL → ref
+// access.  Previously mylite kept the table at ALL because explainDetectAccessType
+// only inspected the inner SELECT's WHERE clause and ignored its JOIN ON
+// equi-join conditions.
+func TestExistsBodyRefPromote(t *testing.T) {
+	cat := catalog.New()
+	store := storage.NewEngine()
+	e := New(cat, store)
+
+	if _, err := e.Execute("CREATE DATABASE IF NOT EXISTS test"); err != nil {
+		t.Fatalf("create db: %v", err)
+	}
+	e.CurrentDB = "test"
+
+	stmts := []string{
+		`CREATE TABLE t1 (i1 INTEGER NOT NULL, c1 VARCHAR(1) NOT NULL) charset latin1 ENGINE=InnoDB`,
+		`INSERT INTO t1 VALUES (2,'w')`,
+		`CREATE TABLE t2 (i1 INTEGER NOT NULL, c1 VARCHAR(1) NOT NULL, c2 VARCHAR(1) NOT NULL, KEY (c1, i1)) charset latin1 ENGINE=InnoDB`,
+		`INSERT INTO t2 VALUES (8,'d','d')`,
+		`INSERT INTO t2 VALUES (4,'v','v')`,
+		`CREATE TABLE t3 (c1 VARCHAR(1) NOT NULL) charset latin1 ENGINE=InnoDB`,
+		`INSERT INTO t3 VALUES ('v')`,
+	}
+	for _, s := range stmts {
+		if _, err := e.Execute(s); err != nil {
+			t.Fatalf("setup %q: %v", s, err)
+		}
+	}
+
+	res, err := e.Execute(`EXPLAIN SELECT i1 FROM t1 WHERE EXISTS (SELECT t2.c1 FROM (t2 INNER JOIN t3 ON (t3.c1 = t2.c1)) WHERE t2.c2 != t1.c1 AND t2.c2 = (SELECT MIN(t3.c1) FROM t3))`)
+	if err != nil {
+		t.Fatalf("EXPLAIN failed: %v", err)
+	}
+
+	// Find the t2 row at id=1.  It should be promoted to ref/c1 with the join
+	// driven by test.t3.c1.
+	found := false
+	for _, row := range res.Rows {
+		if len(row) < 9 {
+			continue
+		}
+		if fmt.Sprintf("%v", row[2]) != "t2" {
+			continue
+		}
+		found = true
+		if got, want := fmt.Sprintf("%v", row[4]), "ref"; got != want {
+			t.Errorf("t2 access_type: got %q, want %q", got, want)
+		}
+		if got, want := fmt.Sprintf("%v", row[5]), "c1"; got != want {
+			t.Errorf("t2 possible_keys: got %q, want %q", got, want)
+		}
+		if got, want := fmt.Sprintf("%v", row[6]), "c1"; got != want {
+			t.Errorf("t2 key: got %q, want %q", got, want)
+		}
+		if got, want := fmt.Sprintf("%v", row[8]), "test.t3.c1"; got != want {
+			t.Errorf("t2 ref: got %q, want %q", got, want)
+		}
+	}
+	if !found {
+		t.Fatalf("no row for t2 in EXPLAIN result; rows=%v", res.Rows)
+	}
+}

--- a/executor/explain.go
+++ b/executor/explain.go
@@ -7792,6 +7792,96 @@ func (e *Executor) explainDetectAccessType(sel *sqlparser.Select, tableName stri
 		whereCols = append(whereCols, gcolConditions...)
 	}
 
+	// Augment with JOIN ON equi-join conditions: for tableName, an ON clause like
+	// `tA.colA = tB.colB` (where one side is a column of tableName and the other
+	// is a column of a sibling FROM-table) becomes an equality condition on the
+	// tableName side.  This lets EXISTS / semijoin body inner tables get promoted
+	// from ALL → ref when the join column matches the leading column of an index
+	// (issue #406).  joinRefByCol maps lower-cased tableName column →
+	// "<db>.<otherTable>.<otherCol>" so the resulting ref output points to the
+	// driving table rather than the default "const".
+	joinRefByCol := map[string]string{}
+	if len(sel.From) > 0 {
+		var onNodes []sqlparser.SQLNode
+		for _, te := range sel.From {
+			e.collectJoinOnConditions(te, &onNodes)
+		}
+		// Collect all FROM-table real names so we can recognise "other tables".
+		// We only add an equi-join entry when the *other* side is a column of a
+		// sibling FROM-table (not an outer-correlated column or a literal), to
+		// match MySQL's ref classification.
+		fromTables := map[string]bool{}
+		for _, te := range sel.From {
+			for _, tn := range e.extractAllTableNames(te) {
+				if !strings.EqualFold(tn, "dual") {
+					fromTables[strings.ToLower(tn)] = true
+				}
+			}
+		}
+		dbName := e.CurrentDB
+		if dbName == "" {
+			dbName = "test"
+		}
+		var visit func(expr sqlparser.Expr)
+		visit = func(expr sqlparser.Expr) {
+			if expr == nil {
+				return
+			}
+			switch ex := expr.(type) {
+			case *sqlparser.AndExpr:
+				visit(ex.Left)
+				visit(ex.Right)
+			case *sqlparser.ComparisonExpr:
+				if ex.Operator != sqlparser.EqualOp && ex.Operator != sqlparser.NullSafeEqualOp {
+					return
+				}
+				lcol, lok := ex.Left.(*sqlparser.ColName)
+				rcol, rok := ex.Right.(*sqlparser.ColName)
+				if !lok || !rok {
+					return
+				}
+				lqual := lcol.Qualifier.Name.String()
+				rqual := rcol.Qualifier.Name.String()
+				if lqual == "" || rqual == "" {
+					return
+				}
+				// Only consider equi-joins where both sides reference a sibling
+				// FROM-table — otherwise this is an outer-correlation predicate.
+				if !fromTables[strings.ToLower(lqual)] || !fromTables[strings.ToLower(rqual)] {
+					return
+				}
+				if strings.EqualFold(lqual, tableName) && !strings.EqualFold(rqual, tableName) {
+					col := strings.ToLower(lcol.Name.String())
+					if _, exists := joinRefByCol[col]; !exists {
+						joinRefByCol[col] = fmt.Sprintf("%s.%s.%s", dbName, rqual, rcol.Name.String())
+					}
+				} else if strings.EqualFold(rqual, tableName) && !strings.EqualFold(lqual, tableName) {
+					col := strings.ToLower(rcol.Name.String())
+					if _, exists := joinRefByCol[col]; !exists {
+						joinRefByCol[col] = fmt.Sprintf("%s.%s.%s", dbName, lqual, lcol.Name.String())
+					}
+				}
+			}
+		}
+		for _, n := range onNodes {
+			if expr, ok := n.(sqlparser.Expr); ok {
+				visit(expr)
+			}
+		}
+		// Inject as equality whereCols (only for columns not already in whereCols).
+		existingEq := map[string]bool{}
+		for _, wc := range whereCols {
+			if wc.isEquality {
+				existingEq[strings.ToLower(wc.column)] = true
+			}
+		}
+		for col := range joinRefByCol {
+			if !existingEq[col] {
+				whereCols = append(whereCols, explainWhereCondition{column: col, isEquality: true})
+			}
+		}
+	}
+
 	if len(whereCols) == 0 {
 		// No WHERE conditions: check if all selected columns are covered by a secondary index
 		// → "index" access type (full index scan) + "Using index".
@@ -8034,13 +8124,24 @@ func (e *Executor) explainDetectAccessType(sel *sqlparser.Select, tableName stri
 			break
 		}
 	}
+	// buildRef constructs the ref string for the matched index columns.
+	// For each matched column, prefer the join-driven ref when the equality
+	// originates from an equi-join ON condition; fall back to "const" otherwise.
+	buildRef := func() string {
+		refs := make([]string, best.matchedEq)
+		for i := 0; i < best.matchedEq && i < len(best.index.Columns); i++ {
+			col := strings.ToLower(best.index.Columns[i])
+			if r, ok := joinRefByCol[col]; ok {
+				refs[i] = r
+			} else {
+				refs[i] = "const"
+			}
+		}
+		return strings.Join(refs, ",")
+	}
 	if best.matchedEq > 0 && hasNullCondition && hasNonNullEqOnIndex {
 		result.accessType = "ref_or_null"
-		refs := make([]string, best.matchedEq)
-		for i := range refs {
-			refs[i] = "const"
-		}
-		result.ref = strings.Join(refs, ",")
+		result.ref = buildRef()
 	} else if best.matchedAll && best.index.Unique && !hasNullCondition {
 		if best.isPrimary || !isJoin {
 			// Use "const" for PK lookups or unique index lookups in standalone queries
@@ -8050,18 +8151,10 @@ func (e *Executor) explainDetectAccessType(sel *sqlparser.Select, tableName stri
 			result.accessType = "eq_ref"
 		}
 		// Build ref string
-		refs := make([]string, best.matchedEq)
-		for i := range refs {
-			refs[i] = "const"
-		}
-		result.ref = strings.Join(refs, ",")
+		result.ref = buildRef()
 	} else if best.matchedEq > 0 {
 		result.accessType = "ref"
-		refs := make([]string, best.matchedEq)
-		for i := range refs {
-			refs[i] = "const"
-		}
-		result.ref = strings.Join(refs, ",")
+		result.ref = buildRef()
 	} else if best.hasRange {
 		result.accessType = "range"
 	}


### PR DESCRIPTION
## Summary
- When an EXISTS / semijoin body's FROM clause uses an explicit JOIN with an equi-join ON condition (`tA.colA = tB.colB`) and the inner table has a secondary index whose leading column matches that join column, MySQL promotes the inner table from ALL → ref. mylite previously kept it at ALL because `explainDetectAccessType` only inspected `sel.Where` and ignored JOIN ON conditions.
- `explainDetectAccessType` now walks the SELECT's JOIN ON conditions in addition to its WHERE, builds a column → "<db>.<otherTable>.<otherCol>" map for each equi-join between sibling FROM tables, injects matching equality entries into `whereCols`, and uses the recorded mapping to emit `ref` as the driving column rather than the default `"const"`.

## Verification
- `go build ./...`
- `go test ./... -count=1`
- `go run ./cmd/mtrrun -test other/explain_format_json,other/explain_json_all,other/explain_json_none,other/subquery_sj_all,other/subquery_sj_mat -force` (no regressions; t2 in the issue's EXISTS query is now correctly classified as `ref c1` driven by `test.t3.c1`)
- Suite `other` head-to-head with main (`-suite other -j 1 -max 280`):
  - baseline: 106 passed, 113 failed, 32 errors
  - this PR:  106 passed, 113 failed, 32 errors  (zero pass→fail regressions per-test diff)

## KPI delta
First-diff-line on the targeted JSON tests is unchanged because the earlier divergence (table-reorder, issue #402) shows up first in the output. The fix improves the *post*-first-diff content (correct `ref`/`key`/`ref-source` for the inner table). The new unit test `TestExistsBodyRefPromote` locks in the promotion for the canonical EXISTS query.

## Test plan
- [x] `go build ./...`
- [x] `go test ./... -count=1`
- [x] `go run ./cmd/mtrrun -test other/explain_format_json,other/explain_json_all,other/explain_json_none,other/subquery_sj_all,other/subquery_sj_mat -force`
- [x] Head-to-head full `other` suite (max 280): identical pass/fail set

Closes #406

🤖 Generated with [Claude Code](https://claude.com/claude-code)