### PR TITLE
fix(trigger): pass parser_stack — nested BEGIN/END + := SET parsing

### DIFF
--- a/executor/procedures.go
+++ b/executor/procedures.go
@@ -323,14 +323,18 @@ func splitTriggerBody(body string) []string {
 				// END can appear at statement start or inside UNTIL condition (e.g. UNTIL done END REPEAT)
 				if !prevIsAlpha && strings.HasPrefix(remaining, "END") && (i+3 >= len(words) || !isAlphaNum(words[i+3])) && depth > 0 {
 					depth--
+				} else if !prevIsAlpha && strings.HasPrefix(remaining, "BEGIN") && (i+5 >= len(words) || !isAlphaNum(words[i+5])) {
+					// BEGIN is always a block opener in stored routines/triggers — it has no
+					// function-call form. Accept it whenever it appears as a standalone word
+					// (not just at "statement start"), so deeply nested "BEGIN BEGIN BEGIN ..."
+					// on a single line increments depth for each occurrence.
+					depth++
 				} else if isStmtStart {
 					// Check for block openers (only if not part of an END xxx pattern)
 					// Helper: check if preceded by "END " or "END\n" or "END\t" (this keyword follows END)
 					isAfterEnd := i >= 4 && strings.ToUpper(words[i-4:i-1]) == "END" && (words[i-1] == ' ' || words[i-1] == '\n' || words[i-1] == '\t')
 					if !isAfterEnd {
-						if strings.HasPrefix(remaining, "BEGIN") && (i+5 >= len(words) || !isAlphaNum(words[i+5])) {
-							depth++
-						} else if strings.HasPrefix(remaining, "IF") && (i+2 >= len(words) || words[i+2] == ' ' || words[i+2] == '\t' || words[i+2] == '\n') {
+						if strings.HasPrefix(remaining, "IF") && (i+2 >= len(words) || words[i+2] == ' ' || words[i+2] == '\t' || words[i+2] == '\n') {
 							// Skip ELSEIF (preceded by ELSE)
 							isElseIf := i >= 4 && strings.ToUpper(words[i-4:i]) == "ELSE"
 							if !isElseIf {
@@ -3681,8 +3685,10 @@ func (e *Executor) execRoutineBodyWithContext(body []string, ctx *routineContext
 			eqIdx := strings.Index(setPart, "=")
 			if eqIdx >= 0 {
 				varName := strings.TrimSpace(setPart[:eqIdx])
-				// Handle := assignment operator (MySQL stored routine syntax): strip trailing colon.
-				varName = strings.TrimSuffix(varName, ":")
+				// Handle := assignment operator (MySQL stored routine syntax): strip trailing colon
+				// (e.g. "NEW.b :" → "NEW.b"). The colon may be separated from the name by
+				// whitespace, so TrimSpace once more after the colon is removed.
+				varName = strings.TrimSpace(strings.TrimSuffix(varName, ":"))
 				valStr := strings.TrimSpace(setPart[eqIdx+1:])
 				// User variables (@var) have no declared type, so string-to-number truncation
 				// is only a warning (not an error) even inside strict-mode stored functions.


### PR DESCRIPTION
## Summary

Fixes `other/parser_stack` close-to-pass candidate #2 from `docs/close-to-pass-candidates.md` (PR #411).

The trigger body in `parser_stack.test` looks like:
```
BEGIN BEGIN ... BEGIN  -- 108 deep, all on one line, separated by spaces
  SET NEW.b := NEW.a;
  SET NEW.b := NEW.b + 1;
  ...
END; END; ... END;
```

Two bugs were causing `NEW.b` to be NULL after the trigger ran:

1. **`splitTriggerBody` BEGIN depth tracking** — `BEGIN` was only recognised as a block opener when it appeared at "statement start" (start-of-input, after `;`, `\n`, or `:`). For 108 BEGINs on a single line separated by spaces, only the first counted, so depth dropped to 0 partway through and the inner `;` after the first END caused a premature split. Since BEGIN has no function-call form in MySQL stored routines, the `isStmtStart` guard isn't needed — every standalone BEGIN keyword is a block opener.

2. **Routine-body SET handler `:=` parsing** — for `SET NEW.b := NEW.a`, `eqIdx` points at the `=` of `:=`, so `setPart[:eqIdx]` is `"NEW.b :"`. After `TrimSpace` then `TrimSuffix(":")`, the variable name was `"NEW.b "` (trailing space). That space-laden name didn't match the `NEW.` prefix logic and the assignment silently went into a generic local-var slot, leaving the actual NEW row column unchanged. Added a second `TrimSpace` after `TrimSuffix(":")`.

## Regression check

Head-to-head full `mtrrun` (`go run ./cmd/mtrrun -force`):

| | Pass | Fail | Error | Skip | Timeout |
|---|---|---|---|---|---|
| main (`c227a11`) | 1812 | 330 | 122 | 1080 | 1 |
| this PR | **1813** | 329 | 122 | 1080 | 1 |

Pass-set diff: `+other/parser_stack`, **zero regressions**.

## Test plan

- [x] `go build ./...`
- [x] `go test ./... -count=1`
- [x] `go run ./cmd/mtrrun -test other/parser_stack` — passes
- [x] Full mtrrun head-to-head vs main — +1 pass, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)