### PR TITLE
fix: HEX() converts EWKT geometry to MySQL binary WKB+SRID format

### DIFF
--- a/executor/func_string.go
+++ b/executor/func_string.go
@@ -523,6 +523,22 @@ func evalStringFunc(e *Executor, name string, v *sqlparser.FuncExpr, row *storag
 				}
 			}
 		}
+		// If value is an EWKT geometry string (SRID=N;WKT_GEOM), convert to MySQL's
+		// internal binary format: 4-byte LE SRID followed by ISO WKB body.
+		// MySQL stores geometries as SRID(4 bytes LE) + WKB, so HEX() must reflect that.
+		if s, ok := val.(string); ok && strings.HasPrefix(s, "SRID=") {
+			srid := geomGetSRID(s)
+			plainWKT := geomStripSRID(s)
+			if wkb := wktToWKBBody(plainWKT); wkb != nil {
+				full := make([]byte, 4+len(wkb))
+				full[0] = byte(srid)
+				full[1] = byte(srid >> 8)
+				full[2] = byte(srid >> 16)
+				full[3] = byte(srid >> 24)
+				copy(full[4:], wkb)
+				return strings.ToUpper(hex.EncodeToString(full)), true, nil
+			}
+		}
 		switch tv := val.(type) {
 		case int64:
 			// Use unsigned format to avoid negative hex output for large values


### PR DESCRIPTION
## Summary

- When `HEX()` is applied to a geometry value stored internally as EWKT (`SRID=N;WKT_GEOM`), convert it to MySQL's internal binary format: 4-byte little-endian SRID followed by the ISO WKB body
- MySQL stores geometry values as `SRID(4 bytes LE) + WKB`, so `HEX(geometry_with_srid)` must return binary representation, not the EWKT text

## Test result

- `gis/spatial_utility_function_srid`: fail → pass (+1 pass, 1825 → 1826)
- No regressions: all previously passing tests still pass
- FDL guards maintained: `subquery_sj_mat`=8435, `explain_json_all`=1355, `explain_json_none`=1256

## Test plan

- [x] `go build ./...` succeeds
- [x] `go test ./... -count=1` all pass
- [x] `go run ./cmd/mtrrun -test gis/spatial_utility_function_srid` passes
- [x] Full suite run: 1826 passed (was 1825), no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)