### PR TITLE
fix: ROLLBACK for autocommit=0 implicit transactions

### DIFF
--- a/cmd/mtrrun/skiplist.json
+++ b/cmd/mtrrun/skiplist.json
@@ -2781,10 +2781,6 @@
       "reason": "LOAD DATA not fully supported"
     },
     {
-      "test": "sys_vars/autocommit_func2",
-      "reason": "still failing"
-    },
-    {
       "test": "sys_vars/autocommit_func3",
       "reason": "still failing"
     },

--- a/executor/dml_delete.go
+++ b/executor/dml_delete.go
@@ -486,8 +486,8 @@ func (e *Executor) execDelete(stmt *sqlparser.Delete) (*Result, error) {
 			}
 		}
 
-		// Record undo entries (in ascending original-index order) for transaction rollback.
-		if e.inTransaction && len(deleteSet) > 0 {
+		// Record undo entries (in ascending original-index order) for transaction rollback (explicit or autocommit=0 implicit).
+		if (e.inTransaction || e.isAutocommitOff()) && len(deleteSet) > 0 {
 			delIdxOrder := make([]int, 0, len(deleteSet))
 			for idx := range deleteSet {
 				delIdxOrder = append(delIdxOrder, idx)
@@ -638,8 +638,8 @@ func (e *Executor) execDelete(stmt *sqlparser.Delete) (*Result, error) {
 		tbl.Rows = newRows
 		tbl.InvalidateIndexes()
 		affected++
-		// Record undo entry for transaction rollback.
-		if e.inTransaction && rowRemoved {
+		// Record undo entry for transaction rollback (explicit or autocommit=0 implicit).
+		if (e.inTransaction || e.isAutocommitOff()) && rowRemoved {
 			e.txnUndoLog = append(e.txnUndoLog, undoEntry{
 				op:       "DELETE",
 				db:       deleteDB,

--- a/executor/dml_insert.go
+++ b/executor/dml_insert.go
@@ -561,8 +561,8 @@ func (e *Executor) execInsert(stmt *sqlparser.Insert) (*Result, error) {
 					delete(row, "__txn_conn_id__")
 					return nil, err
 				}
-				// Record undo entry for transaction rollback
-				if e.inTransaction {
+				// Record undo entry for transaction rollback (explicit or autocommit=0 implicit)
+				if e.inTransaction || e.isAutocommitOff() {
 					e.txnUndoLog = append(e.txnUndoLog, undoEntry{
 						op:     "INSERT",
 						db:     insertDB,
@@ -2681,8 +2681,8 @@ func (e *Executor) execInsert(stmt *sqlparser.Insert) (*Result, error) {
 			}
 			return nil, err
 		}
-		// Record undo entry for transaction rollback
-		if e.inTransaction {
+		// Record undo entry for transaction rollback (explicit or autocommit=0 implicit)
+		if e.inTransaction || e.isAutocommitOff() {
 			e.txnUndoLog = append(e.txnUndoLog, undoEntry{
 				op:     "INSERT",
 				db:     insertDB,

--- a/executor/dml_update.go
+++ b/executor/dml_update.go
@@ -954,8 +954,8 @@ func (e *Executor) execUpdate(stmt *sqlparser.Update) (*Result, error) {
 		matchedRows++
 		if rowChanged {
 			affected++
-			// Record undo entry for transaction rollback.
-			if e.inTransaction {
+			// Record undo entry for transaction rollback (explicit or autocommit=0 implicit).
+			if e.inTransaction || e.isAutocommitOff() {
 				e.txnUndoLog = append(e.txnUndoLog, undoEntry{
 					op:       "UPDATE",
 					db:       updateDB,

--- a/executor/transaction.go
+++ b/executor/transaction.go
@@ -155,6 +155,18 @@ func (e *Executor) execBegin() (*Result, error) {
 	return &Result{}, nil
 }
 
+// isAutocommitOff returns true when the autocommit session variable is 0/OFF.
+// This is used to determine whether to record undo log entries for implicit
+// (autocommit=0) transactions so that ROLLBACK can undo them.
+func (e *Executor) isAutocommitOff() bool {
+	v, ok := e.getSysVar("autocommit")
+	if !ok {
+		return false
+	}
+	upper := strings.ToUpper(v)
+	return upper == "0" || upper == "OFF"
+}
+
 // ensureImplicitTxnTracked registers the current connection in TxnActiveSet when
 // autocommit=0 is active. MySQL treats autocommit=0 as starting an implicit
 // transaction on the first DML, so we need it to show in INNODB_TRX.
@@ -239,6 +251,8 @@ func (e *Executor) execCommit() (*Result, error) {
 	}
 	if !e.inTransaction {
 		// End implicit autocommit=0 transaction tracking if present.
+		// Discard any pending undo log (data is committed).
+		e.txnUndoLog = nil
 		e.endImplicitTxnTracked()
 		e.restoreNextTxnIsolation()
 		return &Result{}, nil
@@ -363,6 +377,12 @@ func (e *Executor) execRollback() (*Result, error) {
 		e.rowLockManager.ReleaseRowLocks(e.connectionID)
 	}
 	if !e.inTransaction {
+		// For autocommit=0 implicit transactions, apply any accumulated undo log.
+		if len(e.txnUndoLog) > 0 {
+			undoLog := e.txnUndoLog
+			e.txnUndoLog = nil
+			e.replayUndoLog(undoLog)
+		}
 		// End implicit autocommit=0 transaction tracking if present.
 		e.endImplicitTxnTracked()
 		e.restoreNextTxnIsolation()


### PR DESCRIPTION
## Summary

- `ROLLBACK` with `autocommit=0` (no explicit `BEGIN`) was a no-op: DML operations only recorded undo log entries when `e.inTransaction` was true, but implicit autocommit=0 transactions never set that flag
- Fix extends the undo log guard in INSERT/UPDATE/DELETE to also record entries when `isAutocommitOff()` is true
- `execRollback()` now applies accumulated undo log for implicit transactions; `execCommit()` now clears it on commit
- Adds `isAutocommitOff()` helper to `transaction.go` for consistent autocommit detection
- Unskips `sys_vars/autocommit_func2`

## Test plan

- [x] `go build ./... && go test ./... -count=1` — all pass
- [x] `go run ./cmd/mtrrun -test sys_vars/autocommit_func2` — now passes (was skipped)
- [x] Full `go run ./cmd/mtrrun` — 1861 passed (baseline 1860, +1)
- [x] FDL guards: subquery_sj_mat=8435 ≥ 8435, explain_json_all=1355 ≥ 1355, explain_json_none=1256 ≥ 1256
- [x] No regressions: only `autocommit_func2` changed from skipped to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)