### PR TITLE
fix: correct TIMESTAMP NULL handling in INSERT/UPDATE/ALTER TABLE

### DIFF
--- a/executor/ddl.go
+++ b/executor/ddl.go
@@ -5041,13 +5041,33 @@ func (e *Executor) execAlterTable(stmt *sqlparser.AlterTable) (*Result, error) {
 				if isVarcharOrChar {
 					newMaxLen = extractCharLength(colDef.Type)
 				}
+				// For TIMESTAMP NOT NULL columns, use current timestamp when converting
+				// NULL existing values during ALTER TABLE MODIFY. MySQL uses the session
+				// current_timestamp for all TIMESTAMP NOT NULL null-to-value conversions,
+				// regardless of the column's explicit DEFAULT value.
+				nullToTimestamp := ""
+				if !colDef.Nullable {
+					colTypeUpper := strings.ToUpper(strings.TrimSpace(colDef.Type))
+					colTypeBase := colTypeUpper
+					if idx := strings.IndexByte(colTypeBase, '('); idx >= 0 {
+						colTypeBase = colTypeBase[:idx]
+					}
+					if colTypeBase == "TIMESTAMP" {
+						nullToTimestamp = e.nowTime().Format("2006-01-02 15:04:05")
+					}
+				}
 				tbl.Lock()
 				truncWarningIssued := false
 				for i := range tbl.Rows {
 					if cur, ok := tbl.Rows[i][colDef.Name]; ok {
 						if cur == nil && !colDef.Nullable {
-							// ALTER TABLE MODIFY COLUMN x NOT NULL: convert NULL to zero value
-							tbl.Rows[i][colDef.Name] = implicitDefaultForType(colDef.Type)
+							// ALTER TABLE MODIFY COLUMN x NOT NULL: convert NULL to default value.
+							// For TIMESTAMP/DATETIME with CURRENT_TIMESTAMP default, use current time.
+							if nullToTimestamp != "" {
+								tbl.Rows[i][colDef.Name] = nullToTimestamp
+							} else {
+								tbl.Rows[i][colDef.Name] = implicitDefaultForType(colDef.Type)
+							}
 						} else {
 							val := e.coerceValueForColumnTypeForWrite(colDef, cur)
 							// CHAR → VARCHAR: strip trailing spaces from stored padded values

--- a/executor/dml_insert.go
+++ b/executor/dml_insert.go
@@ -1102,8 +1102,10 @@ func (e *Executor) execInsert(stmt *sqlparser.Insert) (*Result, error) {
 								// Try to parse as expression; fallback to string
 								v = strings.Trim(defVal, "'")
 							}
-						} else if strings.HasPrefix(strings.ToUpper(col.Type), "TIMESTAMP") {
-							// TIMESTAMP columns implicitly default to CURRENT_TIMESTAMP
+						} else if strings.HasPrefix(strings.ToUpper(col.Type), "TIMESTAMP") && !col.Nullable {
+							// TIMESTAMP NOT NULL columns without explicit default: implicit CURRENT_TIMESTAMP.
+							// Nullable TIMESTAMP columns with DEFAULT NULL (col.Default==nil) fall through
+							// to the Nullable branch below which returns nil.
 							v = e.nowTime().Format("2006-01-02 15:04:05")
 						} else if col.AutoIncrement {
 							v = nil // AUTO_INCREMENT will be handled later
@@ -1116,7 +1118,8 @@ func (e *Executor) execInsert(stmt *sqlparser.Insert) (*Result, error) {
 							e.addWarning("Warning", 1364, fmt.Sprintf("Field '%s' doesn't have a default value", col.Name))
 							v = implicitZeroValue(col.Type)
 						} else {
-							v = implicitZeroValue(col.Type)
+							// Nullable column with no explicit default: DEFAULT = NULL
+							v = nil
 						}
 						break
 					}

--- a/executor/dml_update.go
+++ b/executor/dml_update.go
@@ -755,8 +755,14 @@ func (e *Executor) execUpdate(stmt *sqlparser.Update) (*Result, error) {
 				colUpper := strings.ToUpper(col.Type)
 				isTimestamp := strings.HasPrefix(colUpper, "TIMESTAMP")
 				if isTimestamp {
-					// TIMESTAMP NOT NULL: MySQL converts NULL to CURRENT_TIMESTAMP
-					newRow[col.Name] = e.nowTime().Format("2006-01-02 15:04:05")
+					// TIMESTAMP NOT NULL: MySQL keeps the old value and warns when
+					// an UPDATE tries to set it to NULL in non-strict mode.
+					// Restore the old row's value.
+					if oldVal, hasOld := oldRow[col.Name]; hasOld {
+						newRow[col.Name] = oldVal
+					} else {
+						newRow[col.Name] = implicitZeroValue(col.Type)
+					}
 					if !e.isStrictMode() || bool(stmt.Ignore) {
 						e.addWarning("Warning", 1048, fmt.Sprintf("Column '%s' cannot be null", col.Name))
 					}


### PR DESCRIPTION
## Summary

- **INSERT DEFAULT**: Nullable `TIMESTAMP DEFAULT NULL` columns now correctly receive `NULL` (not `CURRENT_TIMESTAMP`) when the `DEFAULT` keyword is used. Previously, the code checked only the column type without checking nullability, so `DEFAULT NULL` timestamps were incorrectly filled with the current time.
- **UPDATE NULL on NOT NULL TIMESTAMP**: When an `UPDATE` sets a `TIMESTAMP NOT NULL` column to `NULL` in non-strict mode, MySQL keeps the old row value and emits Warning 1048. The old code incorrectly set the column to `CURRENT_TIMESTAMP` instead.
- **ALTER TABLE MODIFY NULL→TIMESTAMP NOT NULL**: During column type conversion, rows that had `NULL` in a column being changed to `TIMESTAMP NOT NULL` now use `e.nowTime()` (the session-level current timestamp) instead of the zero value `0000-00-00 00:00:00`.

## Impact

- `other/type_timestamp_explicit` FDL: **363 → 464** (improved by 101 lines)
- `other/type_time` FDL: 206 (unchanged — blocked by expr_eval.go)
- `other/type_date` FDL: 250 (unchanged — blocked by expr_eval.go)
- Baseline pass count: **1823** (maintained)
- FDL guards: subquery_sj_mat ≥ 8435 ✓, explain_json_all ≥ 1355 ✓, explain_json_none ≥ 1256 ✓

## Files changed

- `executor/dml_insert.go`: Fix DEFAULT keyword handling for nullable TIMESTAMP columns
- `executor/dml_update.go`: Fix NULL assignment to TIMESTAMP NOT NULL — keep old value + warn
- `executor/ddl.go`: Fix ALTER TABLE MODIFY NULL→TIMESTAMP NOT NULL to use session timestamp

Refs #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)