### PR TITLE
fix: ST_SRID validates WKB geometry before SRID lookup for hex literals

### DIFF
--- a/executor/spatial_funcs.go
+++ b/executor/spatial_funcs.go
@@ -1249,6 +1249,16 @@ func evalSpatialFunc(e *Executor, name string, exprs []sqlparser.Expr) (interfac
 				if geomStr == "" {
 					return nil, true, mysqlError(3516, "22023", "Invalid GIS data provided to function st_srid.")
 				}
+			} else if hb, ok := val.(HexBytes); ok {
+				// Hex literal (x'...'): decode hex digits to raw bytes, then validate as WKB
+				decoded, decErr := hex.DecodeString(string(hb))
+				if decErr != nil {
+					return nil, true, mysqlError(3516, "22023", "Invalid GIS data provided to function st_srid.")
+				}
+				geomStr = wkbToWKT(decoded)
+				if geomStr == "" {
+					return nil, true, mysqlError(3516, "22023", "Invalid GIS data provided to function st_srid.")
+				}
 			} else {
 				geomStr = toString(val)
 				if geomStr == "" {


### PR DESCRIPTION
## Summary

- `ST_SRID(x'<short-wkb>', srid)` was returning `ERROR SR001: There's no spatial reference system with SRID N` instead of `ERROR 22023: Invalid GIS data provided to function st_srid.`
- Root cause: when a hex literal (`x'...'`) is used as the geometry argument, its value is internally typed as `HexBytes` (a hex-digit string). The previous code treated any non-empty string as valid geometry, skipping WKB validation and jumping straight to the SRID existence check.
- Fix: add an explicit `HexBytes` branch that decodes the hex digits to raw bytes and runs them through `wkbToWKT()` before the SRID check — consistent with how `[]byte` inputs are handled.

## Test results

- Pass count: 1825 → 1825 (+0 net new passes)
- `gis/spatial_utility_function_srid` FDL: **465 → 1037** (within-test improvement; test still fails on unrelated WKB binary-format issue)
- FDL guards maintained: subquery_sj_mat=8435, explain_json_all=1355, explain_json_none=1256
- No regressions

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./... -count=1` passes
- [x] `go run ./cmd/mtrrun` full suite: 1825 pass, no regressions
- [x] FDL guard values maintained

🤖 Generated with [Claude Code](https://claude.com/claude-code)