### PR TITLE
fix: convert optimizer_trace_features bitmask integers to key=value text form

### DIFF
--- a/cmd/mtrrun/skiplist.json
+++ b/cmd/mtrrun/skiplist.json
@@ -4113,10 +4113,6 @@
       "reason": "output mismatch or execution error"
     },
     {
-      "test": "sys_vars/optimizer_trace_features_basic",
-      "reason": "output mismatch or execution error"
-    },
-    {
       "test": "sys_vars/time_zone_func",
       "reason": "output mismatch or execution error"
     },

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -1162,6 +1162,101 @@ func (e *Executor) normalizeOptimizerTrace(newValue string, expr sqlparser.Expr,
 	return "", mysqlError(1231, "42000", fmt.Sprintf("Variable 'optimizer_trace' can't be set to the value of '%s'", newValue))
 }
 
+// optimizerTraceFeaturesBitmaskToText converts an integer bitmask for optimizer_trace_features
+// to the canonical key=value text form. Bits: 0=greedy_search, 1=range_optimizer,
+// 2=dynamic_range, 3=repeated_subselect.
+func optimizerTraceFeaturesBitmaskToText(n int64) string {
+	onOff := func(bit int64) string {
+		if n&bit != 0 {
+			return "on"
+		}
+		return "off"
+	}
+	return fmt.Sprintf("greedy_search=%s,range_optimizer=%s,dynamic_range=%s,repeated_subselect=%s",
+		onOff(1), onOff(2), onOff(4), onOff(8))
+}
+
+// normalizeOptimizerTraceFeatures normalizes a SET value for optimizer_trace_features.
+// Accepts integer bitmask or key=value pairs; rejects floats and invalid strings.
+func (e *Executor) normalizeOptimizerTraceFeatures(newValue string, expr sqlparser.Expr, evalVal interface{}) (string, error) {
+	const defaultFeatures = "greedy_search=on,range_optimizer=on,dynamic_range=on,repeated_subselect=on"
+	validKeys := map[string]bool{
+		"greedy_search": true, "range_optimizer": true,
+		"dynamic_range": true, "repeated_subselect": true,
+	}
+
+	// Reject float/scientific notation literals
+	if lit, isLit := expr.(*sqlparser.Literal); isLit {
+		litStr := sqlparser.String(lit)
+		isQuoted := strings.HasPrefix(litStr, "'") || strings.HasPrefix(litStr, "\"")
+		if !isQuoted && strings.ContainsAny(litStr, ".eE") {
+			return "", mysqlError(1232, "42000", "Incorrect argument type to variable 'optimizer_trace_features'")
+		}
+	}
+
+	upper := strings.ToUpper(strings.TrimSpace(newValue))
+	if upper == "DEFAULT" {
+		return defaultFeatures, nil
+	}
+
+	// If numeric integer, convert bitmask to text
+	if n, err := strconv.ParseInt(strings.TrimSpace(newValue), 10, 64); err == nil {
+		return optimizerTraceFeaturesBitmaskToText(n), nil
+	}
+
+	// Handle key=value format
+	if strings.Contains(newValue, "=") {
+		// Get current value for merging
+		currentValue := defaultFeatures
+		if cv, ok := e.getSysVar("optimizer_trace_features"); ok {
+			currentValue = cv
+		}
+		type flagEntry struct{ key, val string }
+		var flags []flagEntry
+		flagIndex := map[string]int{}
+		for _, part := range strings.Split(currentValue, ",") {
+			part = strings.TrimSpace(part)
+			if part == "" {
+				continue
+			}
+			kv := strings.SplitN(part, "=", 2)
+			if len(kv) == 2 {
+				k, v := strings.TrimSpace(kv[0]), strings.TrimSpace(kv[1])
+				flagIndex[k] = len(flags)
+				flags = append(flags, flagEntry{k, v})
+			}
+		}
+		for _, part := range strings.Split(newValue, ",") {
+			part = strings.TrimSpace(part)
+			if part == "" {
+				continue
+			}
+			kv := strings.SplitN(part, "=", 2)
+			if len(kv) != 2 {
+				return "", mysqlError(1231, "42000", fmt.Sprintf("Variable 'optimizer_trace_features' can't be set to the value of '%s'", newValue))
+			}
+			k, v := strings.ToLower(strings.TrimSpace(kv[0])), strings.ToLower(strings.TrimSpace(kv[1]))
+			if !validKeys[k] {
+				return "", mysqlError(1231, "42000", fmt.Sprintf("Variable 'optimizer_trace_features' can't be set to the value of '%s'", newValue))
+			}
+			if v != "on" && v != "off" {
+				return "", mysqlError(1231, "42000", fmt.Sprintf("Variable 'optimizer_trace_features' can't be set to the value of '%s'", newValue))
+			}
+			if idx, exists := flagIndex[k]; exists {
+				flags[idx].val = v
+			}
+		}
+		parts := make([]string, len(flags))
+		for i, f := range flags {
+			parts[i] = f.key + "=" + f.val
+		}
+		return strings.Join(parts, ","), nil
+	}
+
+	// Unknown string value
+	return "", mysqlError(1231, "42000", fmt.Sprintf("Variable 'optimizer_trace_features' can't be set to the value of '%s'", newValue))
+}
+
 // deleteSysVar deletes a system variable from the appropriate scope map (for DEFAULT).
 func (e *Executor) deleteSysVar(name string, isGlobal bool) {
 	if isGlobal {

--- a/executor/variables.go
+++ b/executor/variables.go
@@ -1406,6 +1406,17 @@ func (e *Executor) execSet(stmt *sqlparser.Set) (*Result, error) {
 							return nil, traceErr
 						}
 						e.sessionScopeVars[cleanName] = traceVal
+					} else if cleanName == "optimizer_trace_features" {
+						// optimizer_trace_features uses bitmask or key=value format.
+						sv := val
+						if evalVal != nil {
+							sv = fmt.Sprintf("%v", evalVal)
+						}
+						featVal, featErr := e.normalizeOptimizerTraceFeatures(sv, expr.Expr, evalVal)
+						if featErr != nil {
+							return nil, featErr
+						}
+						e.sessionScopeVars[cleanName] = featVal
 					} else if isBooleanVariable(cleanName) {
 						boolVal, bErr := normalizeBooleanSetValue(cleanName, expr.Expr, evalVal)
 						if bErr != nil {


### PR DESCRIPTION
## Summary

- Implements bitmask-to-text conversion for `optimizer_trace_features` system variable so that `SET optimizer_trace_features=2` produces `greedy_search=off,range_optimizer=on,dynamic_range=off,repeated_subselect=off` instead of storing the raw integer
- Handles all assignment forms: integer bitmask, `key=value` format (with merge of current state), `DEFAULT` keyword
- Rejects float literals with ER_WRONG_TYPE_FOR_VAR (1232) and invalid strings with ER_WRONG_VALUE_FOR_VAR (1231)
- Enables `sys_vars/optimizer_trace_features_basic` test (removed from skiplist)

## Test plan

- [x] `sys_vars/optimizer_trace_features_basic` now passes (was skipped)
- [x] Pass count: 1858 (baseline was 1857, target >= 1858)
- [x] `go build ./... && go test ./... -count=1` all pass
- [x] FDL guards: subquery_sj_mat=8435 >= 8435, explain_json_all=1355 >= 1355, explain_json_none=1256 >= 1256
- [x] No regressions vs baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)