### PR TITLE
fix(explain): reorder 3-row nested IN inside materialized subquery

### DIFF
--- a/executor/explain.go
+++ b/executor/explain.go
@@ -11596,7 +11596,7 @@ type explainJSONNestedINJoinInfo struct {
 // equality condition between outer_t.col and inner_t.col.  When the pattern is
 // not detected, returns the rows unchanged and nil.
 func (e *Executor) explainJSONReorderNestedINMatRows(rows [][]interface{}, innerSQL string) ([][]interface{}, *explainJSONNestedINJoinInfo) {
-	if len(rows) != 2 {
+	if len(rows) != 2 && len(rows) != 3 {
 		return rows, nil
 	}
 	stmt, err := e.parser().Parse(innerSQL)
@@ -11607,8 +11607,9 @@ func (e *Executor) explainJSONReorderNestedINMatRows(rows [][]interface{}, inner
 	if !ok || sel.Where == nil {
 		return rows, nil
 	}
-	// Look for `outerCol IN (SELECT innerCol FROM innerTbl ...)` at the top level
-	// of the WHERE clause.  Walk both sides of any AND nodes.
+	// Look for `outerCol IN (SELECT innerCol FROM innerTbl ...)` or the
+	// row-IN form `(outerCol, ...) IN (SELECT innerCol, ... FROM ...)` at
+	// the top level of the WHERE clause.  Walk both sides of any AND nodes.
 	var outerCol *sqlparser.ColName
 	var innerSel *sqlparser.Select
 	var walk func(expr sqlparser.Expr)
@@ -11624,8 +11625,18 @@ func (e *Executor) explainJSONReorderNestedINMatRows(rows [][]interface{}, inner
 			if x.Operator != sqlparser.InOp {
 				return
 			}
-			lhs, lok := x.Left.(*sqlparser.ColName)
-			if !lok {
+			var lhs *sqlparser.ColName
+			switch l := x.Left.(type) {
+			case *sqlparser.ColName:
+				lhs = l
+			case sqlparser.ValTuple:
+				if len(l) > 0 {
+					if cn, cok := l[0].(*sqlparser.ColName); cok {
+						lhs = cn
+					}
+				}
+			}
+			if lhs == nil {
 				return
 			}
 			sub, sok := x.Right.(*sqlparser.Subquery)
@@ -11644,10 +11655,11 @@ func (e *Executor) explainJSONReorderNestedINMatRows(rows [][]interface{}, inner
 	if outerCol == nil || innerSel == nil {
 		return rows, nil
 	}
-	// Identify outer table from the outer SELECT's FROM list.
+	// Identify outer table from the outer SELECT's FROM list.  Use display
+	// names (alias when present) to align with EXPLAIN row's `table` column.
 	outerTbl := ""
 	for _, te := range sel.From {
-		for _, n := range e.extractAllTableNames(te) {
+		for _, n := range e.extractAllTableDisplayNames(te) {
 			outerTbl = n
 			break
 		}
@@ -11656,15 +11668,15 @@ func (e *Executor) explainJSONReorderNestedINMatRows(rows [][]interface{}, inner
 		}
 	}
 	// Identify inner SELECT's first SELECT-list ColName for innerCol; identify
-	// inner table from the inner SELECT's FROM list.
+	// inner table(s) from the inner SELECT's FROM list (alias-aware).
 	innerTbl := ""
+	var innerTbls []string
 	for _, te := range innerSel.From {
-		for _, n := range e.extractAllTableNames(te) {
-			innerTbl = n
-			break
-		}
-		if innerTbl != "" {
-			break
+		for _, n := range e.extractAllTableDisplayNames(te) {
+			if innerTbl == "" {
+				innerTbl = n
+			}
+			innerTbls = append(innerTbls, n)
 		}
 	}
 	if outerTbl == "" || innerTbl == "" {
@@ -11704,6 +11716,40 @@ func (e *Executor) explainJSONReorderNestedINMatRows(rows [][]interface{}, inner
 		return strings.ToLower(fmt.Sprintf("%v", r[2]))
 	}
 	outerLower := strings.ToLower(outerTbl)
+
+	// 3-row case: outer_t plus a multi-table inner SELECT (e.g. inner_t LEFT
+	// JOIN inner2_t).  MySQL flattens the nested IN via semijoin and emits
+	// the inner tables first inside the materialized subquery's nested_loop,
+	// followed by the outer table that joins them via the IN equality.
+	// Reorder by table-name set; if rows do not partition cleanly into
+	// {outer_t} ∪ {innerTbls}, bail out.  Do not attach BNL joinInfo —
+	// access metadata for the 3-row case is more involved than the 2-row
+	// case and is left for a follow-up.
+	if len(rows) == 3 {
+		if len(innerTbls) != 2 {
+			return rows, nil
+		}
+		byName := map[string][]interface{}{}
+		for _, r := range rows {
+			byName[rowName(r)] = r
+		}
+		outerRow, ok1 := byName[outerLower]
+		var innerRows [][]interface{}
+		for _, t := range innerTbls {
+			r, ok := byName[strings.ToLower(t)]
+			if !ok {
+				return rows, nil
+			}
+			innerRows = append(innerRows, r)
+		}
+		if !ok1 || outerRow == nil {
+			return rows, nil
+		}
+		ordered := append([][]interface{}{}, innerRows...)
+		ordered = append(ordered, outerRow)
+		return ordered, nil
+	}
+
 	innerLower := strings.ToLower(innerTbl)
 	r0 := rowName(rows[0])
 	r1 := rowName(rows[1])

--- a/executor/explain_nested_in_mat_3rows_test.go
+++ b/executor/explain_nested_in_mat_3rows_test.go
@@ -1,0 +1,62 @@
+package executor
+
+import (
+	"testing"
+
+	"github.com/myuon/mylite/catalog"
+	"github.com/myuon/mylite/storage"
+)
+
+// TestExplainJSONReorderNestedINMat3Rows: when a materialized subquery
+// body has 3 rows from a nested `(outer.col, ...) IN (SELECT inner.col,
+// ... FROM inner_t LEFT JOIN inner2_t ON ...)`, MySQL emits the inner
+// tables before the outer table inside the materialized subquery's
+// nested_loop.  The reorder helper must rearrange the tabular order
+// (outer, inner1, inner2) to (inner1, inner2, outer).
+func TestExplainJSONReorderNestedINMat3Rows(t *testing.T) {
+	cat := catalog.New()
+	store := storage.NewEngine()
+	e := New(cat, store)
+	e.CurrentDB = "test"
+	innerSQL := `SELECT grandparent1.col_int_nokey AS g1
+FROM t1 AS grandparent1
+WHERE (grandparent1.col_int_nokey, grandparent1.col_int_key) IN
+(SELECT parent1.col_int_key AS p1, parent1.col_int_key AS p2
+ FROM t1 AS parent1
+ LEFT JOIN t2 AS parent2
+ ON parent1.col_int_nokey = parent2.col_int_key)
+AND grandparent1.col_int_key <> 3`
+
+	// Tabular row layout: id, selectType, table, partitions, accessType,
+	// possibleKeys, key, keyLen, ref, rows, filtered, extra
+	mkRow := func(name string) []interface{} {
+		return []interface{}{
+			int64(2), "MATERIALIZED", name, nil, "ALL",
+			nil, nil, nil, nil, int64(11), 100.0, "",
+		}
+	}
+	rows := [][]interface{}{
+		mkRow("grandparent1"),
+		mkRow("parent1"),
+		mkRow("parent2"),
+	}
+	out, info := e.explainJSONReorderNestedINMatRows(rows, innerSQL)
+	if len(out) != 3 {
+		t.Fatalf("expected 3 rows; got %d", len(out))
+	}
+	got := []string{
+		out[0][2].(string),
+		out[1][2].(string),
+		out[2][2].(string),
+	}
+	wantOrder := []string{"parent1", "parent2", "grandparent1"}
+	for i := range wantOrder {
+		if got[i] != wantOrder[i] {
+			t.Errorf("position %d: want %s, got %s (full: %v)", i, wantOrder[i], got[i], got)
+		}
+	}
+	// joinInfo must be nil for the 3-row case (no BNL injection on parent2).
+	if info != nil {
+		t.Errorf("expected joinInfo nil for 3-row reorder, got %+v", info)
+	}
+}


### PR DESCRIPTION
## Summary
- Extends `explainJSONReorderNestedINMatRows` to handle the 3-row case where a materialized subquery body contains a nested `(outer.col, ...) IN (SELECT inner.col, ... FROM inner_t LEFT JOIN inner2_t ON ...)`. Previously the helper returned rows unchanged for 3-row bodies, leaking the tabular order (outer first) into JSON output.
- Accepts row-IN (`ValTuple` LHS) in addition to scalar IN, and looks up table names by their display alias so the matching aligns with EXPLAIN's `table` column (which uses aliases).
- Adds a unit test (`TestExplainJSONReorderNestedINMat3Rows`) exercising the new branch directly with a hand-built row set.

Access metadata (`possible_keys` / `ref` / `using_index` / BNL) is **not** yet emitted for the 3-row case; that requires planner-level work and is left for a follow-up. The reorder alone moves the first-diff line forward by 2 lines on the affected tests.

## KPI delta (other suite, j=1, 900 tests)

|test|before|after|
|---|---|---|
|subquery_sj_mat first-diff-line|8418|**8420**|
|subquery_sj_mat_bka first-diff-line|8419|**8421**|
|explain_json_all FDL guard|1355|1355 (held)|
|explain_json_none FDL guard|1256|1256 (held)|
|opt_hints_subquery FDL guard|107|107 (held)|
|subquery_sj_all FDL guard|3265|3265 (held)|

Pass / fail / error totals unchanged in the `other` suite (only `sp-threads` flapped fail↔error, a known flaky test). No FDL regressions.

## Test plan
- [x] `go build ./...`
- [x] `go test ./... -count=1`
- [x] `go run ./cmd/mtrrun -test other/explain_json_all,other/explain_json_none,other/subquery_sj_mat,other/subquery_sj_mat_bka,other/subquery_sj_all,other/opt_hints_subquery -force`
- [x] `go run ./cmd/mtrrun -suite other -j 1 -force` head-to-head with main

Refs #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)