### PR TITLE
fix: keep all view columns when synthesizing TableDef from view SQL

### DIFF
--- a/docs/close-to-pass-candidates.md
+++ b/docs/close-to-pass-candidates.md
@@ -41,16 +41,16 @@ same scoping work.
 - **Risk**: High — could regress many GROUP BY tests that depend on current
   sort order.
 
-### 4. `json/json_innodb` — diff 13 lines
-- **First diff line 241**: `SUM(col_int)\tcol_int` (expected header) vs
-  `col_int` (actual header — only one column). The `SUM(col_int)` aggregate is
-  silently being dropped from the SELECT list when combined with another column
-  selected from JSON-typed source.
-- **Fix sketch**: Investigate `executor/select.go` aggregate column detection
-  when the source row has JSON-typed values. The actual `SUM(col_int)` value
-  also returns `null` instead of `4572643328` — could be JSON→numeric coercion
-  failure.
-- **Risk**: Low-medium — narrow to JSON+aggregate path.
+### 4. `json/json_innodb` — FIXED
+- Root cause was in `syntheticTableDefFromViewSQL` (`executor/select.go`):
+  when a view's SELECT mixed an unnamed computed expression with a direct
+  column ref (e.g. `SELECT SUM(col_int), col_int FROM ...`), the computed
+  expr was silently dropped, leaving the synthetic view def with one fewer
+  column. `SELECT * FROM view` then returned only `col_int`, hiding the
+  `SUM(col_int)` column entirely. Not actually JSON-related.
+- Fix: bail out of the synthesizer when any expr lacks a clean name; let
+  the caller fall back to the actual view-scan column names (which preserve
+  MySQL's exact display style like `SUM(col_int)` and `b+1`).
 
 ### 5. `other/endspace` — diff 55 lines
 - **First diff line 8**: `1  0  0` (expected) vs `0  1  0` (actual) for

--- a/executor/select.go
+++ b/executor/select.go
@@ -143,23 +143,30 @@ func (e *Executor) syntheticTableDefFromViewSQL(viewName, viewSQL string) *catal
 						}
 					}
 				}
-				// For named column lists, synthesize from SELECT expressions (alias or ColName only).
-				var synCols []catalog.ColumnDef
+				// For named column lists, synthesize from SELECT expressions.
+				// We must produce one synthetic column per SELECT expression so that
+				// the column count is correct (e.g. SELECT SUM(c), c FROM t produces
+				// two columns, not one). For any expression we cannot cleanly name
+				// here (computed exprs without an explicit alias), bail out and
+				// return nil so the caller falls back to the actual view-scan
+				// result columns — those preserve MySQL's exact display name
+				// (e.g. "b+1" with no spaces, "SUM(col_int)" with original case).
+				synCols := make([]catalog.ColumnDef, 0, len(sel.SelectExprs.Exprs))
 				for _, se := range sel.SelectExprs.Exprs {
-					switch s := se.(type) {
-					case *sqlparser.StarExpr:
-						return nil // can't handle qualified star here
-					case *sqlparser.AliasedExpr:
-						name := ""
-						if !s.As.IsEmpty() {
-							name = s.As.String()
-						} else if col, ok := s.Expr.(*sqlparser.ColName); ok {
-							name = col.Name.String()
-						}
-						if name != "" {
-							synCols = append(synCols, catalog.ColumnDef{Name: name})
-						}
+					ae, ok := se.(*sqlparser.AliasedExpr)
+					if !ok {
+						return nil
 					}
+					name := ""
+					if !ae.As.IsEmpty() {
+						name = ae.As.String()
+					} else if col, ok := ae.Expr.(*sqlparser.ColName); ok {
+						name = col.Name.String()
+					}
+					if name == "" {
+						return nil
+					}
+					synCols = append(synCols, catalog.ColumnDef{Name: name})
 				}
 				if len(synCols) > 0 {
 					return &catalog.TableDef{Name: viewName, Columns: synCols}


### PR DESCRIPTION
## Summary
- Fix `syntheticTableDefFromViewSQL` in `executor/select.go` so unnamed computed expressions (e.g. `SUM(col_int)`) are not silently dropped from a view's synthetic column list. When any select expression lacks a clean alias/ColName, return nil so the caller falls back to the actual view-scan column names — which already carry MySQL's exact display style (`SUM(col_int)`, `b+1` with no spaces, etc.).
- Net effect on mtrrun: passing **1811 -> 1812**, zero regressions. Specifically `json/json_innodb` now passes; `gcol/gcol_view_innodb` and `gcol/gcol_view_myisam` continue to pass.

## Root cause
`CREATE VIEW v AS SELECT SUM(col_int), col_int FROM t` was producing a synthetic TableDef with only one column (`col_int`) because the unnamed `SUM(col_int)` was skipped by the synthesizer. `SELECT * FROM v` then silently omitted the SUM column. This was misdiagnosed in `docs/close-to-pass-candidates.md` as a JSON+aggregate issue; in fact it had nothing to do with JSON.

## Test plan
- [x] `go build ./...`
- [x] `go test ./... -count=1`
- [x] `go run ./cmd/mtrrun -test json/json_innodb,gcol/gcol_view_innodb,gcol/gcol_view_myisam -force` -> all pass
- [x] Full `go run ./cmd/mtrrun` regression check: passing 1811 -> 1812, zero tests went from pass to non-pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)