### PR TITLE
fix(explain): omit (col is not null) attached_condition for ref-joined outer tables

### DIFF
--- a/executor/explain.go
+++ b/executor/explain.go
@@ -12685,9 +12685,17 @@ func (e *Executor) explainJSONDocument(query string) string {
 		if matDBName == "" {
 			matDBName = "test"
 		}
-		injectMatINNotNull := func(tblName string, tblBlock []orderedKV) []orderedKV {
+		injectMatINNotNull := func(tblName string, accessType string, tblBlock []orderedKV) []orderedKV {
 			cols := matINCols[strings.ToLower(tblName)]
 			if len(cols) == 0 {
+				return tblBlock
+			}
+			// MySQL only emits the `(col is not null)` attached_condition when
+			// the table is scanned (ALL/range/index) — for ref/eq_ref/const
+			// access types, the join key itself filters NULL values so the
+			// predicate is redundant and MySQL omits it.
+			switch strings.ToLower(accessType) {
+			case "ref", "eq_ref", "const", "system":
 				return tblBlock
 			}
 			for _, kv := range tblBlock {
@@ -12739,8 +12747,12 @@ func (e *Executor) explainJSONDocument(query string) string {
 			if strings.HasPrefix(tblName, "<subquery") {
 				continue
 			}
+			accessType := "ALL"
+			if p.row[4] != nil {
+				accessType = fmt.Sprintf("%v", p.row[4])
+			}
 			tblBlock := e.explainJSONTableBlock(p.row, query)
-			tblBlock = injectMatINNotNull(tblName, tblBlock)
+			tblBlock = injectMatINNotNull(tblName, accessType, tblBlock)
 			outerTableBlocks = append(outerTableBlocks, []orderedKV{{"table", tblBlock}})
 		}
 
@@ -12822,7 +12834,7 @@ func (e *Executor) explainJSONDocument(query string) string {
 				// In the non-BNL (eq_ref probe) case: all outer tables come BEFORE the subquery
 				isDependent := anySubqueryBNL && (accessType == "ref" || accessType == "eq_ref" || accessType == "const")
 				tblBlock := e.explainJSONTableBlock(p.row, query)
-				tblBlock = injectMatINNotNull(tblName, tblBlock)
+				tblBlock = injectMatINNotNull(tblName, accessType, tblBlock)
 				if isDependent {
 					dependentTables = append(dependentTables, []orderedKV{{"table", tblBlock}})
 				} else {


### PR DESCRIPTION
## Summary
- When MySQL materializes an IN-subquery and probes the outer table via `ref`/`eq_ref` on the materialized `<auto_key>`, the join key filters NULL outer values so MySQL omits the `(col is not null)` attached_condition that would otherwise be emitted on an `ALL`-scanned driver table.
- Mirror that behavior by skipping `injectMatINNotNull` for `ref`/`eq_ref`/`const`/`system` access types.

## KPI (FDL deltas, suite=other)
| Test | Before | After | Delta |
| --- | --- | --- | --- |
| subquery_sj_mat | 3791 | 8418 | +4627 |
| subquery_sj_mat_bka | 3792 | 8419 | +4627 |
| explain_json_all | 1355 | 1355 | hold |
| explain_json_none | 1256 | 1256 | hold |
| subquery_sj_all | 3265 | 3265 | hold |
| opt_hints_subquery | 107 | 107 | hold |

## Regression check
Full `other` suite (900 tests) head-to-head:
- pass→fail: **0**
- fail→pass: **0**
- FDL changes: only the two improvements above

## Test plan
- [x] `go build ./...`
- [x] `go test ./... -count=1`
- [x] `go run ./cmd/mtrrun -test other/explain_json_all,other/explain_json_none,other/subquery_sj_mat,other/subquery_sj_mat_bka,other/subquery_sj_all,other/opt_hints_subquery -force`
- [x] `go run ./cmd/mtrrun -suite other -j 1 -force` head-to-head with main

Refs #81