### PR TITLE
fix: truncate CHAR(N) in non-strict mode, coerce DivisionResult for string columns

### DIFF
--- a/executor/coerce.go
+++ b/executor/coerce.go
@@ -1058,6 +1058,26 @@ func (e *Executor) coerceColumnValueWithSession(colType string, val interface{})
 	} else if isVarbinaryType(colType) && val != nil {
 		val = hexIntToBytes(val)
 	}
+	// For CHAR/VARCHAR columns, convert DivisionResult/ScaledValue to their full-precision
+	// float string representation so that subsequent CHAR(N) truncation yields the correct
+	// stored value (e.g. 1/3 in CHAR(10) → "0.33333333").
+	// Note: int64/uint64/float64 are intentionally NOT converted here — converting them would
+	// break HEX() behavior (e.g. HEX(253) should return "FD", not HEX of the string "253").
+	if val != nil {
+		colUp := strings.ToUpper(strings.TrimSpace(colType))
+		colBase := colUp
+		if idx := strings.IndexByte(colBase, '('); idx >= 0 {
+			colBase = colBase[:idx]
+		}
+		if colBase == "CHAR" || colBase == "VARCHAR" {
+			switch v := val.(type) {
+			case DivisionResult:
+				val = strconv.FormatFloat(v.Value, 'f', -1, 64)
+			case ScaledValue:
+				val = strconv.FormatFloat(v.Value, 'f', -1, 64)
+			}
+		}
+	}
 	if val != nil {
 		val = formatDecimalValue(colType, val)
 		val = validateEnumSetValue(colType, val)
@@ -1091,6 +1111,26 @@ func (e *Executor) coerceValueForColumnTypeWithSession(col catalog.ColumnDef, va
 		val = padBinaryValue(val, padLen)
 	} else if isVarbinaryType(col.Type) {
 		val = hexIntToBytes(val)
+	}
+	// For CHAR/VARCHAR columns, convert DivisionResult/ScaledValue to their full-precision
+	// float string representation. MySQL stores the underlying float value with maximum
+	// precision into string columns, allowing subsequent CHAR(N) truncation to produce
+	// the correct result (e.g. 1/3 in CHAR(10) → "0.33333333" after truncation).
+	{
+		colUp := strings.ToUpper(strings.TrimSpace(col.Type))
+		colBase := colUp
+		if idx := strings.IndexByte(colBase, '('); idx >= 0 {
+			colBase = colBase[:idx]
+		}
+		isStrCol := colBase == "CHAR" || colBase == "VARCHAR"
+		if isStrCol {
+			switch v := val.(type) {
+			case DivisionResult:
+				val = strconv.FormatFloat(v.Value, 'f', -1, 64)
+			case ScaledValue:
+				val = strconv.FormatFloat(v.Value, 'f', -1, 64)
+			}
+		}
 	}
 	val = formatDecimalValue(col.Type, val)
 	val = validateEnumSetValue(col.Type, val)
@@ -3522,6 +3562,12 @@ func coerceColumnValue(colType string, val interface{}) interface{} {
 			case float64:
 				// Format without trailing zeros (e.g., 1.0 → "1")
 				val = strconv.FormatFloat(v, 'f', -1, 64)
+			case DivisionResult:
+				// Use full float64 precision for string storage; CHAR(N) truncation
+				// will then limit the result to the column width.
+				val = strconv.FormatFloat(v.Value, 'f', -1, 64)
+			case ScaledValue:
+				val = strconv.FormatFloat(v.Value, 'f', -1, 64)
 			}
 		}
 	}

--- a/executor/dml_insert.go
+++ b/executor/dml_insert.go
@@ -472,6 +472,63 @@ func (e *Executor) execInsert(stmt *sqlparser.Insert) (*Result, error) {
 				return nil, err
 			}
 
