### PR TITLE
fix: TIMESTAMP fractional-second comparison excludes boundary rows (Bug#50774)

### DIFF
--- a/executor/func_datetime.go
+++ b/executor/func_datetime.go
@@ -4167,10 +4167,13 @@ func normalizeDateTimeForCompare(a, b string) (string, string) {
 		}
 	}
 
-	// DATE vs DATETIME: extend DATE to DATETIME by appending " 00:00:00"
-	if aIsDate && !aIsDatetime && bIsDatetime {
+	// DATE vs DATETIME: extend DATE to DATETIME by appending " 00:00:00".
+	// Only extend if the string is a pure DATE (exactly 10 chars), not a
+	// datetime-with-fractional-seconds like "2010-02-01 09:31:02.0" which
+	// already has a time component and must not be mangled by appending " 00:00:00".
+	if aIsDate && !aIsDatetime && bIsDatetime && len(a) == 10 {
 		a = a + " 00:00:00"
-	} else if bIsDate && !bIsDatetime && aIsDatetime {
+	} else if bIsDate && !bIsDatetime && aIsDatetime && len(b) == 10 {
 		b = b + " 00:00:00"
 	}
 
@@ -4192,6 +4195,25 @@ func normalizeDateTimeForCompare(a, b string) (string, string) {
 			} else {
 				b = b[:bDotIdx+1+len(aFrac)]
 			}
+		}
+	} else if aDotIdx > 10 && bDotIdx <= 10 {
+		// a has fractional seconds in a datetime context but b does not (e.g. a literal
+		// like '2010-02-01 09:31:02.0' compared with a plain TIMESTAMP column value).
+		// A plain TIMESTAMP is implicitly 'YYYY-MM-DD HH:MM:SS.000...0'.
+		// Extend b with zeros matching a's fractional digit count so that string
+		// comparison is correct for all fractional values:
+		//   '09:31:02.0' vs '09:31:02' → extend to '09:31:02.0' vs '09:31:02.0' → equal ✓
+		//   '09:31:02.5' vs '09:31:02' → extend to '09:31:02.5' vs '09:31:02.0' → a > b ✓
+		aFracLen := len(a) - aDotIdx - 1
+		if len(b) >= 19 && b[4] == '-' && b[10] == ' ' {
+			b = b + "." + strings.Repeat("0", aFracLen)
+		}
+	} else if bDotIdx > 10 && aDotIdx <= 10 {
+		// b has fractional seconds in a datetime context but a does not.
+		// Extend a with zeros matching b's fractional digit count.
+		bFracLen := len(b) - bDotIdx - 1
+		if len(a) >= 19 && a[4] == '-' && a[10] == ' ' {
+			a = a + "." + strings.Repeat("0", bFracLen)
 		}
 	}
 

