### PR TITLE
feat: support inline CHECK constraints in ALTER TABLE ADD COLUMN

### DIFF
--- a/executor/ddl.go
+++ b/executor/ddl.go
@@ -5734,6 +5734,34 @@ func (e *Executor) execAlterTable(stmt *sqlparser.AlterTable) (*Result, error) {
 				if td, _ := db.GetTable(tableName); td != nil {
 					td.ForeignKeys = append(td.ForeignKeys, fk)
 				}
+			} else if checkDef, ok := op.ConstraintDefinition.Details.(*sqlparser.CheckConstraintDefinition); ok {
+				// ADD CHECK(expr) or ADD CONSTRAINT name CHECK(expr)
+				name := op.ConstraintDefinition.Name.String()
+				if td, _ := db.GetTable(tableName); td != nil {
+					if name == "" {
+						// Auto-generate name: tableName_chk_N (next available index)
+						nextIdx := len(td.CheckConstraints) + 1
+						for {
+							candidate := fmt.Sprintf("%s_chk_%d", tableName, nextIdx)
+							taken := false
+							for _, cc := range td.CheckConstraints {
+								if strings.EqualFold(cc.Name, candidate) {
+									taken = true
+									break
+								}
+							}
+							if !taken {
+								name = candidate
+								break
+							}
+							nextIdx++
+						}
+					}
+					td.CheckConstraints = append(td.CheckConstraints, catalog.CheckConstraint{
+						Name: name,
+						Expr: sqlparser.String(checkDef.Expr),
+					})
+				}
 			}
 
 		case *sqlparser.DropKey:
