### PR TITLE
fix: pass sys_vars/lc_messages_basic by implementing locale variable semantics

### DIFF
--- a/cmd/mtrrun/skiplist.json
+++ b/cmd/mtrrun/skiplist.json
@@ -2729,10 +2729,6 @@
       "reason": "output mismatch or execution error"
     },
     {
-      "test": "sys_vars/lc_messages_basic",
-      "reason": "output mismatch or execution error"
-    },
-    {
       "test": "sys_vars/log_error_suppression_list_basic",
       "reason": "output mismatch or execution error"
     },
@@ -2766,10 +2762,6 @@
     },
     {
       "test": "sys_vars/mysql_native_password_proxy_users_func",
-      "reason": "output mismatch or execution error"
-    },
-    {
-      "test": "sys_vars/optimizer_switch_basic",
       "reason": "output mismatch or execution error"
     },
     {
@@ -2917,14 +2909,6 @@
       "reason": "uses slow_log table"
     },
     {
-      "test": "other/func_math",
-      "reason": "timeout"
-    },
-    {
-      "test": "other/derived",
-      "reason": "timeout"
-    },
-    {
       "test": "other/sp",
       "reason": "test file is 9787 lines, takes >20s to run"
     },
@@ -3057,10 +3041,6 @@
       "reason": "partition failures"
     },
     {
-      "test": "other/func_weight_string",
-      "reason": "timeout"
-    },
-    {
       "test": "gcol/gcol_select_myisam",
       "reason": "complex query failures"
     },
@@ -3181,10 +3161,6 @@
       "reason": "timeout"
     },
     {
-      "test": "other/insert",
-      "reason": "timeout"
-    },
-    {
       "test": "other/rollback",
       "reason": "timeout"
     },
@@ -3243,10 +3219,6 @@
     {
       "test": "sys_vars/character_set_client_func",
       "reason": "charset conversion not yet implemented"
-    },
-    {
-      "test": "sys_vars/character_set_results_basic",
-      "reason": "@@session.character_set_results casing issue"
     },
     {
       "test": "sys_vars/character_set_client_basic",
@@ -3921,10 +3893,6 @@
       "reason": "requires concurrent metadata locking which is not implemented"
     },
     {
-      "test": "sys_vars/explicit_defaults_for_timestamp_basic",
-      "reason": "needs user privilege checking"
-    },
-    {
       "test": "sys_vars/windowing_use_high_precision_basic",
       "reason": "needs window functions"
     },
@@ -4237,10 +4205,6 @@
       "reason": "GRANT SHOW GRANTS missing all privileges list"
     },
     {
-      "test": "engine_funcs/jp_comment_older_compatibility1",
-      "reason": "row ordering issue in result"
-    },
-    {
       "test": "engine_iuds/update_delete_calendar",
       "reason": "column duplication in output; also WHERE clause date validation errors instead of returning 0 rows"
     },
@@ -4259,6 +4223,38 @@
     {
       "test": "innodb/partition_autoinc",
       "reason": "still failing"
+    },
+    {
+      "test": "other/func_math",
+      "reason": "complex - floor/rand/pi/format issues"
+    },
+    {
+      "test": "other/insert",
+      "reason": "view is not updatable error"
+    },
+    {
+      "test": "other/derived",
+      "reason": "mysqltest user access denied"
+    },
+    {
+      "test": "sys_vars/explicit_defaults_for_timestamp_basic",
+      "reason": "requires multi-connection + privilege check"
+    },
+    {
+      "test": "other/func_weight_string",
+      "reason": "timeout/memory issue"
+    },
+    {
+      "test": "engine_funcs/jp_comment_older_compatibility1",
+      "reason": "Japanese string ordering issue"
+    },
+    {
+      "test": "sys_vars/character_set_results_basic",
+      "reason": "@@session.character_set_results casing issue"
+    },
+    {
+      "test": "sys_vars/optimizer_switch_basic",
+      "reason": "output mismatch or execution error"
     }
   ]
 }

--- a/executor/variables.go
+++ b/executor/variables.go
@@ -545,7 +545,7 @@ func (e *Executor) execSet(stmt *sqlparser.Set) (*Result, error) {
 			if name == "character_set_database" {
 				e.addWarning("Warning", 1681, "Updating 'character_set_database' is deprecated. It will be made read-only in a future release.")
 			}
-		case "lc_time_names":
+		case "lc_time_names", "lc_messages":
 			isGlobal := scope == sqlparser.GlobalScope
 			locVal := val
 			if strings.ToUpper(locVal) == "DEFAULT" {
@@ -583,10 +583,20 @@ func (e *Executor) execSet(stmt *sqlparser.Set) (*Result, error) {
 						locVal = strings.ToUpper(rawName)
 					}
 				}
-				// Floats are ER_WRONG_TYPE_FOR_VAR
+				// Floats are ER_WRONG_TYPE_FOR_VAR.
+				// Also check the original expression for scientific notation (1e1) which
+				// evaluates to an integer string but is semantically a float literal.
+				if lit, isLit := expr.Expr.(*sqlparser.Literal); isLit {
+					litStr := sqlparser.String(lit)
+					if strings.ContainsAny(litStr, ".eE") {
+						if _, fErr := strconv.ParseFloat(litStr, 64); fErr == nil {
+							return nil, mysqlError(1232, "42000", fmt.Sprintf("Incorrect argument type to variable '%s'", name))
+						}
+					}
+				}
 				if strings.ContainsAny(locVal, ".eE") {
 					if _, fErr := strconv.ParseFloat(locVal, 64); fErr == nil {
-						return nil, mysqlError(1232, "42000", fmt.Sprintf("Incorrect argument type to variable 'lc_time_names'"))
+						return nil, mysqlError(1232, "42000", fmt.Sprintf("Incorrect argument type to variable '%s'", name))
 					}
 				}
 				// Numeric locale ID: 0-110 are valid.


### PR DESCRIPTION
## Summary

- `lc_messages` now shares the same locale name/integer-ID validation logic as `lc_time_names`: integer IDs 0–110 map to locale names (e.g., 1→en_GB, 2→ja_JP), float literals (1.1, 1e1) return ER_WRONG_TYPE_FOR_VAR, and string locale names are validated against validMySQLLocales.
- Also fixes the original expression float check to detect scientific notation (e.g., 1e1) before it is evaluated and converted to an integer string — this was a latent bug that affected the lc_time_names handler too.
- Unskips `sys_vars/lc_messages_basic` (+1 pass, 1834 total).

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./... -count=1` passes
- [x] `go run ./cmd/mtrrun -test sys_vars/lc_messages_basic` → pass
- [x] Full suite: Passed 1834 (+1 over baseline 1833)
- [x] FDL guards: subquery_sj_mat=8435, explain_json_all=1355, explain_json_none=1256 (all maintained)

🤖 Generated with [Claude Code](https://claude.com/claude-code)