### PR TITLE
fix: enforce max_prepared_stmt_count limit with correct error (pass +1)

### DIFF
--- a/cmd/mtrrun/skiplist.json
+++ b/cmd/mtrrun/skiplist.json
@@ -2717,10 +2717,6 @@
       "reason": "output mismatch or execution error"
     },
     {
-      "test": "sys_vars/max_prepared_stmt_count_func",
-      "reason": "output mismatch or execution error"
-    },
-    {
       "test": "sys_vars/myisam_data_pointer_size_func",
       "reason": "output mismatch or execution error"
     },

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -4896,6 +4896,28 @@ func (e *Executor) isTableImplicitlyLockedViaView(dbName, tableName string) bool
 	return false
 }
 
+// storePreparedStmt stores a prepared statement enforcing max_prepared_stmt_count.
+// MySQL behavior (Bug#35389): if a statement with the same name already exists,
+// it is deleted first, then the limit is checked against the reduced count.
+func (e *Executor) storePreparedStmt(name, query string) error {
+	if _, alreadyExists := e.preparedStmts[name]; alreadyExists {
+		delete(e.preparedStmts, name)
+	}
+	maxStmtStr, ok := e.getGlobalVar("max_prepared_stmt_count")
+	if !ok {
+		maxStmtStr = "16382"
+	}
+	maxStmt, err := strconv.ParseInt(maxStmtStr, 10, 64)
+	if err != nil {
+		maxStmt = 16382
+	}
+	if int64(len(e.preparedStmts)) >= maxStmt {
+		return mysqlError(1461, "42000", fmt.Sprintf("Can't create more than max_prepared_stmt_count statements (current value: %d)", maxStmt))
+	}
+	e.preparedStmts[name] = query
+	return nil
+}
+
 // execPrepare handles PREPARE stmt_name FROM 'query'.
 func (e *Executor) execPrepare(stmt *sqlparser.PrepareStmt) (*Result, error) {
 	name := strings.ToLower(stmt.Name.String())
@@ -4920,7 +4942,9 @@ func (e *Executor) execPrepare(stmt *sqlparser.PrepareStmt) (*Result, error) {
 			return nil, syntaxErr
 		}
 	}
-	e.preparedStmts[name] = query
+	if err := e.storePreparedStmt(name, query); err != nil {
+		return nil, err
+	}
 	return &Result{}, nil
 }
 

--- a/executor/preprocess.go
+++ b/executor/preprocess.go
@@ -1215,7 +1215,9 @@ func (e *Executor) preprocessQuery(query string) (string, *Result, error) {
 			// The variable may contain raw bytes from CONVERT(str USING utf16/utf32).
 			// Decode multi-byte encodings back to UTF-8 so the SQL parser can handle it.
 			queryStr = decodeMultiByteToUTF8(queryStr)
-			e.preparedStmts[stmtName] = queryStr
+			if err := e.storePreparedStmt(stmtName, queryStr); err != nil {
+				return "", nil, err
+			}
 			return "", &Result{}, nil
 		}
 		// Handle PREPARE stmt FROM 'string' or PREPARE stmt FROM "string" where the
@@ -1234,7 +1236,9 @@ func (e *Executor) preprocessQuery(query string) (string, *Result, error) {
 					return "", nil, syntaxErr
 				}
 			}
-			e.preparedStmts[strings.ToLower(stmtName)] = queryStr
+			if err := e.storePreparedStmt(strings.ToLower(stmtName), queryStr); err != nil {
+				return "", nil, err
+			}
 			return "", &Result{}, nil
 		}
 	}

--- a/executor/variables.go
+++ b/executor/variables.go
@@ -5129,6 +5129,7 @@ func (e *Executor) showStatus(upper string) (*Result, error) {
 		{Name: "Opened_tables", Value: "0"},
 		{Name: "Queries", Value: fmt.Sprintf("%d", e.questions)},
 		{Name: "Questions", Value: fmt.Sprintf("%d", e.questions)},
+		{Name: "Prepared_stmt_count", Value: fmt.Sprintf("%d", len(e.preparedStmts))},
 		{Name: "Slow_queries", Value: "0"},
 		{Name: "Sort_merge_passes", Value: "0"},
 		{Name: "Sort_range", Value: fmt.Sprintf("%d", e.sortRange)},


### PR DESCRIPTION
## Summary
- Implements `max_prepared_stmt_count` enforcement in PREPARE statement handling
- Returns MySQL error 1461 (`42000`) with the correct message: `Can't create more than max_prepared_stmt_count statements (current value: N)`
- Follows MySQL Bug#35389: when re-PREPAREing with the same name, old statement is dropped first, then count is re-checked
- Adds `Prepared_stmt_count` to `SHOW STATUS` output
- Unskips `sys_vars/max_prepared_stmt_count_func`

## Changes
- `executor/executor.go`: Added `storePreparedStmt()` helper that enforces the limit; `execPrepare()` uses it
- `executor/preprocess.go`: Both PREPARE preprocess paths (user variable and string literal) now use `storePreparedStmt()`
- `executor/variables.go`: Added `Prepared_stmt_count` to `showStatus()`
- `cmd/mtrrun/skiplist.json`: Removed `sys_vars/max_prepared_stmt_count_func`

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./... -count=1` passes
- [x] `sys_vars/max_prepared_stmt_count_func` now passes
- [x] Full mtrrun: passed 1852 (was 1851, +1, no regressions)
- [x] FDL guards: subquery_sj_mat=8435 ✓, explain_json_all=1355 ✓, explain_json_none=1256 ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)