--- a/executor/timestamp_frac_test.go
+++ b/executor/timestamp_frac_test.go
@@ -1,0 +1,78 @@
+package executor
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/myuon/mylite/catalog"
+	"github.com/myuon/mylite/storage"
+)
+
+// TestTimestampFractionalComparison exercises Bug#50774: comparing a plain
+// TIMESTAMP column against a string literal with .0 fractional seconds.
+func TestTimestampFractionalComparison(t *testing.T) {
+	cat := catalog.New()
+	store := storage.NewEngine()
+	e := New(cat, store)
+	if _, err := e.Execute("CREATE DATABASE IF NOT EXISTS test"); err != nil {
+		t.Fatalf("create db: %v", err)
+	}
+	e.CurrentDB = "test"
+
+	if _, err := e.Execute("CREATE TABLE t1 ( a TIMESTAMP, KEY ( a ) )"); err != nil {
+		t.Fatalf("create: %v", err)
+	}
+	for _, ts := range []string{"'2010-02-01 09:31:01'", "'2010-02-01 09:31:02'", "'2010-02-01 09:31:03'", "'2010-02-01 09:31:04'"} {
+		if _, err := e.Execute("INSERT INTO t1 VALUES( " + ts + " )"); err != nil {
+			t.Fatalf("insert %s: %v", ts, err)
+		}
+	}
+
+	tests := []struct {
+		query string
+		want  []string
+	}{
+		{
+			"SELECT * FROM t1 WHERE a >= '2010-02-01 09:31:02.0'",
+			[]string{"2010-02-01 09:31:02", "2010-02-01 09:31:03", "2010-02-01 09:31:04"},
+		},
+		{
+			"SELECT * FROM t1 WHERE '2010-02-01 09:31:02.0' <= a",
+			[]string{"2010-02-01 09:31:02", "2010-02-01 09:31:03", "2010-02-01 09:31:04"},
+		},
+		{
+			"SELECT * FROM t1 WHERE a <= '2010-02-01 09:31:02.0'",
+			[]string{"2010-02-01 09:31:01", "2010-02-01 09:31:02"},
+		},
+		{
+			"SELECT * FROM t1 WHERE '2010-02-01 09:31:02.0' >= a",
+			[]string{"2010-02-01 09:31:01", "2010-02-01 09:31:02"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.query, func(t *testing.T) {
+			rs, err := e.Execute(tc.query)
+			if err != nil {
+				t.Fatalf("query: %v", err)
+			}
+			got := []string{}
+			for _, row := range rs.Rows {
+				got = append(got, fmt.Sprintf("%v", row[0]))
+			}
+			if len(got) != len(tc.want) {
+				t.Errorf("got %d rows %v, want %d rows %v", len(got), got, len(tc.want), tc.want)
+				return
+			}
+			for i := range tc.want {
+				if got[i] != tc.want[i] {
+					t.Errorf("row %d: got %q want %q", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
+
+	if _, err := e.Execute("DROP TABLE t1"); err != nil {
+		t.Fatalf("drop: %v", err)
+	}
+}

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -1357,6 +1357,13 @@ func compareRowValue(a, b interface{}) int {
 	}
 	as := fmt.Sprintf("%v", a)
 	bs := fmt.Sprintf("%v", b)
+	// Normalize datetime strings with mismatched fractional-second precision.
+	// A plain TIMESTAMP/DATETIME like "2010-02-01 09:31:02" is implicitly
+	// "2010-02-01 09:31:02.000..." — extend the non-fractional side with zeros
+	// so that string comparison is lexicographically correct:
+	//   "09:31:02" vs "09:31:02.0" → extend to "09:31:02.0" vs "09:31:02.0" → equal
+	//   "09:31:02" vs "09:31:02.5" → extend to "09:31:02.0" vs "09:31:02.5" → a < b
+	as, bs = normalizeDatetimeFractionalForCompare(as, bs)
 	if as < bs {
 		return -1
 	}
@@ -1364,6 +1371,29 @@ func compareRowValue(a, b interface{}) int {
 		return 1
 	}
 	return 0
+}
+
+// normalizeDatetimeFractionalForCompare extends the datetime string that lacks
+// fractional seconds with ".0...0" to match the other's fractional digit count,
+// so that string comparison yields the correct order when one side is a plain
+// DATETIME/TIMESTAMP (no fractional seconds) and the other has ".N" fractional.
+func normalizeDatetimeFractionalForCompare(a, b string) (string, string) {
+	isDatetimeLike := func(s string) bool {
+		// Must look like YYYY-MM-DD HH:MM:SS (exactly 19 chars with correct separators)
+		return len(s) == 19 && s[4] == '-' && s[7] == '-' && s[10] == ' ' && s[13] == ':' && s[16] == ':'
+	}
+	aDotIdx := strings.LastIndex(a, ".")
+	bDotIdx := strings.LastIndex(b, ".")
+	if aDotIdx > 10 && bDotIdx <= 10 && isDatetimeLike(b) {
+		// a has fractional seconds (in datetime context), b does not — extend b
+		aFracLen := len(a) - aDotIdx - 1
+		b = b + "." + strings.Repeat("0", aFracLen)
+	} else if bDotIdx > 10 && aDotIdx <= 10 && isDatetimeLike(a) {
+		// b has fractional seconds (in datetime context), a does not — extend a
+		bFracLen := len(b) - bDotIdx - 1
+		a = a + "." + strings.Repeat("0", bFracLen)
+	}
+	return a, b
 }
 
 func toComparableFloat(v interface{}) (float64, bool) {


### PR DESCRIPTION
## Summary

- **Root cause**: `normalizeDateTimeForCompare` misclassified datetime-with-fractional strings (e.g. `"2010-02-01 09:31:02.0"`) as pure DATE values (`isDateString` matched, `isDatetimeString` did not because `len != 19`), causing the DATE→DATETIME extension to append `" 00:00:00"` and produce `"2010-02-01 09:31:02.0 00:00:00"` — a corrupted value that breaks all subsequent comparison.
- **Executor fix** (`executor/func_datetime.go`): added `&& len(a) == 10` / `&& len(b) == 10` guard to the DATE→DATETIME extension so it only fires for genuine 10-character DATE strings. Added a new branch that extends the plain-TIMESTAMP side with fractional zeros when the other operand carries a fractional part (e.g. `"09:31:02"` → `"09:31:02.0"`) so string comparison is lexicographically correct.
- **Storage fix** (`storage/storage.go`): added `normalizeDatetimeFractionalForCompare` helper and called it from `compareRowValue` so the same correction applies when index range scans use `inRange` → `compareRowValue` (bypassing the executor filter path).

## Metrics

| metric | before | after |
|--------|--------|-------|
| passes | 1827 | 1826* |
| type_timestamp_explicit FDL | 464 | 511 (+47) |
| subquery_sj_mat FDL | 8435 | 8435 ✓ |
| explain_json_all FDL | 1355 | 1355 ✓ |
| explain_json_none FDL | 1256 | 1256 ✓ |

\* The -1 pass is `other/filter_single_col_idx_big_myisam` which timed out at 20.003s during a loaded full-suite run (baseline elapsed: 19.752s). When run alone it passes in 15.3s — this is a pre-existing flaky timing issue unrelated to this change.

## Test plan

- [x] All 4 query forms from Bug#50774 now pass (`TestTimestampFractionalComparison`)
- [x] `go test ./... -count=1` passes
- [x] `type_timestamp_explicit` FDL improved 464 → 511
- [x] FDL guards maintained (subquery_sj_mat/explain_json_all/explain_json_none)
- [x] No regressions from code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)