### PR TITLE
fix(explain): skip (col is not null) attached_condition for NOT NULL columns

### DIFF
--- a/executor/explain.go
+++ b/executor/explain.go
@@ -12695,8 +12695,31 @@ func (e *Executor) explainJSONDocument(query string) string {
 					return tblBlock
 				}
 			}
-			parts := make([]string, 0, len(cols))
-			for _, c := range cols {
+			// Filter out columns that are declared NOT NULL — the
+			// `(col is not null)` predicate is trivially true for them and
+			// MySQL omits the attached_condition entirely in that case.
+			td := e.explainGetTableDef(tblName)
+			filteredCols := cols
+			if td != nil {
+				filteredCols = filteredCols[:0]
+				for _, c := range cols {
+					nullable := true
+					for _, cd := range td.Columns {
+						if strings.EqualFold(cd.Name, c) {
+							nullable = cd.Nullable
+							break
+						}
+					}
+					if nullable {
+						filteredCols = append(filteredCols, c)
+					}
+				}
+			}
+			if len(filteredCols) == 0 {
+				return tblBlock
+			}
+			parts := make([]string, 0, len(filteredCols))
+			for _, c := range filteredCols {
 				parts = append(parts, fmt.Sprintf("(`%s`.`%s`.`%s` is not null)", matDBName, tblName, c))
 			}
 			cond := parts[0]


### PR DESCRIPTION
## Summary
- When MySQL materializes an IN-subquery and probes the outer table via eq_ref on `<auto_key>`, the outer table block normally carries `attached_condition: (col is not null)` to reflect the NULL-dropping nature of the probe.
- When that column is declared `NOT NULL`, MySQL omits the attached_condition entirely (predicate is trivially true).
- This change filters NOT NULL columns out of the injected predicate; if no nullable columns remain, no `attached_condition` is appended to the table block.

## KPI delta (FDL)
- subquery_sj_mat: 3378 -> 3791 (+413)
- subquery_sj_mat_bka: 3379 -> 3792 (+413)
- subquery_sj_mat_bka_nixbnl: 3379 -> 3521 (+142)
- subquery_sj_all: 3248 -> 3265 (+17)

FDL guards held:
- explain_json_all: 1355 (>=1355)
- explain_json_none: 1256 (>=1256)
- opt_hints_subquery: 107 (>=107)

## Test plan
- [x] `go build ./...`
- [x] `go test ./... -count=1` (all green)
- [x] `go run ./cmd/mtrrun -test other/explain_json_all,other/explain_json_none,other/subquery_sj_mat,other/subquery_sj_mat_bka,other/subquery_sj_all,other/opt_hints_subquery -force` (FDL guards verified)
- [x] Wider regression: full `other` suite, head-to-head with main shows 0 pass->fail regressions

Refs #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)