+			// Non-strict mode: truncate CHAR(N) strings that exceed the declared column width.
+			// Only fixed-width CHAR columns are truncated; VARCHAR is excluded to match Dolt behavior.
+			if !e.isStrictMode() && tbl.Def != nil {
+				for _, col := range tbl.Def.Columns {
+					rv, exists := row[col.Name]
+					if !exists || rv == nil {
+						continue
+					}
+					colUpper := strings.ToUpper(strings.TrimSpace(col.Type))
+					colBase := colUpper
+					if idx := strings.IndexByte(colBase, '('); idx >= 0 {
+						colBase = colBase[:idx]
+					}
+					if colBase != "CHAR" {
+						continue
+					}
+					// Determine effective column charset.
+					effectiveCs := strings.ToLower(col.Charset)
+					if effectiveCs == "" && tbl.Def != nil {
+						effectiveCs = strings.ToLower(tbl.Def.Charset)
+					}
+					// For single-byte non-ASCII charsets (e.g. hebrew, latin1), integer values
+					// represent character code points — do NOT convert to decimal string.
+					// Only UTF-8 / ASCII compatible charsets treat numeric values as decimal digits.
+					isSpecialSingleByte := effectiveCs != "" && effectiveCs != "ascii" &&
+						effectiveCs != "utf8" && effectiveCs != "utf8mb4" && effectiveCs != "utf8mb3" &&
+						isSingleByteCharset(effectiveCs)
+					// Convert non-string numerics to their decimal string representation for
+					// UTF-8 compatible columns so that CHAR(N) truncation can be applied.
+					sv, ok := rv.(string)
+					if !ok && !isSpecialSingleByte {
+						switch v := rv.(type) {
+						case int64:
+							sv = fmt.Sprintf("%d", v)
+							ok = true
+						case uint64:
+							sv = fmt.Sprintf("%d", v)
+							ok = true
+						case float64:
+							sv = strconv.FormatFloat(v, 'f', -1, 64)
+							ok = true
+						}
+					}
+					if !ok {
+						continue
+					}
+					maxLen := extractCharLength(col.Type)
+					if maxLen <= 0 {
+						continue
+					}
+					if utf8.ValidString(sv) && len([]rune(sv)) > maxLen {
+						row[col.Name] = string([]rune(sv)[:maxLen])
+						e.addWarning("Warning", 1265, fmt.Sprintf("Data truncated for column '%s' at row 1", col.Name))
+					}
+				}
+			}
+
 			bulkRows = append(bulkRows, row)
 		}
 
@@ -2305,25 +2362,25 @@ func (e *Executor) execInsert(stmt *sqlparser.Insert) (*Result, error) {
 			}
 		}
 
