### PR TITLE
fix: clamp immediate/original_server_version max to 999999 + privilege check

### DIFF
--- a/cmd/mtrrun/skiplist.json
+++ b/cmd/mtrrun/skiplist.json
@@ -3021,10 +3021,6 @@
       "reason": "engine does not support gtid_purged"
     },
     {
-      "test": "sys_vars/immediate_server_version_basic",
-      "reason": "engine returns wrong value for immediate_server_version max"
-    },
-    {
       "test": "sys_vars/original_server_version_basic",
       "reason": "engine returns wrong value for original_server_version max"
     },

--- a/executor/variables.go
+++ b/executor/variables.go
@@ -776,6 +776,33 @@ func (e *Executor) execSet(stmt *sqlparser.Set) (*Result, error) {
 						}
 					}
 				}
+				// Enforce SUPER, SYSTEM_VARIABLES_ADMIN, or SESSION_VARIABLES_ADMIN privilege
+				// for session-only variables that require elevated access (e.g. immediate_server_version).
+				if !isGlobal && superOnlySessionVars[cleanName] {
+					cuStr := ""
+					if cu, ok := e.userVars["__current_user"]; ok {
+						if s, ok2 := cu.(string); ok2 {
+							cuStr = s
+						}
+					}
+					isNonRoot := cuStr != "" && !strings.EqualFold(cuStr, "root")
+					if isNonRoot {
+						hasPriv := false
+						if e.superUsersMu != nil {
+							e.superUsersMu.RLock()
+							hasPriv = e.superUsers[strings.ToLower(cuStr)]
+							e.superUsersMu.RUnlock()
+						}
+						if !hasPriv && e.sysVarsAdminUsersMu != nil {
+							e.sysVarsAdminUsersMu.RLock()
+							hasPriv = e.sysVarsAdminUsers[strings.ToLower(cuStr)]
+							e.sysVarsAdminUsersMu.RUnlock()
+						}
+						if !hasPriv {
+							return nil, mysqlError(1227, "42000", "Access denied; you need (at least one of) the SUPER, SYSTEM_VARIABLES_ADMIN or SESSION_VARIABLES_ADMIN privilege(s) for this operation")
+						}
+					}
+				}
 				// Save previous session value before SET GLOBAL overwrites it.
 				savedSessionVal := map[string]string{}
 				if isGlobal {
@@ -2039,6 +2066,14 @@ var sysVarNonPersistReadOnly = map[string]bool{
 var superOnlyGlobalVars = map[string]bool{
 	"read_only":       true,
 	"super_read_only": true,
+}
+
+// superOnlySessionVars lists session-only system variables that require SUPER,
+// SYSTEM_VARIABLES_ADMIN, or SESSION_VARIABLES_ADMIN privilege to set.
+// Non-privileged users get ER_SPECIFIC_ACCESS_DENIED_ERROR (1227).
+var superOnlySessionVars = map[string]bool{
+	"original_server_version":  true,
+	"immediate_server_version": true,
 }
 
 var sysVarGlobalOnly = map[string]bool{
@@ -3391,8 +3426,8 @@ var sysVarIntRange = map[string]intVarRange{
 	"rand_seed1":                {Min: 0, Max: 18446744073709551615, IsUnsigned: true},
 	"rand_seed2":                {Min: 0, Max: 18446744073709551615, IsUnsigned: true},
 	"original_commit_timestamp": {Min: 0, Max: 18446744073709551615, IsUnsigned: true},
-	"original_server_version":   {Min: 0, Max: 18446744073709551615, IsUnsigned: true},
-	"immediate_server_version":  {Min: 0, Max: 18446744073709551615, IsUnsigned: true},
+	"original_server_version":   {Min: 0, Max: 999999, IsUnsigned: true},
+	"immediate_server_version":  {Min: 0, Max: 999999, IsUnsigned: true},
 }
 
 func parseStrictIntegerAssignment(expr sqlparser.Expr, evalVal interface{}) (int64, uint64, bool, string, error) {


### PR DESCRIPTION
## Summary

- Fixes `immediate_server_version` and `original_server_version` max value from uint64 max (`18446744073709551615`) to `999999` (MySQL's actual maximum). Values above 999999 now trigger a warning and get truncated to 999999.
- Adds `superOnlySessionVars` map and privilege check so non-privileged users cannot `SET SESSION immediate_server_version`/`original_server_version` without SUPER, SYSTEM_VARIABLES_ADMIN, or SESSION_VARIABLES_ADMIN privilege.
- Unskips `sys_vars/immediate_server_version_basic` (+1 pass: 1832→1833).

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./... -count=1` passes
- [x] `go run ./cmd/mtrrun -test sys_vars/immediate_server_version_basic` → pass
- [x] Full suite: Passed=1833 (was 1832, +1)
- [x] FDL guards: subquery_sj_mat=8435 ✓, explain_json_all=1355 ✓, explain_json_none=1256 ✓
- [x] No regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)