### PR TITLE
fix: correct error message for role grants without ADMIN option

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -8593,7 +8593,7 @@ func (e *Executor) checkGrantPrivilege(privs, object string, isRoleGrant bool) e
 			}
 			if !e.grantStore.HasAdminOption(user, host, roleName, rh, activeRoles) {
 				// ER_SPECIFIC_ACCESS_DENIED_ERROR
-				return mysqlError(1227, "42000", fmt.Sprintf("Access denied; you need (at least one of) the WITH GRANT OPTION privilege(s) for this operation"))
+				return mysqlError(1227, "42000", "Access denied; you need (at least one of) the WITH ADMIN, ROLE_ADMIN, SUPER privilege(s) for this operation")
 			}
 		}
 		return nil


### PR DESCRIPTION
## Summary

- Fixed incorrect privilege error message in `checkGrantPrivilege` for role grants
- When a non-privileged user attempts `GRANT role TO user` without having `WITH ADMIN OPTION` for that role, the error now correctly says "WITH ADMIN, ROLE_ADMIN, SUPER privilege(s)" instead of "WITH GRANT OPTION privilege(s)"
- This matches MySQL's `ER_SPECIFIC_ACCESS_DENIED_ERROR` (1227) behavior

## Change

Single line change in `/executor/executor.go` line 8596:

```go
// Before:
return mysqlError(1227, "42000", fmt.Sprintf("Access denied; you need (at least one of) the WITH GRANT OPTION privilege(s) for this operation"))

// After:
return mysqlError(1227, "42000", "Access denied; you need (at least one of) the WITH ADMIN, ROLE_ADMIN, SUPER privilege(s) for this operation")
```

## Test Results

- Baseline: 1824 passed, 326 failed
- After fix: 1825 passed, 325 failed (+1 pass, no regressions)
- `other/roles-admin` now passes (was failing at line 62 with wrong error message)
- FDL guards maintained: subquery_sj_mat=8435, explain_json_all=1355, explain_json_none=1256

🤖 Generated with [Claude Code](https://claude.com/claude-code)