-		// Non-strict mode: warn about strings that exceed column length but do NOT truncate
-		// (Dolt does not enforce VARCHAR/CHAR length limits)
+		// Non-strict mode: truncate CHAR strings that exceed column length and warn.
+		// MySQL truncates fixed-width CHAR(N) values in non-strict mode (Warning 1265).
+		// Note: VARCHAR(N) is intentionally excluded – the Dolt-generated test results
+		// expect variable-length columns to store the full value (matching Dolt behavior).
 		if !e.isStrictMode() {
 			for _, col := range tbl.Def.Columns {
 				rv, exists := row[col.Name]
 				if !exists || rv == nil {
 					continue
 				}
-				colUpper := strings.ToUpper(col.Type)
-				isCharType := strings.Contains(colUpper, "CHAR") || strings.Contains(colUpper, "BINARY")
-				if !isCharType {
+				colUpper := strings.ToUpper(strings.TrimSpace(col.Type))
+				colBase := colUpper
+				if idx := strings.IndexByte(colBase, '('); idx >= 0 {
+					colBase = colBase[:idx]
+				}
+				// Only truncate fixed-width CHAR(N) columns; skip VARCHAR, BINARY, etc.
+				if colBase != "CHAR" {
 					continue
 				}
-				sv, ok := rv.(string)
-				if !ok {
-					continue
-				}
-				maxLen := extractCharLength(col.Type)
-				runeLen := 0
 				effectiveCs := col.Charset
 				if effectiveCs == "" && tbl.Def != nil {
 					effectiveCs = tbl.Def.Charset
@@ -2335,10 +2392,40 @@ func (e *Executor) execInsert(stmt *sqlparser.Insert) (*Result, error) {
 				isUtf8Cs := effectiveCs == "utf8" || effectiveCs == "utf8mb4" ||
 					effectiveCs == "utf8mb3" || effectiveCs == "ascii" ||
 					effectiveCs == "" || isSingleByteCharset(effectiveCs)
-				if isUtf8Cs && utf8.ValidString(sv) {
-					runeLen = len([]rune(sv))
+				// For special single-byte non-ASCII charsets (e.g. hebrew, latin1), integer values
+				// represent character code points — do NOT convert to decimal string.
+				// ASCII and UTF-8 family treat numbers as decimal digits.
+				isSpecialSingleByte := effectiveCs != "" && effectiveCs != "ascii" &&
+					effectiveCs != "utf8" && effectiveCs != "utf8mb4" && effectiveCs != "utf8mb3" &&
+					isSingleByteCharset(effectiveCs)
+				sv, ok := rv.(string)
+				if !ok && !isSpecialSingleByte {
+					switch v := rv.(type) {
+					case int64:
+						sv = fmt.Sprintf("%d", v)
+						ok = true
+					case uint64:
+						sv = fmt.Sprintf("%d", v)
+						ok = true
+					case float64:
+						sv = strconv.FormatFloat(v, 'f', -1, 64)
+						ok = true
+					}
 				}
-				if maxLen > 0 && runeLen > maxLen {
+				if !ok {
+					continue
+				}
+				maxLen := extractCharLength(col.Type)
+				if maxLen <= 0 {
+					continue
+				}
+				if !isUtf8Cs || !utf8.ValidString(sv) {
+					continue
+				}
+				runeLen := len([]rune(sv))
+				if runeLen > maxLen {
+					// Truncate to column width and emit warning (MySQL behavior in non-strict mode)
+					row[col.Name] = string([]rune(sv)[:maxLen])
 					e.addWarning("Warning", 1265, fmt.Sprintf("Data truncated for column '%s' at row 1", col.Name))
 				}
 			}


### PR DESCRIPTION
## Summary

- In `NO_ENGINE_SUBSTITUTION` (non-strict) mode, `CHAR(N)` columns now silently truncate overlength strings and emit Warning 1265, matching MySQL behavior. `VARCHAR(N)` is intentionally excluded to match the Dolt test expectations.
- `DivisionResult` and `ScaledValue` types (e.g. the result of `1/3`) are now converted to full-precision float strings before being stored in `CHAR`/`VARCHAR` columns, enabling correct truncation (e.g. `1/3` in `CHAR(10)` → `"0.33333333"`).
- Integer literals stored into `CHAR(N)` columns with UTF-8/ASCII charsets are now converted to their decimal string representation and truncated if needed. Single-byte non-ASCII charsets (hebrew, latin1, etc.) are excluded to preserve character-code semantics used by `HEX()`.

## Results

New passes (3):
- `other/ctype_hebrew`
- `other/ctype_utf32_myisam`
- `other/strings_update_delete`

FDL improvement:
- `other/type_ranges`: 102 → 154 (+52)

FDL guards verified (all maintained):
- `subquery_sj_mat` FDL = 8435 ≥ 8435 ✓
- `explain_json_all` FDL = 1355 ≥ 1355 ✓
- `explain_json_none` FDL = 1256 ≥ 1256 ✓

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./... -count=1` passes
- [x] `go run ./cmd/mtrrun -test other/type_ranges,other/ctype_hebrew,other/ctype_utf32_myisam,other/strings_update_delete` — ctype tests pass, type_ranges FDL improved
- [x] Full suite run: 1823 passed, no regressions from code changes (`filter_single_col_idx_big_myisam` is a pre-existing flaky timeout test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)