### PR TITLE
fix(index): normalize YEAR/TIME literals in IndexAccessSpec (salvaged)

### DIFF
--- a/executor/index_access.go
+++ b/executor/index_access.go
@@ -518,6 +518,31 @@ func normalizeLiteralForColumnType(v interface{}, colName string, td *catalog.Ta
 				return normalized + " 00:00:00"
 			}
 		}
+
+	case "YEAR":
+		// For YEAR columns, normalize 2-digit values to 4-digit form so that
+		// index lookups match the stored value. E.g. '05' -> "2005", 70 -> "1970".
+		if coerced := coerceYearValue(v); coerced != nil {
+			if s, ok := coerced.(string); ok && s != "" {
+				return s
+			}
+		}
+
+	case "TIME":
+		// For TIME columns, normalize integer HHMMSS literals and other time
+		// formats to "HH:MM:SS" so that index lookups match the stored value.
+		// E.g. int64(111127) -> "11:11:27", "080808" -> "08:08:08".
+		switch val := v.(type) {
+		case int64:
+			return parseMySQLTimeValue(strconv.FormatInt(val, 10))
+		case float64:
+			return parseMySQLTimeValue(strconv.FormatFloat(val, 'f', -1, 64))
+		case string:
+			// Only normalize if not already in HH:MM:SS format.
+			if !strings.Contains(val, ":") {
+				return parseMySQLTimeValue(val)
+			}
+		}
 	}
 
 	return v


### PR DESCRIPTION
## Summary

Salvaged from a Round 96 close-to-pass (sonnet) agent that completed the fix but didn't commit/push.

Extends `normalizeLiteralForColumnType` (added in #424 for DATE/DATETIME) to handle YEAR and TIME columns, fixing index lookups like `WHERE year_col='05'` and `WHERE time_col=111127`.

## KPI delta

- engine_iuds/update_year: fail → **pass**
- engine_iuds/update_time: fail → **pass**
- 25 lines added in executor/index_access.go

## Test plan

- [x] `go build ./...`
- [x] `go test ./... -count=1`
- [x] `go run ./cmd/mtrrun -test engine_iuds/update_year,engine_iuds/update_time -force` — both pass