### PR TITLE
feat(explain): reorder EXISTS body tables by key access

### DIFF
--- a/executor/explain.go
+++ b/executor/explain.go
@@ -6632,6 +6632,33 @@ func (e *Executor) walkForSubqueries(node sqlparser.SQLNode, idCounter *int64, r
 								}
 							}
 						}
+						// Issue #403: MySQL's optimizer reorders the EXISTS body's
+						// FROM tables so the table accessed via key lookup (ref /
+						// eq_ref) becomes the inner of the join — i.e. it appears
+						// AFTER the driver in the EXPLAIN output.  Without this
+						// reorder, mylite emits tables in textual order, which can
+						// place a `ref`-access table before its driving (`ALL`-scan)
+						// table.  Move ALL-access tables to the front and ref/eq_ref
+						// tables to the back, preserving relative order within each
+						// group (stable partition).  Only applies for plain EXISTS
+						// (NOT EXISTS antijoin keeps textual order).
+						if !existsNegated && len(innerFromTables) > 1 {
+							var drivers, probes []string
+							for _, tn := range innerFromTables {
+								ai := e.explainDetectAccessType(inner, tn)
+								switch ai.accessType {
+								case "ref", "eq_ref", "ref_or_null":
+									probes = append(probes, tn)
+								default:
+									drivers = append(drivers, tn)
+								}
+							}
+							// Only reorder when both groups are non-empty (otherwise
+							// the order is unchanged anyway).
+							if len(drivers) > 0 && len(probes) > 0 {
+								innerFromTables = append(drivers, probes...)
+							}
+						}
 						for idx, tblName := range innerFromTables {
 							var rowCount int64 = 1
 							if e.Storage != nil {
@@ -10936,6 +10963,67 @@ func (e *Executor) explainJSONExistsBodyDecorrelate(query string, outerTblName s
 	}
 }
 
+// explainJSONExistsBodyDriverName returns the table name of the EXISTS body's
+// "driver" — the inner table that scans first in the body's nested loop —
+// when the outer query's WHERE contains an EXISTS whose body has 2+ FROM
+// tables. The driver is the inner table whose detected access type is NOT
+// `ref`/`eq_ref`/`ref_or_null` (i.e. an ALL-scan or other non-keyed access).
+//
+// Returns "" when no such EXISTS body exists or the driver cannot be
+// determined unambiguously.  Used by the EXPLAIN FORMAT=JSON nested_loop
+// builder to suppress `using_join_buffer: Block Nested Loop` on the EXISTS
+// body driver (issue #403): MySQL does not annotate a sub-chain's own
+// driver with BNL even when the table is accessed via ALL.
+func (e *Executor) explainJSONExistsBodyDriverName(query string) string {
+	stmt, err := e.parser().Parse(query)
+	if err != nil {
+		return ""
+	}
+	sel, ok := stmt.(*sqlparser.Select)
+	if !ok || sel.Where == nil {
+		return ""
+	}
+	driverName := ""
+	_ = sqlparser.Walk(func(n sqlparser.SQLNode) (bool, error) {
+		ex, ok := n.(*sqlparser.ExistsExpr)
+		if !ok {
+			return true, nil
+		}
+		// Skip negated EXISTS — antijoin keeps textual order.
+		if isExistsExprNegated(sel.Where, ex) {
+			return true, nil
+		}
+		inner, ok := ex.Subquery.Select.(*sqlparser.Select)
+		if !ok {
+			return true, nil
+		}
+		var innerTbls []string
+		for _, te := range inner.From {
+			for _, tn := range e.extractAllTableNames(te) {
+				if !strings.EqualFold(tn, "dual") {
+					innerTbls = append(innerTbls, tn)
+				}
+			}
+		}
+		if len(innerTbls) < 2 {
+			return true, nil
+		}
+		// Identify the driver: first table whose access is NOT ref/eq_ref.
+		for _, tn := range innerTbls {
+			ai := e.explainDetectAccessType(inner, tn)
+			switch ai.accessType {
+			case "ref", "eq_ref", "ref_or_null":
+				continue
+			default:
+				driverName = tn
+				return false, nil
+			}
+		}
+		return false, nil
+	}, sel.Where)
+	return driverName
+}
+
 // explainJSONFormatExprQualifiedWithDefault is like
 // explainJSONFormatExprQualified but uses defaultTbl when a column has no
 // explicit qualifier.  This is used to format outer-side predicates
@@ -13440,6 +13528,12 @@ func (e *Executor) explainJSONDocument(query string) string {
 						firstTableName = fmt.Sprintf("%v", primaryRows[0].row[2])
 					}
 					conds := semijoinAttachedConditions()
+					// Issue #403: detect the EXISTS body driver. When the outer
+					// WHERE has an EXISTS whose body has ≥2 FROM tables, MySQL
+					// treats the body's driver as a nested-chain driver and does
+					// NOT add `using_join_buffer: Block Nested Loop` to it (even
+					// though it appears at primaryRows[1] in the flattened plan).
+					existsBodyDriverName := e.explainJSONExistsBodyDriverName(query)
 					// Issue #404: only the LAST semijoin inner table gets first_match.
 					lastIdx := len(primaryRows) - 1
 					for i, pr := range primaryRows[1:] {
@@ -13448,6 +13542,27 @@ func (e *Executor) explainJSONDocument(query string) string {
 						accessType := ""
 						if pr.row[4] != nil {
 							accessType = fmt.Sprintf("%v", pr.row[4])
+						}
+						tblNameStr := ""
+						if pr.row[2] != nil {
+							tblNameStr = fmt.Sprintf("%v", pr.row[2])
+						}
+						isExistsBodyDriver := existsBodyDriverName != "" && strings.EqualFold(tblNameStr, existsBodyDriverName)
+						// Issue #403: the EXISTS body driver receives no
+						// attached_condition in MySQL's EXPLAIN — the body's
+						// JOIN ON condition becomes the `ref` on the probe
+						// side, and there is no per-table filter to attach.
+						// Strip any attached_condition that explainJSONTableBlock
+						// added based on the synthetic "Using where" extra.
+						if isExistsBodyDriver {
+							filtered := innerTbl[:0]
+							for _, kv := range innerTbl {
+								if kv.Key == "attached_condition" {
+									continue
+								}
+								filtered = append(filtered, kv)
+							}
+							innerTbl = filtered
 						}
 						insertPos := len(innerTbl)
 						for j, kv := range innerTbl {
@@ -13461,7 +13576,7 @@ func (e *Executor) explainJSONDocument(query string) string {
 						if isLast {
 							newBlock = append(newBlock, orderedKV{"first_match", firstTableName})
 						}
-						if accessType == "ALL" {
+						if accessType == "ALL" && !isExistsBodyDriver {
 							alreadyHas := false
 							for _, kv := range innerTbl {
 								if kv.Key == "using_join_buffer" {

--- a/executor/explain_exists_body_reorder_test.go
+++ b/executor/explain_exists_body_reorder_test.go
@@ -1,0 +1,104 @@
+package executor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/myuon/mylite/catalog"
+	"github.com/myuon/mylite/storage"
+)
+
+// TestExplain_ExistsBodyTableReorder verifies issue #403: when an EXISTS body
+// has multiple FROM tables and one is accessed via a key (ref/eq_ref) driven
+// by an equi-join condition, MySQL reorders the body's tables so the
+// non-keyed (ALL-scan) driver appears FIRST and the key-access table appears
+// LAST in the EXPLAIN nested_loop chain.  mylite previously emitted them in
+// textual FROM-clause order regardless of access type.
+//
+// In the canonical case below, the body is `(t2 INNER JOIN t3 ON
+// t3.c1 = t2.c1)`. Textual order would put t2 first, but t2 has KEY (c1, i1)
+// allowing ref access driven by t3.c1, so MySQL emits t3 (ALL driver) first
+// and t2 (ref probe with first_match) last.
+func TestExplain_ExistsBodyTableReorder(t *testing.T) {
+	cat := catalog.New()
+	store := storage.NewEngine()
+	e := New(cat, store)
+
+	if _, err := e.Execute("CREATE DATABASE IF NOT EXISTS test"); err != nil {
+		t.Fatalf("create db: %v", err)
+	}
+	e.CurrentDB = "test"
+
+	for _, q := range []string{
+		"SET optimizer_switch='semijoin=on,materialization=on,firstmatch=on,loosescan=on,index_condition_pushdown=on,mrr=on'",
+		"CREATE TABLE t1 (i1 INTEGER NOT NULL, c1 VARCHAR(1) NOT NULL) charset latin1 ENGINE=InnoDB",
+		"INSERT INTO t1 VALUES (2,'w')",
+		"CREATE TABLE t2 (i1 INTEGER NOT NULL, c1 VARCHAR(1) NOT NULL, c2 VARCHAR(1) NOT NULL, KEY (c1, i1)) charset latin1 ENGINE=InnoDB",
+		"INSERT INTO t2 VALUES (8,'d','d')",
+		"INSERT INTO t2 VALUES (4,'v','v')",
+		"CREATE TABLE t3 (c1 VARCHAR(1) NOT NULL) charset latin1 ENGINE=InnoDB",
+		"INSERT INTO t3 VALUES ('v')",
+	} {
+		if _, err := e.Execute(q); err != nil {
+			t.Fatalf("setup %q: %v", q, err)
+		}
+	}
+
+	res, err := e.Execute(`EXPLAIN FORMAT=JSON SELECT i1 FROM t1 WHERE EXISTS (SELECT t2.c1 FROM (t2 INNER JOIN t3 ON (t3.c1 = t2.c1)) WHERE t2.c2 != t1.c1 AND t2.c2 = (SELECT MIN(t3.c1) FROM t3))`)
+	if err != nil {
+		t.Fatalf("EXPLAIN failed: %v", err)
+	}
+	if len(res.Rows) != 1 {
+		t.Fatalf("expected 1 EXPLAIN row, got %d", len(res.Rows))
+	}
+	js, _ := res.Rows[0][0].(string)
+	if testing.Verbose() {
+		t.Logf("FULL JSON:\n%s", js)
+	}
+
+	// The EXISTS body's tables should appear in order t3 (driver), then t2 (ref).
+	t1Idx := strings.Index(js, `"table_name": "t1"`)
+	t3Idx := strings.Index(js, `"table_name": "t3",`+"\n          \"access_type\": \"ALL\"")
+	t2Idx := strings.LastIndex(js, `"table_name": "t2"`)
+	if t1Idx == -1 {
+		t.Fatalf("expected t1 table block, got:\n%s", js)
+	}
+	if t3Idx == -1 {
+		// Fall back to a relaxed match (t3 with ALL access_type somewhere after t1).
+		idx := strings.Index(js[t1Idx:], `"table_name": "t3"`)
+		if idx == -1 {
+			t.Fatalf("expected t3 table block in EXISTS body, got:\n%s", js)
+		}
+		t3Idx = t1Idx + idx
+	}
+	if t2Idx == -1 {
+		t.Fatalf("expected t2 table block, got:\n%s", js)
+	}
+	if !(t1Idx < t3Idx && t3Idx < t2Idx) {
+		t.Errorf("EXISTS body order wrong: expected t1 (%d) < t3 (%d) < t2 (%d)", t1Idx, t3Idx, t2Idx)
+	}
+
+	// The driver (t3) must NOT carry `using_join_buffer` (BNL) or
+	// `attached_condition` — both are absent in MySQL's expected output.
+	t3Block := js[t3Idx:]
+	endIdx := strings.Index(t3Block[len(`"table_name": "t3"`):], `"table_name":`)
+	if endIdx > 0 {
+		t3Block = t3Block[:len(`"table_name": "t3"`)+endIdx]
+	}
+	if strings.Contains(t3Block, `"using_join_buffer"`) {
+		t.Errorf("EXISTS body driver t3 should not have using_join_buffer, got:\n%s", t3Block)
+	}
+	if strings.Contains(t3Block, `"attached_condition"`) {
+		t.Errorf("EXISTS body driver t3 should not have attached_condition, got:\n%s", t3Block)
+	}
+
+	// The probe (t2) must carry `first_match: t1` (since it's the LAST inner
+	// of the EXISTS body chain) and `access_type: ref`.
+	t2Block := js[t2Idx:]
+	if !strings.Contains(t2Block, `"access_type": "ref"`) {
+		t.Errorf("expected t2 access_type=ref (issue #403/#406), got:\n%s", t2Block)
+	}
+	if !strings.Contains(t2Block, `"first_match": "t1"`) {
+		t.Errorf("expected first_match=t1 on t2 (last inner of EXISTS body), got:\n%s", t2Block)
+	}
+}


### PR DESCRIPTION
## Summary

When an EXISTS body's FROM clause has 2+ tables and one is accessed via a key (ref/eq_ref) driven by an equi-join condition, MySQL's optimizer reorders the body's tables so the non-keyed (ALL-scan) driver appears FIRST and the key-access table appears LAST in the EXPLAIN nested_loop chain. mylite previously emitted them in textual FROM-clause order.

For the canonical query in #403:

```sql
EXPLAIN FORMAT=JSON SELECT i1 FROM t1 WHERE EXISTS (
  SELECT t2.c1 FROM (t2 INNER JOIN t3 ON (t3.c1 = t2.c1))
  WHERE t2.c2 != t1.c1 AND t2.c2 = (SELECT MIN(t3.c1) FROM t3))
```

with `t2` having `KEY (c1, i1)`, MySQL emits `[t1, t3 (ALL driver), t2 (ref c1, first_match: t1)]`. mylite previously emitted `[t1, t2 (ref c1), t3 (ALL)]`.

## Changes (`executor/explain.go`)

- `walkForSubqueries` (EXISTS body branch): partition the body's FROM tables into "drivers" (non-ref access) and "probes" (ref/eq_ref/ref_or_null), preserving relative order within each group, and concatenate drivers + probes. Only applies for plain EXISTS (NOT EXISTS antijoin keeps textual order). Skips reorder when one of the groups is empty.
- New helper `explainJSONExistsBodyDriverName`: re-walks the outer WHERE to identify the EXISTS body driver's table name so the JSON builder can recognise it.
- FirstMatch nested_loop builder (the multi-primary path with subqueries): when a primary row is the EXISTS body driver, suppress (a) `using_join_buffer: Block Nested Loop` (a sub-chain's own driver does not get BNL even with ALL access) and (b) any `attached_condition` that `explainJSONTableBlock` added from the synthetic "Using where" extra (the body's JOIN ON condition becomes the probe's `ref`, not a per-table filter).

## KPI

Targeted JSON tests, head-to-head with main (`-j 1 -force`):

| test                | before fdl | after fdl |
|---------------------|-----------:|----------:|
| explain_json_all    | 1258       | **1303 (+45)** |
| explain_json_none   | 1104       | 1104       |
| explain_format_json | n/a (skip) | n/a        |
| subquery_sj_all     | 142        | 142        |
| subquery_sj_mat     | 146        | 146        |

Wider `other` suite head-to-head (`-suite other -j 1 -max 280`):
- main:        106 pass / 113 fail / 49 skip / 32 err
- this branch: 106 pass / 113 fail / 49 skip / 32 err
- 0 per-test status changes, 0 regressions

## Test plan

- [x] `go build ./...`
- [x] `go test ./... -count=1` (incl. new `TestExplain_ExistsBodyTableReorder`)
- [x] `go run ./cmd/mtrrun -test other/{explain_format_json,explain_json_all,explain_json_none,subquery_sj_all,subquery_sj_mat} -force` head-to-head with main: explain_json_all FDL +45, others unchanged
- [x] `go run ./cmd/mtrrun -suite other -j 1 -max 280 -force` head-to-head with main: identical totals, zero regressions

Closes #403
Refs #264, #287, #402, #406, #410

🤖 Generated with [Claude Code](https://claude.com/claude-code)