### PR TITLE
fix: reject sql_slave_skip_counter SET when gtid_mode=ON

### DIFF
--- a/cmd/mtrrun/skiplist.json
+++ b/cmd/mtrrun/skiplist.json
@@ -4185,10 +4185,6 @@
       "reason": "type validation for string-type vars"
     },
     {
-      "test": "sys_vars/sql_slave_skip_counter_basic",
-      "reason": "GTID mode interaction needed"
-    },
-    {
       "test": "sys_vars/windowing_use_high_precision_basic",
       "reason": "float formatting and EXPLAIN output mismatch"
     }

--- a/executor/variables.go
+++ b/executor/variables.go
@@ -963,6 +963,14 @@ func (e *Executor) execSet(stmt *sqlparser.Set) (*Result, error) {
 							return nil, mysqlError(1231, "42000", fmt.Sprintf("Variable '%s' can't be set to the value of '%s'", cleanName, rawVal))
 						}
 					}
+					// sql_slave_skip_counter (and its alias sql_replica_skip_counter) cannot
+					// be set when @@GLOBAL.GTID_MODE = ON.
+					if cleanName == "sql_slave_skip_counter" || cleanName == "sql_replica_skip_counter" {
+						gtidMode, _ := e.getGlobalVar("gtid_mode")
+						if strings.ToUpper(gtidMode) == "ON" {
+							return nil, mysqlError(1695, "HY000", "sql_slave_skip_counter can not be set when the server is running with @@GLOBAL.GTID_MODE = ON. Instead, for each transaction that you want to skip, generate an empty transaction with the same GTID as the transaction")
+						}
+					}
 					e.sessionScopeVars[cleanName] = clamped
 					// When max_join_size is set, update sql_big_selects accordingly.
 					// Non-default value -> sql_big_selects = OFF; default -> ON.


### PR DESCRIPTION
## Summary

- When `@@GLOBAL.GTID_MODE = ON`, setting `sql_slave_skip_counter` (or its alias `sql_replica_skip_counter`) now correctly fails with error 1695 (HY000), matching MySQL's behavior
- Added validation in the int-range variable SET handler to check `gtid_mode` before allowing `sql_slave_skip_counter` to be set
- Unskips `sys_vars/sql_slave_skip_counter_basic` test

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./... -count=1` passes  
- [x] `sys_vars/sql_slave_skip_counter_basic` now passes (was skipped)
- [x] Full mtrrun: Passed 1852 (was 1850, +2)
- [x] FDL guards maintained: subquery_sj_mat=8435, explain_json_all=1355, explain_json_none=1256
- [x] No regressions detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)