### PR TITLE
fix(explain): inline nested IN-subquery body into outer semijoin chain

### DIFF
--- a/executor/explain.go
+++ b/executor/explain.go
@@ -73,6 +73,16 @@ type explainSelectType struct {
 	// EXPLAIN FORMAT=JSON emits a union_result block with
 	// using_temporary_table:false and no table_name/access_type keys.
 	isUnionAll bool
+	// inlineNestedIN marks a SUBQUERY/DEPENDENT SUBQUERY row that represents
+	// the body of a nested IN-subquery whose parent IN-subquery is itself
+	// being inlined (semijoin-flattened) into the outer query.  When set, the
+	// outer walkForSubqueries skips the NESTED_SUBQUERY marking, allowing the
+	// row to fall into the catch-all "non-SIMPLE → id=1 SIMPLE" branch in
+	// explainMultiRows post-processing, so MySQL-style 3+ table semijoin
+	// chains (e.g. `t1.a IN (SELECT pk FROM t10 WHERE t10.a IN (SELECT pk FROM t12))`)
+	// emit all tables as id=1 SIMPLE rather than splitting into separate
+	// SUBQUERY blocks.
+	inlineNestedIN bool
 }
 
 // explainMultiRows returns one or more EXPLAIN rows, detecting subqueries,
@@ -7427,6 +7437,17 @@ func (e *Executor) walkForSubqueries(node sqlparser.SQLNode, idCounter *int64, r
 						} else {
 							subRows[0].id = subQueryID
 						}
+						// Mark this row as a nested IN-subquery body when the parent IN
+						// is itself being inlined (selectType "SUBQUERY"/"DEPENDENT SUBQUERY"
+						// with no MATERIALIZED row).  This lets the outer walkForSubqueries
+						// skip the NESTED_SUBQUERY marker so the nested body inlines into
+						// the same id=1 SIMPLE chain (MySQL FirstMatch semijoin behavior
+						// for chained IN subqueries with eq_ref-able inner tables).
+						if inContext && !mergedMaterialized && !mergedDependent &&
+							(selectType == "SUBQUERY" || selectType == "DEPENDENT SUBQUERY") &&
+							outerCanSemijoin && e.isSemijoinEnabled() {
+							subRows[0].inlineNestedIN = true
+						}
 					}
 					// Mark nested scalar subquery rows (those NOT belonging to the IN
 					// subquery's own merged row, i.e. id != subQueryID) so the outer
@@ -7442,6 +7463,12 @@ func (e *Executor) walkForSubqueries(node sqlparser.SQLNode, idCounter *int64, r
 						for i := 1; i < len(subRows); i++ {
 							st := subRows[i].selectType
 							if st != "SUBQUERY" && st != "DEPENDENT SUBQUERY" {
+								continue
+							}
+							// Skip NESTED marking for rows tagged as nested-IN bodies —
+							// those should inline into the outer semijoin chain (id=1
+							// SIMPLE) via the catch-all post-processing branch.
+							if subRows[i].inlineNestedIN {
 								continue
 							}
 							if id, ok := subRows[i].id.(int64); ok {


### PR DESCRIPTION
## Summary

When the parent IN-subquery is itself being inlined as id=1 SIMPLE (selectType `SUBQUERY`/`DEPENDENT SUBQUERY`, no MATERIALIZED row), nested IN-subquery bodies were being marked as `NESTED_SUBQUERY` by `walkForSubqueries` and kept as separate `id=N SUBQUERY` blocks in the EXPLAIN output.

MySQL flattens these chains into a single `id=1 SIMPLE` join when both the outer and inner IN can be semijoin-flattened (e.g. eq_ref via PRIMARY KEY on the join col), producing 3+ table semijoin chains rather than nested SUBQUERY rows.

This adds an `inlineNestedIN` flag on `explainSelectType` that is set when an IN-context subquery's body is added by a recursive `walkForSubqueries` call whose own context indicates inline flattening. The outer marking loop skips rows carrying this flag so the catch-all post-processing folds them into the `id=1 SIMPLE` chain.

## KPI delta (FDL guard tests)

| Test | Before | After |
| --- | ---: | ---: |
| `other/explain_json_all` | line 1355 | line 1355 |
| `other/explain_json_none` | line 1256 | line 1256 |
| `other/subquery_sj_mat` | line 146 | **line 3378** |
| `other/subquery_sj_all` | line 142 | **line 3248** |
| `other/opt_hints_subquery` | line 97 | **line 107** |

Additional improvements observed in `other` suite:
- `subquery_sj_all_bka`: 143 → 3239
- `subquery_sj_all_bka_nixbnl`: 143 → 2151
- `subquery_sj_mat_bka`: 147 → 3379
- `subquery_sj_mat_bka_nixbnl`: 147 → 3379

Other suite head-to-head:
- Passed: 264 → 265 (`subselect_innodb` fail → pass)
- Failed: 312 → 311
- No regressions detected.

Refs #264

## Test plan

- [x] `go build ./...`
- [x] `go test ./... -count=1`
- [x] FDL guards verified: `explain_json_all >= 1355`, `explain_json_none >= 1256`, `subquery_sj_mat >= 146`, `subquery_sj_all >= 142`, `opt_hints_subquery >= 97`
- [x] `other` suite head-to-head vs main: pass count up by 1, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)