### PR TITLE
fix: add transaction_allow_batching to boolean sysvar map

### DIFF
--- a/cmd/mtrrun/skiplist.json
+++ b/cmd/mtrrun/skiplist.json
@@ -2805,10 +2805,6 @@
       "reason": "output mismatch or execution error"
     },
     {
-      "test": "sys_vars/transaction_allow_batching_basic",
-      "reason": "output mismatch or execution error"
-    },
-    {
       "test": "sys_vars/updatable_views_with_limit_func",
       "reason": "output mismatch or execution error"
     },

--- a/executor/variables.go
+++ b/executor/variables.go
@@ -3150,6 +3150,7 @@ var sysVarBoolean = map[string]bool{
 	"mysqlx_enable_hello_notice":   true,
 	"partial_revokes":              true,
 	"innodb_extend_and_initialize": true,
+	"transaction_allow_batching":   true,
 }
 
 func isBooleanVariable(name string) bool {


### PR DESCRIPTION
## Summary
- Adds `transaction_allow_batching` to `sysVarBoolean` map in `executor/variables.go`
- This enables correct MySQL type validation: float values (1.1, 1e1) → ER_WRONG_TYPE_FOR_VAR, invalid strings (\"foobar\") → ER_WRONG_VALUE_FOR_VAR
- Unskips `sys_vars/transaction_allow_batching_basic` (1 test now passes)

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./... -count=1` passes (all existing tests green)
- [x] `go run ./cmd/mtrrun -test sys_vars/transaction_allow_batching_basic` → PASS
- [x] Full suite: 1835 passed (+1 vs baseline 1834), 0 regressions
- [x] FDL guard: subquery_sj_mat=8435, explain_json_all=1355, explain_json_none=1256 (all at minimums)

🤖 Generated with [Claude Code](https://claude.com/claude-code)