### PR TITLE
feat: charset/collation improvements for default_collation_for_utf8mb4

### DIFF
--- a/cmd/mtrrun/skiplist.json
+++ b/cmd/mtrrun/skiplist.json
@@ -3469,10 +3469,6 @@
       "reason": "needs charset conversion for result encoding"
     },
     {
-      "test": "sys_vars/default_collation_for_utf8mb4",
-      "reason": "collation function differences"
-    },
-    {
       "test": "perfschema/all_tests",
       "reason": "output mismatch, timeout, or error"
     },

--- a/executor/ddl.go
+++ b/executor/ddl.go
@@ -450,7 +450,7 @@ func (e *Executor) execCreateDatabase(stmt *sqlparser.CreateDatabase) (*Result, 
 	// - When charset came from character_set_server: use collation_server (preserving server defaults).
 	if collation == "" {
 		if explicitCharset && charset != "" {
-			collation = catalog.DefaultCollationForCharset(charset)
+			collation = e.getDefaultCollationForCharset(charset)
 		}
 		if collation == "" {
 			if collVal, ok := e.getSysVarSession("collation_server"); ok && collVal != "" {
@@ -529,7 +529,7 @@ func (e *Executor) execAlterDatabase(stmt *sqlparser.AlterDatabase) (*Result, er
 			}
 			db.CharacterSet = csVal
 			// Update collation to default for the new charset
-			db.CollationName = catalog.DefaultCollationForCharset(csVal)
+			db.CollationName = e.getDefaultCollationForCharset(csVal)
 		case sqlparser.CollateType:
 			collVal := strings.ToLower(strings.Trim(opt.Value, "'\""))
 			if !isKnownCollation(collVal) {
@@ -718,7 +718,7 @@ func (e *Executor) execAlterDatabaseRaw(query string) (*Result, error) {
 		if len(csFields) > 0 {
 			charset := strings.ToLower(csFields[0])
 			db.CharacterSet = charset
-			db.CollationName = catalog.DefaultCollationForCharset(charset)
+			db.CollationName = e.getDefaultCollationForCharset(charset)
 		}
 	}
 	// Extract COLLATE
@@ -1355,7 +1355,7 @@ func (e *Executor) execCreateTable(stmt *sqlparser.CreateTable) (*Result, error)
 			csLower := strings.ToLower(col.Type.Charset.Name)
 			if csLower != "binary" {
 				colDef.Charset = csLower
-				colDef.Collation = catalog.DefaultCollationForCharset(colDef.Charset)
+				colDef.Collation = e.getDefaultCollationForCharset(colDef.Charset)
 				colDef.CharsetExplicit = true // user explicitly wrote CHARACTER SET
 			}
 		} else if col.Type.Charset.Binary {
@@ -1403,8 +1403,11 @@ func (e *Executor) execCreateTable(stmt *sqlparser.CreateTable) (*Result, error)
 			colDef.Collation = collLower
 			// If no charset was set explicitly, derive it from the collation.
 			// Only set charset for character types; numeric/temporal types don't carry charset.
+			// When charset is derived from an explicit COLLATE clause, treat it as explicit
+			// so that SHOW CREATE TABLE always shows CHARACTER SET + COLLATE (MySQL behavior).
 			if colDef.Charset == "" && columnTypeSupportsCharset(colDef.Type) {
 				colDef.Charset = collCharset
+				colDef.CharsetExplicit = true // charset derived from explicit COLLATE clause
 			}
 		}
 		if tUpper := strings.ToUpper(strings.TrimSpace(colDef.Type)); strings.HasPrefix(tUpper, "BIT(") {
@@ -2324,9 +2327,9 @@ func (e *Executor) execCreateTable(stmt *sqlparser.CreateTable) (*Result, error)
 	}
 	// If charset was set but collation was not, always derive collation for that charset.
 	if charsetSpecified && !collationSpecified {
-		def.Collation = catalog.DefaultCollationForCharset(def.Charset)
+		def.Collation = e.getDefaultCollationForCharset(def.Charset)
 	} else if def.Charset != "" && def.Collation == "" {
-		def.Collation = catalog.DefaultCollationForCharset(def.Charset)
+		def.Collation = e.getDefaultCollationForCharset(def.Charset)
 	}
 
 	// Validate maximum row size (ER_TOO_BIG_ROWSIZE = 1118).
@@ -3849,6 +3852,7 @@ func columnDefFromAST(col *sqlparser.ColumnDefinition) catalog.ColumnDef {
 		if colDef.Charset == "" {
 			if collCharset, ok := catalog.CharsetForCollation(collLower); ok {
 				colDef.Charset = collCharset
+				colDef.CharsetExplicit = true // charset derived from explicit COLLATE clause
 			}
 		}
 	}
@@ -4589,6 +4593,7 @@ func (e *Executor) execAlterTable(stmt *sqlparser.AlterTable) (*Result, error) {
 					}
 				}
 				colDef := columnDefFromAST(col)
+				e.applyDefaultCollationToColDef(&colDef)
 				// Extract and validate SRID constraint for ADD COLUMN.
 				if sridErr := e.alterApplySRID(col, &colDef); sridErr != nil {
 					return nil, sridErr
@@ -4876,6 +4881,7 @@ func (e *Executor) execAlterTable(stmt *sqlparser.AlterTable) (*Result, error) {
 
 		case *sqlparser.ModifyColumn:
 			colDef := columnDefFromAST(op.NewColDefinition)
+			e.applyDefaultCollationToColDef(&colDef)
 			// MODIFY COLUMN cannot make a primary-key column explicitly nullable.
 			// Only reject when NULL was explicitly written in the definition; if
 			// the user omitted it, MySQL silently keeps the column NOT NULL.
@@ -5073,6 +5079,7 @@ func (e *Executor) execAlterTable(stmt *sqlparser.AlterTable) (*Result, error) {
 		case *sqlparser.ChangeColumn:
 			oldName := op.OldColumn.Name.String()
 			colDef := columnDefFromAST(op.NewColDefinition)
+			e.applyDefaultCollationToColDef(&colDef)
 			// CHANGE COLUMN cannot make a primary-key column explicitly nullable.
 			// Only reject when NULL was explicitly written in the definition; if
 			// the user omitted it, MySQL silently keeps the column NOT NULL.
@@ -5926,7 +5933,7 @@ func (e *Executor) execAlterTable(stmt *sqlparser.AlterTable) (*Result, error) {
 						}
 						tableDef.Charset = newCharset
 						// Reset collation to default for the new charset (may be overridden by COLLATE option).
-						tableDef.Collation = catalog.DefaultCollationForCharset(newCharset)
+						tableDef.Collation = e.getDefaultCollationForCharset(newCharset)
 					}
 				case "COLLATE":
 					// ALTER TABLE ... COLLATE=newcoll

--- a/executor/display.go
+++ b/executor/display.go
@@ -117,13 +117,14 @@ func normalizeSQLDisplayName(s string) string {
 
 // normalizeCharsetIntroducers normalizes charset introducers in column display names.
 // The sqlparser converts _utf8 to _utf8mb3 and adds a space before the literal.
-// MySQL displays these as _utf8'...' without space.
+// MySQL displays these as _utf8'...' without space for _utf8mb3.
+// However, _utf8mb4 preserves any space that was in the original SQL query.
 func normalizeCharsetIntroducers(s string) string {
-	// Replace _utf8mb3 ' with _utf8'
+	// Replace _utf8mb3 ' with _utf8' (sqlparser always adds space; MySQL shows no space)
 	s = strings.ReplaceAll(s, "_utf8mb3 '", "_utf8'")
 	s = strings.ReplaceAll(s, "_utf8mb3'", "_utf8'")
-	// Also handle other common alias pairs
-	s = strings.ReplaceAll(s, "_utf8mb4 '", "_utf8mb4'")
+	// NOTE: Do NOT strip the space from "_utf8mb4 '" here.
+	// MySQL preserves the space in COLLATION(_utf8mb4 'a') column headers.
 	return s
 }
 

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -469,6 +469,10 @@ type Executor struct {
 	// "SHOW CREATE DATABASE IF NOT EXISTS db", so that execShow can include the
 	// /*!32312 IF NOT EXISTS*/ comment in the Create Database column value.
 	showCreateDBIfNotExists bool
+	// pendingNamesCollation holds the explicit COLLATE clause from "SET NAMES charset COLLATE coll".
+	// The vitess parser drops the COLLATE clause, so preprocessQuery extracts it and stores
+	// it here. execSet then applies it to collation_connection after setting NAMES.
+	pendingNamesCollation string
 	// onDupValuesRow holds the candidate INSERT row while evaluating
 	// ON DUPLICATE KEY UPDATE expressions (for VALUES(col) support).
 	onDupValuesRow storage.Row
@@ -854,6 +858,32 @@ func (e *Executor) getSysVar(name string) (string, bool) {
 		return v, true
 	}
 	return "", false
+}
+
+// getDefaultCollationForCharset returns the default collation for a charset,
+// respecting the current session's default_collation_for_utf8mb4 setting.
+// For utf8mb4, if default_collation_for_utf8mb4 is set to utf8mb4_general_ci,
+// that value is returned instead of the compiled default utf8mb4_0900_ai_ci.
+func (e *Executor) getDefaultCollationForCharset(charset string) string {
+	defColl := catalog.DefaultCollationForCharset(charset)
+	if strings.ToLower(charset) == "utf8mb4" {
+		if dcfu, ok := e.getSysVar("default_collation_for_utf8mb4"); ok && dcfu != "" {
+			defColl = dcfu
+		}
+	}
+	return defColl
+}
+
+// applyDefaultCollationToColDef updates a ColumnDef's collation to respect the current
+// default_collation_for_utf8mb4 setting. This is needed for ALTER TABLE column operations
+// where columnDefFromAST (a standalone function) uses the catalog default directly.
+func (e *Executor) applyDefaultCollationToColDef(colDef *catalog.ColumnDef) {
+	if strings.ToLower(colDef.Charset) == "utf8mb4" && colDef.Collation != "" {
+		// Only override if the collation is the catalog default (i.e., not explicitly set by user)
+		if strings.EqualFold(colDef.Collation, catalog.DefaultCollationForCharset("utf8mb4")) {
+			colDef.Collation = e.getDefaultCollationForCharset("utf8mb4")
+		}
+	}
 }
 
 // getSysVarGlobal reads a global-scoped system variable.

--- a/executor/func_misc.go
+++ b/executor/func_misc.go
@@ -217,13 +217,19 @@ func evalMiscFunc(e *Executor, name string, v *sqlparser.FuncExpr, row *storage.
 		if len(v.Exprs) < 1 {
 			return nil, true, nil
 		}
+		// Handle explicit COLLATE clause: _utf8mb4 'b' COLLATE utf8mb4_0900_ai_ci
+		// is parsed as CollateExpr{Collation: "utf8mb4_0900_ai_ci", Expr: IntroducerExpr{...}}
+		// The COLLATION() function should return the explicit collation name directly.
+		if ce, ok := v.Exprs[0].(*sqlparser.CollateExpr); ok {
+			return strings.ToLower(ce.Collation), true, nil
+		}
 		if cue, ok := v.Exprs[0].(*sqlparser.ConvertUsingExpr); ok {
 			cs := strings.ToLower(cue.Type)
 			switch cs {
 			case "utf8", "utf8mb3":
 				return "utf8mb3_general_ci", true, nil
 			case "utf8mb4":
-				return "utf8mb4_0900_ai_ci", true, nil
+				return e.getDefaultCollationForCharset("utf8mb4"), true, nil
 			case "latin1":
 				return "latin1_swedish_ci", true, nil
 			case "binary":
@@ -239,7 +245,7 @@ func evalMiscFunc(e *Executor, name string, v *sqlparser.FuncExpr, row *storage.
 			case "utf8", "utf8mb3":
 				return "utf8_general_ci", true, nil
 			case "utf8mb4":
-				return "utf8mb4_0900_ai_ci", true, nil
+				return e.getDefaultCollationForCharset("utf8mb4"), true, nil
 			case "latin1":
 				return "latin1_swedish_ci", true, nil
 			case "binary":
@@ -262,7 +268,7 @@ func evalMiscFunc(e *Executor, name string, v *sqlparser.FuncExpr, row *storage.
 				case "utf8", "utf8mb3":
 					return "utf8mb3_general_ci", true, nil
 				case "utf8mb4":
-					return "utf8mb4_0900_ai_ci", true, nil
+					return e.getDefaultCollationForCharset("utf8mb4"), true, nil
 				case "latin1":
 					return "latin1_swedish_ci", true, nil
 				case "binary":
@@ -281,7 +287,7 @@ func evalMiscFunc(e *Executor, name string, v *sqlparser.FuncExpr, row *storage.
 				return "utf8_general_ci", true, nil
 			}
 		}
-		return "utf8mb4_0900_ai_ci", true, nil
+		return e.getDefaultCollationForCharset("utf8mb4"), true, nil
 	case "least":
 		if len(v.Exprs) < 2 {
 			return nil, true, fmt.Errorf("LEAST requires at least 2 arguments")

--- a/executor/preprocess.go
+++ b/executor/preprocess.go
@@ -1267,8 +1267,29 @@ func (e *Executor) preprocessQuery(query string) (string, *Result, error) {
 		query = "DROP TEMPORARY TABLE " + query[len("DROP TEMPORARY TABLES "):]
 	}
 
+	// The vitess parser drops the COLLATE clause from "SET NAMES charset COLLATE coll".
+	// Detect this pattern, strip the COLLATE part so vitess can parse it, and save the
+	// explicit collation in pendingNamesCollation for execSet to apply afterwards.
+	e.pendingNamesCollation = ""
+	if strings.HasPrefix(upper, "SET NAMES ") {
+		if m := reSetNamesCollate.FindStringSubmatch(upper); m != nil {
+			// m[1] is the collation name
+			e.pendingNamesCollation = strings.ToLower(m[1])
+			// Strip the " COLLATE <coll>" suffix from the query
+			collateIdx := strings.Index(upper, " COLLATE ")
+			if collateIdx >= 0 {
+				query = strings.TrimSpace(trimmed[:collateIdx])
+				upper = strings.ToUpper(query)
+				trimmed = query
+			}
+		}
+	}
+
 	return query, nil, nil
 }
+
+// reSetNamesCollate matches "SET NAMES <charset> COLLATE <collation>" and captures the collation name.
+var reSetNamesCollate = regexp.MustCompile(`(?i)^SET\s+NAMES\s+\S+\s+COLLATE\s+(\S+)$`)
 
 // extractFunctionArgList finds the first occurrence of fnName( in query (case-insensitive)
 // and returns the string between the opening and matching closing parentheses.

--- a/executor/variables.go
+++ b/executor/variables.go
@@ -232,7 +232,15 @@ func (e *Executor) execSet(stmt *sqlparser.Set) (*Result, error) {
 				delete(e.sessionScopeVars, "character_set_client")
 				delete(e.sessionScopeVars, "character_set_connection")
 				delete(e.sessionScopeVars, "character_set_results")
-				delete(e.sessionScopeVars, "collation_connection")
+				// For SET NAMES DEFAULT, we need to check if default_collation_for_utf8mb4
+				// overrides the default utf8mb4 collation for collation_connection.
+				// The default charset for SET NAMES DEFAULT is utf8mb4.
+				if dcfu := e.getDefaultCollationForCharset("utf8mb4"); dcfu != "utf8mb4_0900_ai_ci" {
+					// Override: use default_collation_for_utf8mb4 instead of compiled default
+					e.sessionScopeVars["collation_connection"] = dcfu
+				} else {
+					delete(e.sessionScopeVars, "collation_connection")
+				}
 			} else if charset != "binary" && !isKnownCharset(charset) {
 				return nil, mysqlError(1115, "42000", fmt.Sprintf("Unknown character set: '%s'", charset))
 			} else if isNonClientCharset(charset) {
@@ -244,8 +252,16 @@ func (e *Executor) execSet(stmt *sqlparser.Set) (*Result, error) {
 				e.sessionScopeVars["character_set_results"] = charset
 				// Also set collation_connection to the default collation for this charset.
 				// MySQL's SET NAMES also updates collation_connection.
-				if defColl := catalog.DefaultCollationForCharset(charset); defColl != "" {
+				// For utf8mb4, respect the current default_collation_for_utf8mb4 setting.
+				if defColl := e.getDefaultCollationForCharset(charset); defColl != "" {
 					e.sessionScopeVars["collation_connection"] = defColl
+				}
+				// If SET NAMES had an explicit COLLATE clause (e.g. SET NAMES utf8mb4 COLLATE utf8mb4_0900_ai_ci),
+				// override collation_connection with the explicit collation.
+				// The vitess parser drops the COLLATE clause, so it was saved in pendingNamesCollation.
+				if e.pendingNamesCollation != "" {
+					e.sessionScopeVars["collation_connection"] = e.pendingNamesCollation
+					e.pendingNamesCollation = ""
 				}
 			}
 		case "charset":


### PR DESCRIPTION
## Summary

- Fix `COLLATION()` function to handle `CollateExpr` — e.g., `COLLATION(_utf8mb4 'b' COLLATE utf8mb4_0900_ai_ci)` now correctly returns `utf8mb4_0900_ai_ci`
- Support `SET NAMES charset COLLATE collation` — vitess parser drops the COLLATE clause, so we intercept it in `preprocessQuery` and apply to `collation_connection` after `SET NAMES` processing
- Fix `SHOW CREATE TABLE` to show `CHARACTER SET + COLLATE` when a column has an explicit COLLATE clause (set `CharsetExplicit=true` when charset is derived from explicit COLLATE)
- Remove `sys_vars/default_collation_for_utf8mb4` from skiplist; FDL improved from line 25 to line 187 (remaining failure at line 187 is `//` vs `;` delimiter echo due to runner.go limitation)

## Test plan

- [ ] `go build ./... && go test ./... -count=1` passes
- [ ] Full mtrrun suite: 1822 passes maintained (no regressions)
- [ ] FDL guards maintained: subquery_sj_mat ≥ 8435, explain_json_all ≥ 1355, explain_json_none ≥ 1256
- [ ] `default_collation_for_utf8mb4` test FDL at line 187 (up from 25)

Closes #390

🤖 Generated with [Claude Code](https://claude.com/claude-code)