### PR TITLE
fix: gtid_next NULL rejection and GTID ownership tracking

### DIFF
--- a/cmd/mtrrun/skiplist.json
+++ b/cmd/mtrrun/skiplist.json
@@ -2713,10 +2713,6 @@
       "reason": "output mismatch or execution error"
     },
     {
-      "test": "sys_vars/gtid_next_basic",
-      "reason": "output mismatch or execution error"
-    },
-    {
       "test": "sys_vars/myisam_data_pointer_size_func",
       "reason": "output mismatch or execution error"
     },

--- a/executor/transaction.go
+++ b/executor/transaction.go
@@ -271,6 +271,8 @@ func (e *Executor) execCommit() (*Result, error) {
 	}
 	// Restore session isolation level if it was temporarily overridden by a NextTxScope set.
 	e.restoreNextTxnIsolation()
+	// Release GTID ownership acquired by SET SESSION gtid_next = 'ANONYMOUS'.
+	delete(e.sessionScopeVars, "__owns_anonymous_gtid")
 	return &Result{}, nil
 }
 
@@ -364,6 +366,8 @@ func (e *Executor) execRollback() (*Result, error) {
 		// End implicit autocommit=0 transaction tracking if present.
 		e.endImplicitTxnTracked()
 		e.restoreNextTxnIsolation()
+		// Release GTID ownership acquired by SET SESSION gtid_next = 'ANONYMOUS'.
+		delete(e.sessionScopeVars, "__owns_anonymous_gtid")
 		return &Result{}, nil
 	}
 	sp := e.savepoint
@@ -377,6 +381,8 @@ func (e *Executor) execRollback() (*Result, error) {
 	}
 	// Restore session isolation level if it was temporarily overridden by a NextTxScope set.
 	e.restoreNextTxnIsolation()
+	// Release GTID ownership acquired by SET SESSION gtid_next = 'ANONYMOUS'.
+	delete(e.sessionScopeVars, "__owns_anonymous_gtid")
 
 	// If we have an undo log, use it for precise per-connection rollback
 	// instead of the snapshot-based approach which can clobber other connections' data.

--- a/executor/variables.go
+++ b/executor/variables.go
@@ -757,6 +757,47 @@ func (e *Executor) execSet(stmt *sqlparser.Set) (*Result, error) {
 					// Fall through to the normal setSysVar path (validates and stores the value).
 					// The restoration happens in execCommit/execRollback via prevSessionIsolation.
 				}
+				// gtid_next special handling: NULL rejection and GTID ownership checks.
+				if cleanName == "gtid_next" {
+					// NULL is never valid for gtid_next.
+					if _, isNull := expr.Expr.(*sqlparser.NullVal); isNull {
+						return nil, mysqlError(1231, "42000", "Variable 'gtid_next' can't be set to the value of 'NULL'")
+					}
+					if strings.ToUpper(val) == "NULL" {
+						return nil, mysqlError(1231, "42000", "Variable 'gtid_next' can't be set to the value of 'NULL'")
+					}
+					// If the session currently owns a GTID (gtid_next was set to ANONYMOUS
+					// without an intervening COMMIT or ROLLBACK), reject any change.
+					if owns, ok := e.sessionScopeVars["__owns_anonymous_gtid"]; ok && owns == "1" {
+						return nil, mysqlError(1765, "HY000", "@@SESSION.GTID_NEXT cannot be changed by a client that owns a GTID. The client owns ANONYMOUS. Ownership is released on COMMIT or ROLLBACK.")
+					}
+					// Determine the normalized value.
+					var newGtidVal string
+					if _, isDefault := expr.Expr.(*sqlparser.Default); isDefault {
+						newGtidVal = "AUTOMATIC"
+					} else {
+						evalVal, _ := e.evalExpr(expr.Expr)
+						if evalVal != nil {
+							newGtidVal = strings.TrimSpace(fmt.Sprintf("%v", evalVal))
+						} else {
+							newGtidVal = strings.TrimSpace(val)
+						}
+					}
+					upperGtid := strings.ToUpper(newGtidVal)
+					if upperGtid == "ANONYMOUS" {
+						// Setting to ANONYMOUS means the session now owns this GTID slot.
+						e.sessionScopeVars["__owns_anonymous_gtid"] = "1"
+						e.sessionScopeVars["gtid_next"] = "ANONYMOUS"
+					} else if upperGtid == "AUTOMATIC" {
+						delete(e.sessionScopeVars, "__owns_anonymous_gtid")
+						e.sessionScopeVars["gtid_next"] = "AUTOMATIC"
+					} else {
+						// UUID:NUMBER format or other values - clear ownership.
+						delete(e.sessionScopeVars, "__owns_anonymous_gtid")
+						e.sessionScopeVars["gtid_next"] = newGtidVal
+					}
+					continue
+				}
 				// Enforce SUPER or SYSTEM_VARIABLES_ADMIN privilege for setting global variables.
 				// Non-privileged users get ER_SPECIFIC_ACCESS_DENIED_ERROR (1227).
 				if isGlobal {


### PR DESCRIPTION
## Summary
- Reject `SET SESSION gtid_next = NULL` with `ER_WRONG_VALUE_FOR_VAR` (error 1231)
- Track GTID ownership: when `gtid_next` is set to `ANONYMOUS`, mark the session as owning an anonymous GTID slot
- Reject any attempt to change `gtid_next` while owning ANONYMOUS with `ER_CANT_SET_GTID_NEXT_WHEN_OWNING_GTID` (error 1765, message: `@@SESSION.GTID_NEXT cannot be changed...`)
- Release GTID ownership on COMMIT and ROLLBACK via `delete(e.sessionScopeVars, "__owns_anonymous_gtid")`
- Unskip `sys_vars/gtid_next_basic` which now passes

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./... -count=1` passes
- [x] `sys_vars/gtid_next_basic` passes standalone
- [x] Full mtrrun: Passed 1854 (+1 from baseline 1853)
- [x] FDL guard: subquery_sj_mat=8435 ✓, explain_json_all=1355 ✓, explain_json_none=1256 ✓
- [x] No regressions detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)