### PR TITLE
fix: GROUP_CONCAT window function error and ENUM NOT NULL implicit default

### DIFF
--- a/executor/dml_insert.go
+++ b/executor/dml_insert.go
@@ -1109,6 +1109,10 @@ func (e *Executor) execInsert(stmt *sqlparser.Insert) (*Result, error) {
 							v = e.nowTime().Format("2006-01-02 15:04:05")
 						} else if col.AutoIncrement {
 							v = nil // AUTO_INCREMENT will be handled later
+						} else if !col.Nullable && strings.HasPrefix(strings.ToLower(strings.TrimSpace(col.Type)), "enum(") {
+							// ENUM NOT NULL columns always have an implicit default: the first enum value.
+							// This is true even in strict mode, so DEFAULT keyword resolves to it.
+							v = implicitZeroValue(col.Type)
 						} else if !col.Nullable && !isGeneratedColumnType(col.Type) {
 							// DEFAULT keyword used on NOT NULL column with no actual default
 							// In strict mode: error 1364; in non-strict: warning + zero value
@@ -1905,8 +1909,10 @@ func (e *Executor) execInsert(stmt *sqlparser.Insert) (*Result, error) {
 							break
 						}
 					}
-					if !explicitlySpecified && col.Default == nil {
+					if !explicitlySpecified && col.Default == nil && !strings.HasPrefix(strings.ToLower(strings.TrimSpace(col.Type)), "enum(") {
 						// Column not specified and has no default -> error 1364
+						// Exception: ENUM NOT NULL always has an implicit default (first enum value),
+						// handled by implicitZeroValue, so skip the error for ENUM columns.
 						if bool(stmt.Ignore) {
 							e.addWarning("Warning", 1364, fmt.Sprintf("Field '%s' doesn't have a default value", col.Name))
 							row[col.Name] = implicitZeroValue(col.Type)

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -2163,6 +2163,12 @@ func (e *Executor) Execute(query string) (res *Result, retErr error) {
 		// MySQL accepts arbitrary whitespace between keywords, so the prefix-match
 		// table below should be tolerant of repeated spaces/tabs/newlines.
 		upper = collapseUpperWhitespace(upper)
+		// GROUP_CONCAT cannot be used as a window function. Vitess gives a generic
+		// syntax error for "GROUP_CONCAT(...) OVER (...)", but MySQL gives a specific
+		// error. Detect this pattern and return the MySQL-compatible error message.
+		if strings.Contains(upper, "GROUP_CONCAT") && strings.Contains(err.Error(), "near 'over'") {
+			return nil, mysqlError(1235, "42000", "This version of MySQL doesn't yet support 'group_concat as window function'")
+		}
 		// Accept statements that Vitess parser doesn't support
 		if strings.HasPrefix(upper, "EXPLAIN ") || strings.HasPrefix(upper, "DESC ") || strings.HasPrefix(upper, "DESCRIBE ") {
 			explainType := sqlparser.TraditionalType


### PR DESCRIPTION
## Summary

- **executor.go**: Return MySQL error 1235 when `GROUP_CONCAT` is used as a window function (`GROUP_CONCAT(...) OVER (...)`). Vitess gives generic syntax error 1064; MySQL gives specific 1235 with message `'group_concat as window function'`. Detection: check for `GROUP_CONCAT` in query and `'near 'over''` in vitess error.

- **dml_insert.go**: ENUM NOT NULL columns always have an implicit default (first enum value) in MySQL, even in strict mode. Previously, the DEFAULT keyword path and the unspecified-column strict-mode path both raised error 1364. Fixed by detecting ENUM type and using `implicitZeroValue()` instead.

## Test results

- **Full suite**: 1827 passed = baseline (no regressions)
- **Errors**: 115 → 114 (`csv`: error → fail)
- **FDL guards**: subquery_sj_mat=8435 ✓, explain_json_all=1355 ✓, explain_json_none=1256 ✓
- **FDL improvements**:
  - `window_functions`: 6 → 62 (+56)
  - `csv`: ERROR → FDL=4942 (+4942, meets ≥500 criterion)

## LOC

13 lines added across 2 files (well within 300 LOC limit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)