### PR TITLE
fix(explain): merge same-id EXISTS body rows into a single nested_loop

### DIFF
--- a/executor/explain.go
+++ b/executor/explain.go
@@ -11297,6 +11297,99 @@ func explainJSONInjectAttachedSubqueriesIntoTable(qb []orderedKV, children []int
 	return qb
 }
 
+// explainJSONMergeQueryBlocksAsNestedLoop merges multiple query_blocks (each
+// shaped as `{select_id, cost_info, table:{...}}`) that share the same
+// select_id into a single query_block whose body is a `nested_loop` containing
+// the per-row table entries.  Used when an EXISTS / IN subquery's body has
+// multiple FROM tables and shows up as multiple rows with the same id in
+// EXPLAIN.  MySQL emits these as a single dependent/cacheable subquery block
+// with a nested_loop array, not as multiple separate attached_subqueries
+// entries.
+//
+// The result preserves the first qb's select_id and cost_info; per-row tables
+// are reordered so driver tables (access_type=ALL) come first and probe tables
+// (access_type=ref/eq_ref/ref_or_null) come last (stable within group).  The
+// driver's `using_join_buffer` is stripped (MySQL doesn't show that field on
+// the outer driver of a 2-table EXISTS/IN body chain).
+func explainJSONMergeQueryBlocksAsNestedLoop(qbs [][]orderedKV) []orderedKV {
+	if len(qbs) == 0 {
+		return nil
+	}
+	if len(qbs) == 1 {
+		return qbs[0]
+	}
+	// Extract the table block out of each input qb, preserving structure.
+	type tableEntry struct {
+		access string
+		block  []orderedKV
+	}
+	var tables []tableEntry
+	for _, qb := range qbs {
+		for _, kv := range qb {
+			if kv.Key != "table" {
+				continue
+			}
+			tbl, ok := kv.Value.([]orderedKV)
+			if !ok {
+				continue
+			}
+			access := ""
+			for _, t := range tbl {
+				if t.Key == "access_type" {
+					if s, ok := t.Value.(string); ok {
+						access = s
+					}
+					break
+				}
+			}
+			tables = append(tables, tableEntry{access: access, block: tbl})
+		}
+	}
+	if len(tables) < 2 {
+		return qbs[0]
+	}
+	// Stable partition: drivers (ALL, index, range, etc.) first, probes (ref/
+	// eq_ref/ref_or_null) last.
+	var drivers, probes []tableEntry
+	for _, t := range tables {
+		switch t.access {
+		case "ref", "eq_ref", "ref_or_null":
+			probes = append(probes, t)
+		default:
+			drivers = append(drivers, t)
+		}
+	}
+	ordered := append(drivers, probes...)
+	// Strip `using_join_buffer` from the FIRST table (the driver of the
+	// nested-loop chain) — MySQL doesn't display it there.
+	if len(ordered) > 0 {
+		filtered := ordered[0].block[:0]
+		for _, kv := range ordered[0].block {
+			if kv.Key == "using_join_buffer" {
+				continue
+			}
+			filtered = append(filtered, kv)
+		}
+		ordered[0].block = filtered
+	}
+	// Build the nested_loop array.
+	var nl []interface{}
+	for _, t := range ordered {
+		nl = append(nl, []orderedKV{{"table", t.block}})
+	}
+	// Build the merged query_block: take select_id and cost_info from qbs[0]
+	// (they are identical across rows of the same id), then nested_loop.
+	var merged []orderedKV
+	for _, kv := range qbs[0] {
+		if kv.Key == "table" {
+			continue
+		}
+		merged = append(merged, kv)
+	}
+	merged = append(merged, orderedKV{"nested_loop", nl})
+	return merged
+}
+
 // explainJSONCollectMaterializedINColumns walks the outer query's WHERE clause
 // and returns a map of lower-cased outer-table-name -> ordered, deduplicated
 // list of columns that appear as the LHS of any `col IN (SELECT ...)` predicate.
