### PR TITLE
fix: enforce session-scope constraint for max_delayed_threads/max_insert_delayed_threads

### DIFF
--- a/cmd/mtrrun/skiplist.json
+++ b/cmd/mtrrun/skiplist.json
@@ -4113,14 +4113,6 @@
       "reason": "out of range value for geometry column"
     },
     {
-      "test": "sys_vars/max_delayed_threads_basic",
-      "reason": "session-scope SET should give ER_WRONG_VALUE_FOR_VAR not ER_GLOBAL_VARIABLE"
-    },
-    {
-      "test": "sys_vars/max_insert_delayed_threads_basic",
-      "reason": "session-scope SET should give ER_WRONG_VALUE_FOR_VAR not ER_GLOBAL_VARIABLE"
-    },
-    {
       "test": "sys_vars/ft_boolean_syntax_basic",
       "reason": "needs value validation"
     },

--- a/executor/variables.go
+++ b/executor/variables.go
@@ -898,6 +898,7 @@ func (e *Executor) execSet(stmt *sqlparser.Set) (*Result, error) {
 				} else if rng, ok := sysVarIntRange[cleanName]; ok {
 					var clamped string
 					var err error
+					savedWarningsLen := len(e.warnings)
 					if rng.BlockSize > 0 {
 						clamped, err = e.clampIntVar(cleanName, expr.Expr, rng.Min, rng.Max, rng.IsUnsigned, rng.BlockSize)
 					} else {
@@ -944,6 +945,22 @@ func (e *Executor) execSet(stmt *sqlparser.Set) (*Result, error) {
 									}
 								}
 							}
+						}
+					}
+					// max_delayed_threads and max_insert_delayed_threads at session scope
+					// only allow values of 0 or the current global value (MySQL deprecated behavior).
+					// Any in-range value that doesn't equal 0 or global gives ER_WRONG_VALUE_FOR_VAR.
+					if !isGlobal && (cleanName == "max_delayed_threads" || cleanName == "max_insert_delayed_threads") {
+						globalVal := "20" // compiled default
+						if gv, ok := e.getGlobalVar(cleanName); ok {
+							globalVal = gv
+						}
+						if clamped != "0" && clamped != globalVal {
+							// Undo any clamping warnings and return ER_WRONG_VALUE_FOR_VAR.
+							e.warnings = e.warnings[:savedWarningsLen]
+							rawVal := strings.TrimSpace(sqlparser.String(expr.Expr))
+							rawVal = strings.Trim(rawVal, "'\"")
+							return nil, mysqlError(1231, "42000", fmt.Sprintf("Variable '%s' can't be set to the value of '%s'", cleanName, rawVal))
 						}
 					}
 					e.sessionScopeVars[cleanName] = clamped


### PR DESCRIPTION
## Summary
- `max_delayed_threads` and `max_insert_delayed_threads` are deprecated variables with a MySQL-specific constraint: at session scope, only values `0` or the current global value are valid; any other in-range value yields `ER_WRONG_VALUE_FOR_VAR` (error 1231)
- Added post-clamp check in `executor/variables.go` that enforces this constraint, with warning restoration if an out-of-range value was clamped before the check
- Unskipped `sys_vars/max_delayed_threads_basic` and `sys_vars/max_insert_delayed_threads_basic` — both now pass

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./... -count=1` passes
- [x] `sys_vars/max_delayed_threads_basic` passes
- [x] `sys_vars/max_insert_delayed_threads_basic` passes
- [x] Full mtrrun: Passed 1848 (baseline 1845, +3)
- [x] FDL guards: subquery_sj_mat=8435, explain_json_all=1355, explain_json_none=1256 (all maintained)

🤖 Generated with [Claude Code](https://claude.com/claude-code)