### PR TITLE
fix: prevent YEAR-decimal rounding from applying to non-YEAR integer columns

### DIFF
--- a/executor/display.go
+++ b/executor/display.go
@@ -121,11 +121,11 @@ func normalizeSQLDisplayName(s string) string {
 // However, _utf8mb4 preserves any space that was in the original SQL query.
 func normalizeCharsetIntroducers(s string) string {
 	// Replace _utf8mb3 ' with _utf8' (sqlparser always adds space; MySQL shows no space)
-	s = strings.ReplaceAll(s, "_utf8mb3 '", "_utf8'")
-	s = strings.ReplaceAll(s, "_utf8mb3'", "_utf8'")
+	result := strings.ReplaceAll(s, "_utf8mb3 '", "_utf8'")
+	result = strings.ReplaceAll(result, "_utf8mb3'", "_utf8'")
 	// NOTE: Do NOT strip the space from "_utf8mb4 '" here.
 	// MySQL preserves the space in COLLATION(_utf8mb4 'a') column headers.
-	return s
+	return result
 }
 
 // stripCharsetIntroducerForColName strips charset introducers from an expression
@@ -135,7 +135,7 @@ func normalizeCharsetIntroducers(s string) string {
 // Examples: _utf8'abc' -> 'abc', n'abc' -> 'abc', _utf8mb4'abc' -> 'abc'
 func stripCharsetIntroducerForColName(s string) string {
 	// Handle national charset: n'...' or N'...'
-	if len(s) >= 3 && (s[0] == 'n' || s[0] == 'N') && s[1] == '\'' && s[len(s)-1] == '\'' {
+	if len(s) >= 3 && (s[0] == 'n' || s[0] == 'N') && s[1] == '\'' && isSimpleStringLiteral(s[1:]) {
 		return s[1:]
 	}
 	// Handle _charset'...' pattern (e.g. _utf8'abc', _latin1'hello')
@@ -156,7 +156,7 @@ func stripCharsetIntroducerForColName(s string) string {
 				break // space, operator, etc. → not a charset introducer
 			}
 		}
-		if quotePos > 0 && s[len(s)-1] == '\'' {
+		if quotePos > 0 && isSimpleStringLiteral(s[quotePos:]) {
 			isCharsetIntroducer = true
 		}
 		if isCharsetIntroducer {

--- a/executor/typeutil.go
+++ b/executor/typeutil.go
@@ -741,11 +741,15 @@ func normalizeYearComparisonTyped(ls, rs string, origLeft, origRight interface{}
 	hasFractionalPart := func(f float64) bool {
 		return f != math.Trunc(f)
 	}
-	if isYearIntString(ls) && strings.ContainsRune(rs, '.') && hasFractionalPart(rf) {
+	// Only apply YEAR-rounding when the year-like side is an original string
+	// (i.e. came from a YEAR column). Native integer columns (TINYINT, INT, etc.)
+	// must NOT be rounded — e.g. TINYINT 0 vs 0.00001 should compare as 0 < 0.00001,
+	// not as the incorrectly rounded 0 == 0.
+	if isYearIntString(ls) && strings.ContainsRune(rs, '.') && hasFractionalPart(rf) && isOrigString(origLeft) {
 		rounded := int(math.Round(rf))
 		return ls, fmt.Sprintf("%d", rounded)
 	}
-	if isYearIntString(rs) && strings.ContainsRune(ls, '.') && hasFractionalPart(lf) {
+	if isYearIntString(rs) && strings.ContainsRune(ls, '.') && hasFractionalPart(lf) && isOrigString(origRight) {
 		rounded := int(math.Round(lf))
 		return fmt.Sprintf("%d", rounded), rs
 	}


### PR DESCRIPTION
## Summary

- Fixed `normalizeYearComparisonTyped` in `executor/typeutil.go`: the YEAR-decimal rounding logic was incorrectly treating integer value `0` (from TINYINT/INT columns) as a YEAR-like value, rounding decimal literals like `0.00001` to `0`. This caused `colA < 0.00001` to compare as `0 < 0` (false) instead of `0 < 0.00001` (true) for TINYINT UNSIGNED columns.
- Fixed `stripCharsetIntroducerForColName` in `executor/display.go`: used `isSimpleStringLiteral` instead of `s[len(s)-1] == '\''` to prevent charset introducers from being incorrectly stripped from compound LIKE expressions that happen to end with a quote.

## Root cause

`normalizeYearComparisonTyped` used `isYearLike(n)` which returns `true` for `n == 0` (to handle YEAR 0000), and `isYearIntString("0")` therefore returned `true`. The decimal rounding was then applied to any integer column value of 0 compared with a fractional decimal, rounding `0.00001` → `0` and causing wrong comparisons. The fix adds `isOrigString(origLeft)` guard so rounding only applies when the integer-like side came from an actual YEAR column (stored as string).

## Test plan

- `go build ./... && go test ./... -count=1` passes with no failures
- `const_folding` test FDL improved from **768 → 24997** (+24229 lines)
- Full suite: **1827 passes maintained** (no regressions)
- `subquery_sj_mat` FDL: 8435 ≥ 146 ✓
- `explain_json_all` FDL: 1355 ≥ 1355 ✓
- `explain_json_none` FDL: 1256 ≥ 1256 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)