### PR TITLE
fix: enforce event_scheduler as GLOBAL-only variable

### DIFF
--- a/cmd/mtrrun/skiplist.json
+++ b/cmd/mtrrun/skiplist.json
@@ -4141,10 +4141,6 @@
       "reason": "needs SUPER privilege check for SET GLOBAL"
     },
     {
-      "test": "sys_vars/event_scheduler_basic",
-      "reason": "needs global-only var enforcement"
-    },
-    {
       "test": "sys_vars/init_connect_basic",
       "reason": "failing"
     },

--- a/executor/variables.go
+++ b/executor/variables.go
@@ -2398,6 +2398,8 @@ var sysVarGlobalOnly = map[string]bool{
 	"innodb_log_group_home_dir":     true,
 	"innodb_redo_log_capacity":      true,
 	"innodb_segment_reserve_factor": true,
+	// event_scheduler is GLOBAL-only; session-scope SET/SELECT returns ER_GLOBAL_VARIABLE.
+	"event_scheduler": true,
 }
 
 // sysVarEnumSet contains system variables that are ENUM types where ON/OFF


### PR DESCRIPTION
## Summary
- `event_scheduler` is a GLOBAL-only system variable in MySQL 8.0, but was missing from the `sysVarGlobalOnly` map
- Added `event_scheduler` to `sysVarGlobalOnly` so that `SET @@session.event_scheduler = ...` returns `ER_GLOBAL_VARIABLE` (HY000/1228) and `SELECT @@session.event_scheduler` returns the correct error
- Removed `sys_vars/event_scheduler_basic` from the skiplist; the test now passes

## Test plan
- [ ] `sys_vars/event_scheduler_basic` passes (was skipped)
- [ ] Full suite: Passed 1842 (up from baseline 1840, +2)
- [ ] FDL guards: subquery_sj_mat=8435, explain_json_all=1355, explain_json_none=1256 (all maintained)
- [ ] No regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)