@@ -5999,6 +6027,16 @@ func (e *Executor) execAlterTable(stmt *sqlparser.AlterTable) (*Result, error) {
 			// Rename in catalog (skip for no-op same-name renames)
 			if !isSameName {
 				def.Name = newName
+				// Rename auto-generated CHECK constraint names from oldTable_chk_N to newName_chk_N.
+				// Explicitly named constraints (those that don't match the auto-gen pattern) are preserved.
+				oldAutoPrefix := strings.ToLower(tableName) + "_chk_"
+				for i, cc := range def.CheckConstraints {
+					nameLower := strings.ToLower(cc.Name)
+					if strings.HasPrefix(nameLower, oldAutoPrefix) {
+						suffix := cc.Name[len(oldAutoPrefix):]
+						def.CheckConstraints[i].Name = newName + "_chk_" + suffix
+					}
+				}
 				db.DropTable(tableName) //nolint:errcheck
 				targetDB.CreateTable(def) //nolint:errcheck
 				// Rename in storage

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -2114,6 +2114,15 @@ func (e *Executor) Execute(query string) (res *Result, retErr error) {
 		upper = strings.ToUpper(strings.TrimSpace(query))
 	}
 
+	// Vitess parser silently drops inline CHECK constraints in ALTER TABLE ADD COLUMN clauses.
+	// MySQL allows: ALTER TABLE t ADD col INT CHECK(expr), OTHER_OP
+	// But vitess only parses up to "col INT" and drops everything else.
+	// Rewrite: ADD col type [attrs] CHECK(expr)[NOT ENFORCED] -> ADD col type [attrs], ADD CHECK(expr)[NOT ENFORCED]
+	if strings.HasPrefix(upper, "ALTER TABLE ") && strings.Contains(upper, "CHECK") {
+		query = rewriteAlterTableInlineChecks(query)
+		upper = strings.ToUpper(strings.TrimSpace(query))
+	}
+
 	stmt, err := e.parser().Parse(query)
 	if err != nil {
 		// Normalize whitespace runs inside `upper` so that statements with extra
@@ -8991,4 +9000,189 @@ func parseHandlerTarget(stmt string) (string, string, bool) {
 		return "", "", false
 	}
 	return first, second, true
+}
+
+// rewriteAlterTableInlineChecks rewrites ALTER TABLE statements that contain inline CHECK
+// constraints in ADD COLUMN clauses. Vitess v0.23.3 doesn't support the MySQL syntax
+// "ADD col INT CHECK(expr)" and silently drops the CHECK and all following options.
+// This function transforms "ADD col type [attrs] CHECK(expr) [NOT ENFORCED]" into
+// "ADD col type [attrs], ADD CHECK(expr) [NOT ENFORCED]" which vitess can parse correctly.
+//
+// Example:
+//
+//	ALTER TABLE t1 ADD f2 INT CHECK (f2 < 10), RENAME TO t6
+//	  → ALTER TABLE t1 ADD f2 INT, ADD CHECK (f2 < 10), RENAME TO t6
+func rewriteAlterTableInlineChecks(sql string) string {
+	// Quick check: must contain CHECK keyword to be relevant
+	if !strings.Contains(strings.ToUpper(sql), "CHECK") {
+		return sql
+	}
+
+	// Strategy: scan for CHECK keywords that are preceded by a column ADD clause
+	// (not by CONSTRAINT or direct ADD CHECK).
+	// We look for the pattern: ADD [COLUMN] ident type [attrs] CHECK(...)
+	// and transform it to: ADD [COLUMN] ident type [attrs], ADD CHECK(...)
+
+	offset := 0
+	for {
+		upperSuffix := strings.ToUpper(sql[offset:])
+		checkIdx := strings.Index(upperSuffix, "CHECK")
+		if checkIdx < 0 {
+			break
+		}
+		absCheck := offset + checkIdx
+
+		// Verify it's a word boundary
+		if absCheck > 0 {
+			prev := sql[absCheck-1]
+			if isIdentChar(prev) {
+				offset = absCheck + 5
+				continue
+			}
+		}
+		afterCheck := absCheck + 5
+		if afterCheck < len(sql) && isIdentChar(sql[afterCheck]) {
+			offset = afterCheck
+			continue
+		}
+
+		// CHECK must be followed by optional whitespace then '('
+		afterCheckStr := sql[afterCheck:]
+		trimmedAfterCheck := strings.TrimLeft(afterCheckStr, " \t\n\r")
+		if len(trimmedAfterCheck) == 0 || trimmedAfterCheck[0] != '(' {
+			offset = absCheck + 5
+			continue
+		}
+		wsLen := len(afterCheckStr) - len(trimmedAfterCheck)
+
+		// Now determine what precedes this CHECK. Find the last ADD keyword before this CHECK
+		// that is the start of a column ADD clause (not ADD CONSTRAINT/INDEX/etc).
+		// Scan backward from absCheck through the preceding SQL.
+		preceding := sql[:absCheck]
+		precedingUpper := strings.ToUpper(preceding)
+
+		// Find the last "ADD" keyword in the preceding SQL
+		// "ADD" must be a whole word (preceded by whitespace/comma, followed by whitespace)
+		lastAddPos := -1
+		searchUpper := precedingUpper
+		for {
+			idx := strings.LastIndex(searchUpper, "ADD")
+			if idx < 0 {
+				break
+			}
+			// Check word boundaries
+			addOK := true
+			if idx > 0 && isIdentChar(searchUpper[idx-1]) {
+				addOK = false
+			}
+			if idx+3 < len(searchUpper) && isIdentChar(searchUpper[idx+3]) {
+				addOK = false
+			}
+			if addOK {
+				lastAddPos = idx
+				break
+			}
+			// Continue searching before this position
+			if idx == 0 {
+				break
+			}
+			searchUpper = searchUpper[:idx]
+		}
+
+		if lastAddPos < 0 {
+			offset = absCheck + 5
+			continue
+		}
+
+		// Get what comes after the ADD keyword
+		afterADD := strings.TrimSpace(precedingUpper[lastAddPos+3:])
+
+		// Skip if this is ADD CONSTRAINT / ADD CHECK / ADD INDEX / ADD KEY / etc.
+		// These are already correct forms or unrelated to our pattern.
+		if strings.HasPrefix(afterADD, "CONSTRAINT") || strings.HasPrefix(afterADD, "CHECK") ||
+			strings.HasPrefix(afterADD, "INDEX") || strings.HasPrefix(afterADD, "KEY") ||
+			strings.HasPrefix(afterADD, "PRIMARY") || strings.HasPrefix(afterADD, "UNIQUE") ||
+			strings.HasPrefix(afterADD, "FULLTEXT") || strings.HasPrefix(afterADD, "SPATIAL") ||
+			strings.HasPrefix(afterADD, "FOREIGN") {
+			offset = absCheck + 5
+			continue
+		}
+
+		// Skip COLUMN keyword if present
+		if strings.HasPrefix(afterADD, "COLUMN ") || strings.HasPrefix(afterADD, "COLUMN\t") {
+			afterADD = strings.TrimSpace(afterADD[6:])
+		}
+
+		// afterADD should now start with an identifier (column name).
+		// If it doesn't start with a letter/underscore/backtick, skip.
+		if len(afterADD) == 0 || (!isIdentStart(rune(afterADD[0])) && afterADD[0] != '`') {
+			offset = absCheck + 5
+			continue
+		}
+
+		// Also verify CHECK is not preceded by '(' (e.g. inside another expression)
+		trimmedBefore := strings.TrimRight(sql[:absCheck], " \t\n\r")
+		if len(trimmedBefore) > 0 && trimmedBefore[len(trimmedBefore)-1] == '(' {
+			offset = absCheck + 5
+			continue
+		}
+
+		// Find the balanced-paren expression following CHECK
+		openAt := afterCheck + wsLen // position of '(' in original sql
+		depth := 0
+		closeAt := -1
+		for i := openAt; i < len(sql); i++ {
+			ch := sql[i]
+			if ch == '(' {
+				depth++
+			} else if ch == ')' {
+				depth--
+				if depth == 0 {
+					closeAt = i
+					break
+				}
+			} else if ch == '\'' {
+				// Skip string literal
+				i++
+				for i < len(sql) && sql[i] != '\'' {
+					if sql[i] == '\\' {
+						i++
+					}
+					i++
+				}
+			}
+		}
+		if closeAt < 0 {
+			offset = absCheck + 5
+			continue
+		}
+
+		// Check for optional NOT ENFORCED after the closing paren
+		afterClose := strings.TrimLeft(sql[closeAt+1:], " \t\n\r")
+		notEnforcedSuffix := ""
+		afterNotEnforced := closeAt + 1
+		if strings.HasPrefix(strings.ToUpper(afterClose), "NOT ENFORCED") {
+			notEnforcedSuffix = " NOT ENFORCED"
+			wsBeforeNE := len(sql[closeAt+1:]) - len(afterClose)
+			afterNotEnforced = closeAt + 1 + wsBeforeNE + len("NOT ENFORCED")
+		}
+
+		// Build replacement: trim whitespace before CHECK, insert ", ADD " before CHECK
+		insertBefore := strings.TrimRight(sql[:absCheck], " \t\n\r")
+		checkPart := sql[absCheck : closeAt+1] // "CHECK (...)"
+		rest := sql[afterNotEnforced:]
+
+		// If insertBefore already ends with a comma (e.g. due to a prior rewrite pass),
+		// just add " ADD " instead of ", ADD " to avoid double commas.
+		sep := ", ADD "
+		if len(insertBefore) > 0 && insertBefore[len(insertBefore)-1] == ',' {
+			sep = " ADD "
+		}
+		sql = insertBefore + sep + checkPart + notEnforcedSuffix + rest
+
+		// Continue scanning from after the rewritten CHECK
+		offset = len(insertBefore) + len(sep) + len(checkPart) + len(notEnforcedSuffix)
+	}
+
+	return sql
 }


### PR DESCRIPTION
## Summary
- Add pre-parse rewriter `rewriteAlterTableInlineChecks` in `executor.go` that transforms `ADD col type CHECK(expr)` → `ADD col type, ADD CHECK(expr)` in ALTER TABLE statements, working around a Vitess v0.23.3 parser limitation that silently drops everything after inline column CHECK constraints
- Implement `CheckConstraintDefinition` handling in `execAlterTable`'s `AddConstraintDefinition` case in `ddl.go`, storing check constraints with auto-generated names (`tablename_chk_N`)
- Update `RenameTableName` case in `execAlterTable` to rename auto-generated check constraint names (e.g. `t1_chk_N` → `t6_chk_N`) when renaming the table

## Root cause
Vitess v0.23.3 parser silently drops everything after `ADD col INT` when an inline CHECK appears (`ADD col INT CHECK(f2 < 10)`). This caused `ALTER TABLE t1 ADD f2 INT CHECK (f2 < 10), RENAME TO t6, ALGORITHM=COPY` to be parsed as just `ALTER TABLE t1` with no options, making RENAME TO silently disappear.

## Test plan
- [x] `go build ./... && go test ./... -count=1` passes
- [x] `other` suite: 263 pass vs baseline 259 (+4 improvements, 0 regressions)
  - Newly passing: `compare`, `ctype_mb`, `ctype_uca_myisam`, `parser_stack`
- [x] `other/check_constraints` progresses further (error moves past the RENAME TO failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)