### PR TITLE
fix(explain): don't flatten EXISTS body when semijoin=off

### DIFF
--- a/executor/explain.go
+++ b/executor/explain.go
@@ -6586,7 +6586,12 @@ func (e *Executor) walkForSubqueries(node sqlparser.SQLNode, idCounter *int64, r
 			//
 			// A simple EXISTS without nested subqueries is NOT handled here — it
 			// falls through to the regular Subquery case via return true, nil.
-			if !outerCanSemijoin {
+			//
+			// This anti-/semi-join flattening of the EXISTS body only applies when
+			// MySQL's semijoin transformation is enabled (optimizer_switch=semijoin=on).
+			// When semijoin=off, MySQL keeps the EXISTS as a separate DEPENDENT
+			// SUBQUERY block (no FirstMatch / Not exists annotations on the outer).
+			if !outerCanSemijoin && e.isOptimizerSwitchEnabled("semijoin") {
 				if inner, ok := sub.Subquery.Select.(*sqlparser.Select); ok {
 					// Only apply this handling if the EXISTS inner SELECT has nested subqueries.
 					innerHasNestedSubquery := false

--- a/executor/explain_exists_no_semijoin_test.go
+++ b/executor/explain_exists_no_semijoin_test.go
@@ -1,0 +1,107 @@
+package executor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/myuon/mylite/catalog"
+	"github.com/myuon/mylite/storage"
+)
+
+// TestExplain_ExistsBodyNotFlattenedWhenSemijoinOff verifies that when
+// optimizer_switch=semijoin=off, an EXISTS subquery whose body itself has
+// nested scalar subqueries is NOT flattened into the outer query block.
+//
+// MySQL keeps such an EXISTS as a separate DEPENDENT SUBQUERY block in
+// `attached_subqueries`, with the outer table appearing alone (no nested_loop
+// wrapper) under `query_block.table` and no FirstMatch/Not exists annotations
+// on the outer side.
+//
+// Reproduces issue #264 (other/explain_json_none first-diff at line 1214 →
+// 1240+ after fix). Without the fix, the EXISTS body's tables (t3, t2)
+// were emitted at the outer query id with FirstMatch annotations even with
+// semijoin=off.
+func TestExplain_ExistsBodyNotFlattenedWhenSemijoinOff(t *testing.T) {
+	cat := catalog.New()
+	store := storage.NewEngine()
+	e := New(cat, store)
+	if _, err := e.Execute("CREATE DATABASE IF NOT EXISTS test"); err != nil {
+		t.Fatalf("create db: %v", err)
+	}
+	e.CurrentDB = "test"
+	for _, q := range []string{
+		"SET optimizer_switch='semijoin=off,materialization=off,firstmatch=on,loosescan=on,index_condition_pushdown=on,mrr=on'",
+		"CREATE TABLE t1 (i1 INTEGER NOT NULL, c1 VARCHAR(1) NOT NULL) ENGINE=InnoDB",
+		"INSERT INTO t1 VALUES (2,'w')",
+		"CREATE TABLE t2 (i1 INTEGER NOT NULL, c1 VARCHAR(1) NOT NULL, c2 VARCHAR(1) NOT NULL, KEY (c1, i1)) ENGINE=InnoDB",
+		"INSERT INTO t2 VALUES (8,'d','d')",
+		"INSERT INTO t2 VALUES (4,'v','v')",
+		"CREATE TABLE t3 (c1 VARCHAR(1) NOT NULL) ENGINE=InnoDB",
+		"INSERT INTO t3 VALUES ('v')",
+	} {
+		if _, err := e.Execute(q); err != nil {
+			t.Fatalf("setup %q: %v", q, err)
+		}
+	}
+	res, err := e.Execute(`EXPLAIN FORMAT=JSON SELECT i1 FROM t1 WHERE EXISTS (SELECT t2.c1 FROM (t2 INNER JOIN t3 ON (t3.c1 = t2.c1)) WHERE t2.c2 != t1.c1 AND t2.c2 = (SELECT MIN(t3.c1) FROM t3))`)
+	if err != nil {
+		t.Fatalf("EXPLAIN failed: %v", err)
+	}
+	if len(res.Rows) != 1 {
+		t.Fatalf("expected 1 EXPLAIN row, got %d", len(res.Rows))
+	}
+	js, _ := res.Rows[0][0].(string)
+	if testing.Verbose() {
+		t.Logf("FULL JSON:\n%s", js)
+	}
+
+	// The outer (select_id=1) query_block must NOT contain a nested_loop —
+	// the EXISTS body should not be inlined into id=1 when semijoin is off.
+	// We expect a single `"table": { "table_name": "t1", ... }` directly under
+	// the top-level query_block. Look for the first `"select_id": 1` substring
+	// and check that the next structural key is `"table"` (not `"nested_loop"`).
+	idx := strings.Index(js, `"select_id": 1`)
+	if idx < 0 {
+		t.Fatalf("expected select_id 1 in output:\n%s", js)
+	}
+	// Search for the first `"nested_loop"` and the first `"table": {` after select_id=1.
+	rest := js[idx:]
+	tablePos := strings.Index(rest, `"table": {`)
+	nestedPos := strings.Index(rest, `"nested_loop"`)
+	if tablePos < 0 {
+		t.Fatalf("expected `\"table\": {` after select_id=1, got:\n%s", js)
+	}
+	if nestedPos >= 0 && nestedPos < tablePos {
+		t.Errorf("EXISTS body was flattened into outer nested_loop with semijoin=off; got nested_loop before table:\n%s", js)
+	}
+
+	// The outer t1 table should NOT carry a FirstMatch / Not exists annotation
+	// (those are semijoin / antijoin markers added when MySQL flattens the EXISTS).
+	t1Idx := strings.Index(js, `"table_name": "t1"`)
+	if t1Idx < 0 {
+		t.Fatalf("expected t1 table block:\n%s", js)
+	}
+	// Look forward in t1's block for the next table_name boundary.
+	after := js[t1Idx:]
+	endIdx := strings.Index(after[len(`"table_name": "t1"`):], `"table_name":`)
+	t1Block := after
+	if endIdx > 0 {
+		t1Block = after[:len(`"table_name": "t1"`)+endIdx]
+	}
+	if strings.Contains(t1Block, `"first_match"`) || strings.Contains(t1Block, `"FirstMatch`) {
+		t.Errorf("outer t1 carries FirstMatch with semijoin=off:\n%s", t1Block)
+	}
+	if strings.Contains(t1Block, `"Not exists"`) {
+		t.Errorf("outer t1 carries Not exists with semijoin=off:\n%s", t1Block)
+	}
+
+	// The EXISTS body (select#2) must appear as a DEPENDENT SUBQUERY block
+	// inside attached_subqueries — i.e. the inner t2 table should NOT be at
+	// id=1.
+	if !strings.Contains(js, `"attached_subqueries"`) {
+		t.Errorf("expected attached_subqueries on outer t1 block:\n%s", js)
+	}
+	if !strings.Contains(js, `"select_id": 2`) {
+		t.Errorf("expected separate select_id 2 for EXISTS body:\n%s", js)
+	}
+}


### PR DESCRIPTION
## Summary

When optimizer_switch=semijoin=off, MySQL keeps an EXISTS subquery (whose body itself contains nested scalar subqueries) as a separate DEPENDENT SUBQUERY block in `attached_subqueries`. mylite was unconditionally flattening such EXISTS bodies into the outer query block (with FirstMatch/Not exists annotations), which produced wrong EXPLAIN JSON shape with semijoin disabled.

For the canonical query (issue #264 / mtr `other/explain_json_none` first-diff at line 1214):

```sql
SET optimizer_switch='semijoin=off,materialization=off,...';
EXPLAIN FORMAT=json
SELECT i1
FROM t1
WHERE EXISTS (SELECT t2.c1
              FROM (t2 INNER JOIN t3 ON (t3.c1 = t2.c1))
              WHERE t2.c2 != t1.c1 AND t2.c2 = (SELECT MIN(t3.c1) FROM t3));
```

mylite emitted:
```
"query_block": {
  "select_id": 1,
  "nested_loop": [               ← wrong: t1 should be alone in `table:`
    { "table": { "table_name": "t1", ... } },
    { "table": { "table_name": "t3", ... } },
    { "table": { "table_name": "t2", ..., "first_match": "t1", ... } }
  ]
}
```

instead of MySQL's:
```
"query_block": {
  "select_id": 1,
  "table": {
    "table_name": "t1",
    "attached_subqueries": [{ "select_id": 2, "nested_loop": [t3, t2] }]
  }
}
```

## Changes (`executor/explain.go`)

- Gate the EXISTS-body flatten branch (which emits inner tables at the outer query id with FirstMatch/Not exists annotations) on `optimizer_switch=semijoin` being enabled.
- When semijoin=off, the EXISTS falls through to the regular Subquery handling path and becomes a separate DEPENDENT SUBQUERY block.

## KPI

Targeted JSON tests, head-to-head with main (`-j 1 -force`):

| test               | before fdl | after fdl |
|--------------------|-----------:|----------:|
| explain_json_all   | 1355       | 1355       |
| explain_json_none  | 1214       | **1240 (+26)** |

Wider `other` suite head-to-head (`-suite other -j 1 -max 280`):
- main:        106 pass / 113 fail / 49 skip / 32 err
- this branch: 106 pass / 113 fail / 49 skip / 32 err
- 0 per-test status changes, 0 regressions

## Test plan

- [x] `go build ./...`
- [x] `go test ./... -count=1` (incl. new `TestExplain_ExistsBodyNotFlattenedWhenSemijoinOff`)
- [x] Existing `TestExplain_ExistsBodyDecorrelate` still passes (uses semijoin=on, so the gated branch still applies for it).
- [x] `go run ./cmd/mtrrun -test other/{explain_json_all,explain_json_none} -force` head-to-head: explain_json_none FDL +26, explain_json_all unchanged.
- [x] `go run ./cmd/mtrrun -suite other -j 1 -max 280 -force` head-to-head: identical totals, zero per-test status changes.

Refs #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)