@@ -13411,14 +13504,62 @@ func (e *Executor) explainJSONDocument(query string) string {
 					// flattened (not in subqueryRows, e.g. semijoin'd into
 					// PRIMARY, in which case the child attaches to outer too).
 					// Preserve textual order from subqueryRows.
+					//
+					// When multiple top-level entries share the same select_id
+					// (e.g. an EXISTS / IN subquery body with multiple FROM
+					// tables produces one row per inner table at that id), MySQL
+					// emits a SINGLE attached_subqueries entry whose query_block
+					// has a `nested_loop` array, not multiple separate entries.
+					// Group same-id top-level entries and merge them.
+					type topEntry struct {
+						en       subEntry
+						emitted  bool
+					}
+					top := make([]topEntry, 0, len(entries))
 					for _, en := range entries {
 						if en.parentID > 1 && existsByID[en.parentID] {
 							continue
 						}
-						if en.dependent {
+						top = append(top, topEntry{en: en})
+					}
+					for i := range top {
+						if top[i].emitted {
+							continue
+						}
+						curID := top[i].en.selectID
+						// Collect all subsequent entries with the same selectID.
+						group := []int{i}
+						for j := i + 1; j < len(top); j++ {
+							if top[j].emitted {
+								continue
+							}
+							if top[j].en.selectID == curID && top[j].en.dependent == top[i].en.dependent {
+								group = append(group, j)
+							}
+						}
+						if len(group) == 1 {
+							en := top[i].en
+							if en.dependent {
+								hasDependentSubs = true
+							}
+							attachedSubs = append(attachedSubs, wrap(en))
+							top[i].emitted = true
+							continue
+						}
+						// Merge: build a single qb with nested_loop containing all
+						// per-row tables for this id.
+						qbs := make([][]orderedKV, 0, len(group))
+						for _, gi := range group {
+							qbs = append(qbs, top[gi].en.qb)
+							top[gi].emitted = true
+						}
+						merged := explainJSONMergeQueryBlocksAsNestedLoop(qbs)
+						mergedEn := top[i].en
+						mergedEn.qb = merged
+						if mergedEn.dependent {
 							hasDependentSubs = true
 						}
-						attachedSubs = append(attachedSubs, wrap(en))
+						attachedSubs = append(attachedSubs, wrap(mergedEn))
 					}
 				}
 				// When the subqueries are dependent (IN/EXISTS attached to this table's

--- a/executor/explain_exists_body_2tables_nl_test.go
+++ b/executor/explain_exists_body_2tables_nl_test.go
@@ -1,0 +1,110 @@
+package executor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/myuon/mylite/catalog"
+	"github.com/myuon/mylite/storage"
+)
+
+// TestExplain_ExistsBody2TablesNestedLoopAttached verifies that when an EXISTS
+// subquery body has multiple FROM tables and produces multiple EXPLAIN rows
+// sharing the same select_id (e.g. id=2 with t2 + t3), the JSON EXPLAIN
+// emits a SINGLE attached_subqueries entry whose query_block contains a
+// `nested_loop` array — not multiple separate attached_subqueries entries
+// each with a single `table`.
+//
+// MySQL's expected shape (issue #264, other/explain_json_none line 1240+):
+//
+//	"attached_subqueries": [
+//	  {
+//	    "dependent": true, "cacheable": false,
+//	    "query_block": {
+//	      "select_id": 2,
+//	      "nested_loop": [
+//	        { "table": { "table_name": "t3", ... } },
+//	        { "table": { "table_name": "t2", ... } }
+//	      ]
+//	    }
+//	  }
+//	]
+//
+// Tables are reordered: drivers (ALL access) first, probes (ref/eq_ref) last.
+// The driver loses its `using_join_buffer` field (MySQL doesn't show it on
+// the outer driver of the EXISTS-body chain).
+func TestExplain_ExistsBody2TablesNestedLoopAttached(t *testing.T) {
+	cat := catalog.New()
+	store := storage.NewEngine()
+	e := New(cat, store)
+	if _, err := e.Execute("CREATE DATABASE IF NOT EXISTS test"); err != nil {
+		t.Fatalf("create db: %v", err)
+	}
+	e.CurrentDB = "test"
+	for _, q := range []string{
+		"SET optimizer_switch='semijoin=off,materialization=off,firstmatch=on,loosescan=on,index_condition_pushdown=off,mrr=off'",
+		"CREATE TABLE t1 (i1 INTEGER NOT NULL, c1 VARCHAR(1) NOT NULL) ENGINE=InnoDB",
+		"INSERT INTO t1 VALUES (2,'w')",
+		"CREATE TABLE t2 (i1 INTEGER NOT NULL, c1 VARCHAR(1) NOT NULL, c2 VARCHAR(1) NOT NULL, KEY (c1, i1)) ENGINE=InnoDB",
+		"INSERT INTO t2 VALUES (8,'d','d')",
+		"INSERT INTO t2 VALUES (4,'v','v')",
+		"CREATE TABLE t3 (c1 VARCHAR(1) NOT NULL) ENGINE=InnoDB",
+		"INSERT INTO t3 VALUES ('v')",
+	} {
+		if _, err := e.Execute(q); err != nil {
+			t.Fatalf("setup %q: %v", q, err)
+		}
+	}
+	res, err := e.Execute(`EXPLAIN FORMAT=JSON SELECT i1 FROM t1 WHERE EXISTS (SELECT t2.c1 FROM (t2 INNER JOIN t3 ON (t3.c1 = t2.c1)) WHERE t2.c2 != t1.c1 AND t2.c2 = (SELECT MIN(t3.c1) FROM t3))`)
+	if err != nil {
+		t.Fatalf("EXPLAIN failed: %v", err)
+	}
+	if len(res.Rows) != 1 {
+		t.Fatalf("expected 1 EXPLAIN row, got %d", len(res.Rows))
+	}
+	js, _ := res.Rows[0][0].(string)
+	if testing.Verbose() {
+		t.Logf("FULL JSON:\n%s", js)
+	}
+
+	// There should be exactly ONE select_id=2 query_block (not two split
+	// across separate attached_subqueries entries).  Since the scalar subquery
+	// (id=3) appears nested inside the t2 probe block, we count occurrences of
+	// the literal `"select_id": 2` after the outer t1 block.
+	t1End := strings.Index(js, `"table_name": "t1"`)
+	if t1End < 0 {
+		t.Fatalf("expected t1 table block:\n%s", js)
+	}
+	rest := js[t1End:]
+	count := strings.Count(rest, `"select_id": 2`)
+	if count != 1 {
+		t.Errorf("expected exactly 1 `select_id: 2` query_block, got %d (rows for the EXISTS body should be merged into a single nested_loop):\n%s", count, js)
+	}
+
+	// The single select_id=2 query_block should contain a `nested_loop` array
+	// whose first table is t3 (driver, ALL access) and second is t2 (probe,
+	// ref access).  Check ordering by string position.
+	idx2 := strings.Index(js, `"select_id": 2`)
+	if idx2 < 0 {
+		t.Fatalf("expected select_id 2:\n%s", js)
+	}
+	body := js[idx2:]
+	nlIdx := strings.Index(body, `"nested_loop"`)
+	if nlIdx < 0 {
+		t.Errorf("expected nested_loop in select_id=2 block:\n%s", js)
+	}
+	t3Idx := strings.Index(body, `"table_name": "t3"`)
+	t2Idx := strings.Index(body, `"table_name": "t2"`)
+	if t3Idx < 0 || t2Idx < 0 || t3Idx > t2Idx {
+		t.Errorf("expected t3 (driver) before t2 (probe) in nested_loop, got t3@%d t2@%d:\n%s", t3Idx, t2Idx, js)
+	}
+
+	// The driver (t3, listed first) should NOT carry `using_join_buffer`
+	// — that field is dropped from the outer driver of the EXISTS-body chain.
+	if t3Idx >= 0 && t2Idx > t3Idx {
+		t3Block := body[t3Idx:t2Idx]
+		if strings.Contains(t3Block, `"using_join_buffer"`) {
+			t.Errorf("driver (t3) should not carry using_join_buffer:\n%s", t3Block)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

When an EXISTS / IN subquery's body has multiple FROM tables, MySQL emits multiple EXPLAIN rows that share the same `select_id` (e.g. id=2 with t2 + t3). Previously, mylite's JSON EXPLAIN emitted these as separate `attached_subqueries` entries each with a single `table` block, producing duplicate `select_id` blocks under `attached_subqueries`.

For the canonical query (issue #264 / mtr `other/explain_json_none` first-diff at line 1240):

```sql
SET optimizer_switch='semijoin=off,materialization=off,...';
EXPLAIN FORMAT=json
SELECT i1
FROM t1
WHERE EXISTS (SELECT t2.c1
              FROM (t2 INNER JOIN t3 ON (t3.c1 = t2.c1))
              WHERE t2.c2 != t1.c1 AND t2.c2 = (SELECT MIN(t3.c1) FROM t3));
```

mylite emitted (two separate select_id=2 blocks):

```
"attached_subqueries": [
  { "query_block": { "select_id": 2, "table": { "table_name": "t2", ... } } },
  { "query_block": { "select_id": 2, "table": { "table_name": "t3", ... } } }
]
```

instead of MySQL's:

```
"attached_subqueries": [
  { "query_block": {
      "select_id": 2,
      "nested_loop": [
        { "table": { "table_name": "t3", ... } },
        { "table": { "table_name": "t2", ... } }
      ]
  } }
]
```

## Changes (`executor/explain.go`)

- New helper `explainJSONMergeQueryBlocksAsNestedLoop` that:
  - Extracts each input qb's `table` block.
  - Stable-partitions by `access_type`: drivers (`ALL`/index/range) first, probes (`ref`/`eq_ref`/`ref_or_null`) last.
  - Strips `using_join_buffer` from the chain driver (MySQL doesn't show it there).
  - Returns a single qb with `select_id`/`cost_info` from qbs[0] and a `nested_loop` array of per-table entries.
- In the attached-subqueries-builder loop, group consecutive top-level entries by `selectID` (and matching `dependent` flag). Single-entry groups emit unchanged; multi-entry groups go through the merge helper before being wrapped.

## KPI

Targeted JSON tests, head-to-head with main (`-test other/explain_json_all,other/explain_json_none -force`):

| test               | before fdl | after fdl |
|--------------------|-----------:|----------:|
| explain_json_all   | 1355       | 1355       |
| explain_json_none  | 1240       | **1256 (+16)** |

Wider `other` suite head-to-head (`-suite other -j 2 -max 280`):
- main:        107 pass / 112 fail / 49 skip / 32 err
- this branch: 107 pass / 112 fail / 49 skip / 32 err
- 0 per-test status changes, 0 regressions on subquery_sj_* / opt_hints_subquery (verified separately)

## Test plan

- [x] `go build ./...`
- [x] `go test ./... -count=1` (incl. new `TestExplain_ExistsBody2TablesNestedLoopAttached`)
- [x] Existing `TestExplain_ExistsBodyNotFlattenedWhenSemijoinOff` still passes (this fix is layered on top of PR #417's gate).
- [x] `go run ./cmd/mtrrun -test other/{explain_json_all,explain_json_none} -force` head-to-head: explain_json_none FDL +16, explain_json_all unchanged.
- [x] `go run ./cmd/mtrrun -suite other -j 2 -max 280 -force` head-to-head: identical totals, zero per-test status changes.
- [x] `go run ./cmd/mtrrun -test other/{subquery_sj_all_bka,subquery_sj_all_bka_nixbnl,subquery_sj_dupsweed,subquery_sj_firstmatch,subquery_sj_loosescan,subquery_sj_mat,opt_hints_subquery}` head-to-head: identical first-diff lines.

Refs #264

🤖 Generated with [Claude Code](https://claude.com/claude-code)