### PR TITLE
fix: enforce SESSION privilege and deprecation warning for explicit_defaults_for_timestamp

### DIFF
--- a/cmd/mtrrun/skiplist.json
+++ b/cmd/mtrrun/skiplist.json
@@ -4097,10 +4097,6 @@
       "reason": "out of range value for geometry column"
     },
     {
-      "test": "sys_vars/explicit_defaults_for_timestamp_basic",
-      "reason": "needs SUPER privilege check for SET GLOBAL"
-    },
-    {
       "test": "sys_vars/init_connect_basic",
       "reason": "failing"
     },

--- a/executor/variables.go
+++ b/executor/variables.go
@@ -2244,6 +2244,7 @@ var superOnlySessionVars = map[string]bool{
 	"immediate_server_version":           true,
 	"original_commit_timestamp":          true,
 	"histogram_generation_max_mem_size":  true,
+	"explicit_defaults_for_timestamp":    true,
 }
 
 var sysVarGlobalOnly = map[string]bool{
@@ -3269,6 +3270,7 @@ var sysVarDeprecated = map[string]string{
 	"rpl_stop_slave_timeout":           "'@@rpl_stop_slave_timeout' is deprecated and will be removed in a future release. Please use rpl_stop_replica_timeout instead.",
 	"sync_master_info":                 "'@@sync_master_info' is deprecated and will be removed in a future release. Please use sync_source_info instead.",
 	"sql_slave_skip_counter":           "'@@sql_slave_skip_counter' is deprecated and will be removed in a future release. Please use sql_replica_skip_counter instead.",
+	"explicit_defaults_for_timestamp":  "'explicit_defaults_for_timestamp' is deprecated and will be removed in a future release.",
 }
 
 // sysVarBoolean contains system variables that are boolean type (ON/OFF).


### PR DESCRIPTION
## Summary

- Add `explicit_defaults_for_timestamp` to `superOnlySessionVars` so non-SUPER users receive `ER_SPECIFIC_ACCESS_DENIED_ERROR` (1227) when attempting `SET SESSION explicit_defaults_for_timestamp=...`
- Add deprecation warning (code 1287) when `explicit_defaults_for_timestamp` is set, matching MySQL 8.0 behavior
- Remove `sys_vars/explicit_defaults_for_timestamp_basic` from skiplist — test now passes

## Result

- pass: 1854 → 1856 (+2, including `explicit_defaults_for_timestamp_basic` + `other/filter_single_col_idx_big_myisam`)
- No regressions
- FDL guard: subquery_sj_mat=8435, explain_json_all=1355, explain_json_none=1256 (all maintained)

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./... -count=1` passes
- [x] `go run ./cmd/mtrrun -test sys_vars/explicit_defaults_for_timestamp_basic -skipped-only -force` → Passed: 1
- [x] Full `go run ./cmd/mtrrun` → Passed: 1856, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)