### PR TITLE
fix: implement init_slave string-type validation and scope-without-dot parse error

### DIFF
--- a/cmd/mtrrun/skiplist.json
+++ b/cmd/mtrrun/skiplist.json
@@ -4177,10 +4177,6 @@
       "reason": "complex scope handling"
     },
     {
-      "test": "sys_vars/init_slave_basic",
-      "reason": "type validation for string-type vars"
-    },
-    {
       "test": "sys_vars/windowing_use_high_precision_basic",
       "reason": "float formatting and EXPLAIN output mismatch"
     }

--- a/executor/preprocess.go
+++ b/executor/preprocess.go
@@ -175,6 +175,17 @@ func (e *Executor) preprocessQuery(query string) (string, *Result, error) {
 	e.subqueryValCache = nil
 	upper := strings.ToUpper(trimmed)
 
+	// Detect `SELECT @@global X` / `@@session X` / `@@local X` without a dot separator,
+	// e.g. `SELECT @@global init_slave`. MySQL returns ER_PARSE_ERROR (1064/42000) for these.
+	// Vitess happily parses them as `SELECT @@global AS init_slave` so we must catch them here.
+	// Strip string literals first to avoid false matches inside quoted strings.
+	{
+		stripped := stripStringLiterals(trimmed)
+		if m := atAtScopeNoDotReCapture.FindStringSubmatch(stripped); m != nil {
+			return "", nil, mysqlError(1064, "42000", "You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near '"+m[1]+"' at line 1")
+		}
+	}
+
 	// Check for PS function parameter count errors before parsing.
 	// Only match unqualified calls (no schema prefix like "test.ps_thread_id").
 	// Strip string literals first to avoid false matches inside strings.
@@ -1344,6 +1355,11 @@ func (e *Executor) preprocessQuery(query string) (string, *Result, error) {
 
 // reSetNamesCollate matches "SET NAMES <charset> COLLATE <collation>" and captures the collation name.
 var reSetNamesCollate = regexp.MustCompile(`(?i)^SET\s+NAMES\s+\S+\s+COLLATE\s+(\S+)$`)
+
+// atAtScopeNoDotReCapture matches @@global/@@session/@@local followed by whitespace then a word
+// (no dot). E.g. `@@global init_slave` is a parse error in MySQL.
+// Captures the identifier after the scope keyword.
+var atAtScopeNoDotReCapture = regexp.MustCompile(`(?i)@@(?:global|session|local)\s+([a-zA-Z_][a-zA-Z0-9_]*)`)
 
 // extractFunctionArgList finds the first occurrence of fnName( in query (case-insensitive)
 // and returns the string between the opening and matching closing parentheses.

--- a/executor/variables.go
+++ b/executor/variables.go
@@ -1349,8 +1349,14 @@ func (e *Executor) execSet(stmt *sqlparser.Set) (*Result, error) {
 						}
 						e.sessionScopeVars[cleanName] = sv
 					} else if err == nil && evalVal == nil {
-						// nil means NULL - store empty or delete
-						delete(e.sessionScopeVars, cleanName)
+						// nil means NULL.
+						// For pure-string variables (e.g. init_slave), NULL resets to "" (empty string).
+						// For other variables, delete from session scope (falls back to default).
+						if sysVarPureStringType[cleanName] {
+							e.sessionScopeVars[cleanName] = ""
+						} else {
+							delete(e.sessionScopeVars, cleanName)
+						}
 					} else {
 						sv := val
 						if cleanName == "optimizer_switch" {
@@ -2566,6 +2572,9 @@ var sysVarEnumSet = map[string]bool{
 	"binlog_transaction_dependency_tracking":   true,
 	"replica_exec_mode":                        true,
 	"replica_type_conversions":                 true,
+	// init_slave/init_replica are pure-string vars; ON should be stored as "ON" (not converted to 1)
+	"init_slave":   true,
+	"init_replica": true,
 }
 
 // mysqlLocaleByID maps numeric locale IDs (0-110) to locale names in MySQL 8.4.
@@ -2670,6 +2679,9 @@ var sysVarAcceptIdentifier = map[string]bool{
 	"innodb_monitor_enable":    true,
 	"innodb_monitor_reset":     true,
 	"innodb_monitor_reset_all": true,
+	// init_slave/init_replica accept bare identifiers as string values (any string is valid)
+	"init_slave":   true,
+	"init_replica": true,
 }
 
 // sysVarStringType contains system variables that are string types and reject NULL values.
@@ -2728,6 +2740,10 @@ func isInvalidStringVarExpr(varName string, expr sqlparser.Expr) bool {
 	if isNumericLiteralExpr(expr) {
 		return true
 	}
+	// Boolean literals (true/false) are invalid for pure-string variables.
+	if _, isBool := expr.(sqlparser.BoolVal); isBool {
+		return true
+	}
 	// Bare identifier like `mytest.log` parses as ColName; only reject for
 	// filename-type variables (not for enum-like vars that accept bare identifiers).
 	if sysVarFilenameType[varName] {
@@ -2759,6 +2775,9 @@ var sysVarPureStringType = map[string]bool{
 	// SSL path variables: reject numeric literals with ER_WRONG_TYPE_FOR_VAR
 	"ssl_ca": true, "ssl_capath": true, "ssl_cert": true, "ssl_cipher": true,
 	"ssl_key": true, "ssl_crl": true, "ssl_crlpath": true,
+	// init_slave / init_replica: GLOBAL-only string variables that reject numeric literals/booleans
+	"init_slave":   true,
+	"init_replica": true,
 }
 
 // checkIntVarType checks if the expression is a valid integer type for integer-range


### PR DESCRIPTION
## Summary

- Add detection of `@@global X` / `@@session X` / `@@local X` (without dot) in `preprocessQuery`, returning ER_PARSE_ERROR (1064/42000) matching MySQL behavior
- Add `init_slave` and `init_replica` to `sysVarPureStringType` so numeric literals are rejected with ER_WRONG_TYPE_FOR_VAR
- Add `BoolVal` (true/false) check to `isInvalidStringVarExpr` so boolean literals are rejected for pure-string variables
- Add `init_slave`/`init_replica` to `sysVarAcceptIdentifier` so bare identifiers are accepted as string values
- Add `init_slave`/`init_replica` to `sysVarEnumSet` so `ON` is stored as the string `"ON"` (not converted to `1`)
- For `sysVarPureStringType` variables, `NULL` assignment stores `""` (empty string) instead of deleting the variable

Unskips `sys_vars/init_slave_basic`. Pass count: 1852 → 1853.

## Test plan

- [x] `go build ./... && go test ./... -count=1` passes
- [x] `go run ./cmd/mtrrun -test sys_vars/init_slave_basic -force -skipped-only` → pass
- [x] Full suite: 1853 passed (baseline was 1852)
- [x] FDL guards: subquery_sj_mat=8435 ≥ 8435, explain_json_all=1355 ≥ 1355, explain_json_none=1256 ≥ 1256

🤖 Generated with [Claude Code](https://claude.com/claude-code)