### PR TITLE
fix: round float/decimal literals in YEAR column comparisons

### DIFF
--- a/executor/typeutil.go
+++ b/executor/typeutil.go
@@ -722,6 +722,33 @@ func normalizeYearComparisonTyped(ls, rs string, origLeft, origRight interface{}
 		li = convertSmallYear(li)
 		return fmt.Sprintf("%d", li), rs
 	}
+
+	// MySQL rounds float/decimal values when comparing with YEAR columns.
+	// e.g., YEAR_col = 1999.1 → compare as 1999, YEAR_col = 1998.9 → compare as 1999.
+	// This applies when one side is a YEAR-like 4-digit integer string (from column)
+	// and the other side is a decimal literal string with fractional part.
+	isYearIntString := func(s string) bool {
+		// Must be a pure integer string (no decimal point, no sign complications)
+		if strings.ContainsAny(s, ".eE") {
+			return false
+		}
+		n, err := strconv.Atoi(s)
+		if err != nil {
+			return false
+		}
+		return isYearLike(n)
+	}
+	hasFractionalPart := func(f float64) bool {
+		return f != math.Trunc(f)
+	}
+	if isYearIntString(ls) && strings.ContainsRune(rs, '.') && hasFractionalPart(rf) {
+		rounded := int(math.Round(rf))
+		return ls, fmt.Sprintf("%d", rounded)
+	}
+	if isYearIntString(rs) && strings.ContainsRune(ls, '.') && hasFractionalPart(lf) {
+		rounded := int(math.Round(lf))
+		return fmt.Sprintf("%d", rounded), rs
+	}
 	return ls, rs
 }
 


### PR DESCRIPTION
## Summary

- Add rounding of fractional decimal literals in `normalizeYearComparisonTyped` when comparing against YEAR-like values
- MySQL semantics: `WHERE yy = 1999.1` rounds to `WHERE yy = 1999`, `WHERE yy = 1998.9` rounds to `WHERE yy = 1999`
- Improves `other/type_year` FDL from **139 to 153** (no regressions, all FDL guards maintained)

## Technical Details

When a YEAR column value (stored as an integer string like `"1999"`) is compared to a decimal literal with a fractional part (like `"1999.1"`), MySQL rounds the decimal to the nearest integer. The fix detects this pattern in `normalizeYearComparisonTyped`: if one side is a year-like integer string (no decimal point) and the other has a fractional part, the fractional side is rounded before comparison.

The guard requires both: a decimal point in the string representation AND a non-zero fractional part (via `hasFractionalPart`), so values like `2000.0` (whole number) are not affected.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./... -count=1` passes
- [x] `other/type_year` FDL improved: 139 → 153
- [x] Zero regressions vs baseline (Passed: 1822, same as before)
- [x] FDL guards all maintained: explain_json_all ≥ 1355, explain_json_none ≥ 1256, subquery_sj_mat ≥ 8435, subquery_sj_all ≥ 3265, opt_hints_subquery ≥ 107

🤖 Generated with [Claude Code](https://claude.com/claude-code)