### PR TITLE
fix: decode 8-bit charset introduced hex literals to UTF-8

### DIFF
--- a/executor/expr_eval.go
+++ b/executor/expr_eval.go
@@ -18,6 +18,7 @@ import (
 	"github.com/myuon/mylite/storage"
 	"golang.org/x/text/encoding"
 	"golang.org/x/text/encoding/japanese"
+	"golang.org/x/text/transform"
 	"golang.org/x/text/unicode/norm"
 	"vitess.io/vitess/go/mysql/collations"
 	"vitess.io/vitess/go/mysql/collations/charset"
@@ -2516,8 +2517,19 @@ func (e *Executor) evalIntroducerExpr(v *sqlparser.IntroducerExpr) (interface{},
 			}
 			return HexBytes(strings.ToUpper(hex.EncodeToString(bs))), nil
 		default:
-			// For other charsets (latin1, sjis, etc.), return raw bytes as-is.
-			// The existing JP charset conversion tests rely on this behavior.
+			// For 8-bit charsets (latin1, koi8r, cp1250, etc.), decode raw bytes to
+			// proper UTF-8 so that comparisons against UTF-8 columns work correctly.
+			// For multi-byte JP charsets (sjis, ujis), return raw bytes as-is because
+			// the existing JP charset conversion tests rely on that behavior.
+			if cs != "sjis" && cs != "ujis" && cs != "eucjpms" && cs != "cp932" {
+				dec := charsetDecoder(cs)
+				if dec != nil {
+					decoded, _, err := transform.String(dec, string(bs))
+					if err == nil {
+						return decoded, nil
+					}
+				}
+			}
 			return string(bs), nil
 		}
 	}


### PR DESCRIPTION
## Summary

- Fix `evalIntroducerExpr` to properly decode charset-introduced hex literals (e.g. `_latin1 x'C4C4C4C4'`, `_koi8r x'C3C3C3C3'`) through their respective charset decoder to produce correct UTF-8 strings
- Multi-byte JP charsets (sjis, ujis, eucjpms, cp932) retain the existing raw-bytes behavior to preserve passing JP charset tests
- Improves `func_in_all/none/icp/mrr/icp_mrr/mrr_cost` first-diff-line from ~157 to ~398 (+241 each)

## Test plan

- [x] `go build ./... && go test ./... -count=1` passes
- [x] Full mtrrun: Passed=1820, Regressions=0
- [x] FDL guards: explain_json_all=1355 ✓, explain_json_none=1256 ✓, subquery_sj_mat=8420 ✓, subquery_sj_all=3265 ✓
- [x] func_in_all FDL: 157 → 398 (+241)
- [x] func_in_none FDL: 156 → 397 (+241)
- [x] func_in_icp/mrr/icp_mrr/mrr_cost FDL: 157 → 398 (+241)

🤖 Generated with [Claude Code](https://claude.com/claude-code)