### PR TITLE
fix(insert): truncate CHAR/VARCHAR on INSERT IGNORE instead of storing full string

### DIFF
--- a/executor/dml_insert.go
+++ b/executor/dml_insert.go
@@ -2146,8 +2146,9 @@ func (e *Executor) execInsert(stmt *sqlparser.Insert) (*Result, error) {
 										rv = row[col.Name]
 										e.addWarning("Note", 1265, fmt.Sprintf("Data truncated for column '%s' at row 1", col.Name))
 									} else if bool(stmt.Ignore) || !e.isStrictMode() {
-										// INSERT IGNORE or non-strict mode: warn but do NOT truncate
-										// (Dolt does not enforce VARCHAR length limits)
+										// INSERT IGNORE or non-strict mode: truncate with warning (MySQL behavior)
+										row[col.Name] = string([]rune(sv)[:maxLen])
+										rv = row[col.Name]
 										e.addWarning("Warning", 1265, fmt.Sprintf("Data truncated for column '%s' at row 1", col.Name))
 									} else {
 										return nil, mysqlError(1406, "22001", fmt.Sprintf("Data too long for column '%s' at row 1", col.Name))


### PR DESCRIPTION
## Summary
- Fix `INSERT IGNORE` (and non-strict sql_mode) truncation of oversized strings in CHAR/VARCHAR columns
- Previously: warning was emitted but the full oversized string was stored, violating MySQL's behavior
- Now: string is truncated to column's max character length and Warning 1265 is emitted, matching MySQL

## Root cause
In `executor/dml_insert.go`, the `else if bool(stmt.Ignore) || !e.isStrictMode()` branch for CHAR/VARCHAR length overflow emitted the warning but forgot to actually truncate `row[col.Name]`. The comment said "Dolt does not enforce VARCHAR length limits" which was correct for Dolt but not for MySQL compatibility.

## Test
- `other/ctype_mb`: `INSERT IGNORE INTO t1 VALUES ('aaaabbbbccccdddd',...)` into CHAR(4) columns now correctly stores `aaaa` with Warning 1265

## Regression check
Full mtrrun: **1813 passed** (+1 vs baseline 1812), 0 regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)