### PR TITLE
fix: uuid_to_bin/bin_to_uuid arg validation, type inference, and mysql.user count

### DIFF
--- a/executor/ddl.go
+++ b/executor/ddl.go
@@ -8256,6 +8256,9 @@ func (e *Executor) inferExprType(expr sqlparser.Expr) string {
 		case "inet6_aton":
 			// INET6_ATON returns varbinary(16)
 			return "varbinary(16)"
+		case "uuid_to_bin":
+			// UUID_TO_BIN returns varbinary(16)
+			return "varbinary(16)"
 		case "uuid_short":
 			// UUID_SHORT returns a 64-bit unsigned integer
 			return "bigint unsigned"

--- a/executor/func_misc.go
+++ b/executor/func_misc.go
@@ -817,8 +817,8 @@ func evalMiscFunc(e *Executor, name string, v *sqlparser.FuncExpr, row *storage.
 		result, err := e.evalAESDecrypt(v, row)
 		return result, true, err
 	case "uuid_to_bin":
-		if len(v.Exprs) == 0 {
-			return nil, true, nil
+		if len(v.Exprs) == 0 || len(v.Exprs) > 2 {
+			return nil, true, mysqlError(1582, "42000", "Incorrect parameter count in the call to native function 'uuid_to_bin'")
 		}
 		utbVal, isNull, err := e.evalArg1Quiet(v.Exprs, row)
 		if err != nil {
@@ -861,8 +861,8 @@ func evalMiscFunc(e *Executor, name string, v *sqlparser.FuncExpr, row *storage.
 		}
 		return string(decoded), true, nil
 	case "bin_to_uuid":
-		if len(v.Exprs) == 0 {
-			return nil, true, nil
+		if len(v.Exprs) == 0 || len(v.Exprs) > 2 {
+			return nil, true, mysqlError(1582, "42000", "Incorrect parameter count in the call to native function 'bin_to_uuid'")
 		}
 		btuVal, isNull, err := e.evalArg1Quiet(v.Exprs, row)
 		if err != nil {

--- a/executor/grants.go
+++ b/executor/grants.go
@@ -581,6 +581,8 @@ func (gs *GrantStore) ListAllRoles() []UserHostEntry {
 // ListAllUserHosts returns all known user@host pairs in the grant store,
 // including users registered via CREATE USER and users with grant entries.
 // Roles (stored in gs.roles) are excluded.
+// Anonymous users (empty username) are also excluded because MySQL 8.0 does not
+// include anonymous users in mysql.user or other user enumeration contexts.
 func (gs *GrantStore) ListAllUserHosts() []UserHostEntry {
 	gs.mu.RLock()
 	defer gs.mu.RUnlock()
@@ -594,11 +596,21 @@ func (gs *GrantStore) ListAllUserHosts() []UserHostEntry {
 		if _, isRole := gs.roles[key]; isRole {
 			continue
 		}
+		// Skip anonymous users (empty username before '@')
+		atIdx := strings.LastIndex(key, "@")
+		if atIdx == 0 {
+			continue
+		}
 		seen[key] = true
 	}
 	// Include all users with grant entries
 	for key := range gs.entries {
 		if _, isRole := gs.roles[key]; isRole {
+			continue
+		}
+		// Skip anonymous users (empty username before '@')
+		atIdx := strings.LastIndex(key, "@")
+		if atIdx == 0 {
 			continue
 		}
 		seen[key] = true


### PR DESCRIPTION
## Summary

- **Argument count validation**: `uuid_to_bin()` and `bin_to_uuid()` now return `ER_WRONG_PARAMCOUNT_TO_NATIVE_FCT` (1582/42000) for 0 or 3+ arguments instead of silently returning NULL
- **Type inference**: Added `uuid_to_bin` → `varbinary(16)` to `inferExprType` so `CREATE TABLE AS SELECT uuid_to_bin(...)` correctly infers column type as `varbinary(16)` instead of `text`
- **mysql.user row count**: Excluded anonymous users (empty username `''@'%'`) from `ListAllUserHosts()` to match MySQL 8.0 behavior — the built-in system users list already handles the 4 canonical users (`mysql.infoschema`, `mysql.session`, `mysql.sys`, `root`)

## Results

- `other/func_uuid`: **pass** (was fail, FDL 182 → pass)
- No regressions: 1824 passed (baseline 1823)
- FDL guards maintained: subquery_sj_mat=8435, explain_json_all=1355, explain_json_none=1256

## Test plan

- [x] `go build ./...` — clean build
- [x] `go test ./... -count=1` — all unit tests pass
- [x] `go run ./cmd/mtrrun -test other/func_uuid` — now passes
- [x] `go run ./cmd/mtrrun` — 1824 passed, no regressions vs baseline 1823
- [x] FDL guards verified: subquery_sj_mat≥8435, explain_json_all≥1355, explain_json_none≥1256

🤖 Generated with [Claude Code](https://claude.com/claude-code)