### PR TITLE
fix: enforce transaction restriction for SET GLOBAL binlog_checksum

### DIFF
--- a/cmd/mtrrun/skiplist.json
+++ b/cmd/mtrrun/skiplist.json
@@ -4085,10 +4085,6 @@
       "reason": "out of range value for geometry column"
     },
     {
-      "test": "sys_vars/binlog_checksum_basic",
-      "reason": "output mismatch"
-    },
-    {
       "test": "sys_vars/default_table_encryption_basic",
       "reason": "output mismatch or execution error"
     },

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -353,6 +353,7 @@ type Executor struct {
 	Storage        *storage.Engine
 	CurrentDB      string
 	inTransaction  bool
+	inXATransaction bool // true while an XA transaction is active (XA START ... XA END/COMMIT/ROLLBACK)
 	savepoint      *txSavepoint
 	// namedSavepoints tracks savepoint names set in the current transaction.
 	// DDL statements (implicit commit) clears this map, so ROLLBACK TO SAVEPOINT fails.
@@ -2810,6 +2811,19 @@ func (e *Executor) Execute(query string) (res *Result, retErr error) {
 		if strings.HasPrefix(upper, "CHECKSUM TABLE ") || upper == "CHECKSUM TABLE" {
 			return e.execOtherAdmin(query)
 		}
+		// XA transaction tracking: XA START sets inXATransaction; XA END/COMMIT/ROLLBACK clears it.
+		if strings.HasPrefix(upper, "XA ") {
+			rest := strings.TrimSpace(upper[3:])
+			if strings.HasPrefix(rest, "START ") || strings.HasPrefix(rest, "BEGIN ") {
+				e.inXATransaction = true
+			} else if strings.HasPrefix(rest, "END ") ||
+				strings.HasPrefix(rest, "COMMIT ") ||
+				strings.HasPrefix(rest, "ROLLBACK ") ||
+				rest == "END" || rest == "COMMIT" || rest == "ROLLBACK" {
+				e.inXATransaction = false
+			}
+			return &Result{}, nil
+		}
 		if strings.HasPrefix(upper, "CREATE EVENT") ||
 			strings.HasPrefix(upper, "DROP EVENT") ||
 			strings.HasPrefix(upper, "CREATE USER") ||
@@ -2834,7 +2848,6 @@ func (e *Executor) Execute(query string) (res *Result, retErr error) {
 			strings.HasPrefix(upper, "SIGNAL ") ||
 			strings.HasPrefix(upper, "RESIGNAL") ||
 			strings.HasPrefix(upper, "GET DIAGNOSTICS") ||
-			strings.HasPrefix(upper, "XA ") ||
 			strings.HasPrefix(upper, "ALTER PROCEDURE") ||
 			strings.HasPrefix(upper, "ALTER FUNCTION") ||
 			strings.HasPrefix(upper, "CHANGE ") ||

--- a/executor/transaction.go
+++ b/executor/transaction.go
@@ -285,8 +285,9 @@ func (e *Executor) execCommit() (*Result, error) {
 	}
 	// Restore session isolation level if it was temporarily overridden by a NextTxScope set.
 	e.restoreNextTxnIsolation()
-	// Release GTID ownership acquired by SET SESSION gtid_next = 'ANONYMOUS'.
+	// Release GTID ownership acquired by SET SESSION gtid_next = 'ANONYMOUS' or UUID:NUMBER.
 	delete(e.sessionScopeVars, "__owns_anonymous_gtid")
+	delete(e.sessionScopeVars, "__owns_specific_gtid")
 	return &Result{}, nil
 }
 
@@ -386,8 +387,9 @@ func (e *Executor) execRollback() (*Result, error) {
 		// End implicit autocommit=0 transaction tracking if present.
 		e.endImplicitTxnTracked()
 		e.restoreNextTxnIsolation()
-		// Release GTID ownership acquired by SET SESSION gtid_next = 'ANONYMOUS'.
+		// Release GTID ownership acquired by SET SESSION gtid_next = 'ANONYMOUS' or UUID:NUMBER.
 		delete(e.sessionScopeVars, "__owns_anonymous_gtid")
+		delete(e.sessionScopeVars, "__owns_specific_gtid")
 		return &Result{}, nil
 	}
 	sp := e.savepoint
@@ -401,8 +403,9 @@ func (e *Executor) execRollback() (*Result, error) {
 	}
 	// Restore session isolation level if it was temporarily overridden by a NextTxScope set.
 	e.restoreNextTxnIsolation()
-	// Release GTID ownership acquired by SET SESSION gtid_next = 'ANONYMOUS'.
+	// Release GTID ownership acquired by SET SESSION gtid_next = 'ANONYMOUS' or UUID:NUMBER.
 	delete(e.sessionScopeVars, "__owns_anonymous_gtid")
+	delete(e.sessionScopeVars, "__owns_specific_gtid")
 
 	// If we have an undo log, use it for precise per-connection rollback
 	// instead of the snapshot-based approach which can clobber other connections' data.

--- a/executor/variables.go
+++ b/executor/variables.go
@@ -792,13 +792,16 @@ func (e *Executor) execSet(stmt *sqlparser.Set) (*Result, error) {
 					if upperGtid == "ANONYMOUS" {
 						// Setting to ANONYMOUS means the session now owns this GTID slot.
 						e.sessionScopeVars["__owns_anonymous_gtid"] = "1"
+						delete(e.sessionScopeVars, "__owns_specific_gtid")
 						e.sessionScopeVars["gtid_next"] = "ANONYMOUS"
 					} else if upperGtid == "AUTOMATIC" {
 						delete(e.sessionScopeVars, "__owns_anonymous_gtid")
+						delete(e.sessionScopeVars, "__owns_specific_gtid")
 						e.sessionScopeVars["gtid_next"] = "AUTOMATIC"
 					} else {
-						// UUID:NUMBER format or other values - clear ownership.
+						// UUID:NUMBER format: session now owns this specific GTID.
 						delete(e.sessionScopeVars, "__owns_anonymous_gtid")
+						e.sessionScopeVars["__owns_specific_gtid"] = newGtidVal
 						e.sessionScopeVars["gtid_next"] = newGtidVal
 					}
 					continue
@@ -857,6 +860,17 @@ func (e *Executor) execSet(stmt *sqlparser.Set) (*Result, error) {
 						if !hasPriv {
 							return nil, mysqlError(1227, "42000", "Access denied; you need (at least one of) the SUPER, SYSTEM_VARIABLES_ADMIN or SESSION_VARIABLES_ADMIN privilege(s) for this operation")
 						}
+					}
+				}
+				// binlog_checksum cannot be changed when there is an ongoing transaction or
+				// when the session owns a GTID (GTID_NEXT is set to ANONYMOUS or UUID:NUMBER).
+				if isGlobal && cleanName == "binlog_checksum" {
+					if e.inTransaction || e.inXATransaction {
+						return nil, mysqlError(1238, "HY000", "The system variable binlog_checksum cannot be set when there is an ongoing transaction.")
+					}
+					if ownedGtid, ok := e.sessionScopeVars["__owns_specific_gtid"]; ok && ownedGtid != "" {
+						lowerGtid := strings.ToLower(ownedGtid)
+						return nil, mysqlError(1238, "HY000", fmt.Sprintf("Variable binlog_checksum cannot be changed by a client that owns a GTID. The client owns %s. Ownership is released on COMMIT or ROLLBACK.", lowerGtid))
 					}
 				}
 				// Save previous session value before SET GLOBAL overwrites it.


### PR DESCRIPTION
## Summary

- Add `inXATransaction` flag to Executor to track active XA transactions (set on `XA START`, cleared on `XA END`/`XA COMMIT`/`XA ROLLBACK`)
- Track specific GTID ownership via `__owns_specific_gtid` session var when `GTID_NEXT` is set to a UUID:NUMBER value; cleared on `COMMIT`/`ROLLBACK` or when reset to `AUTOMATIC`
- Reject `SET GLOBAL binlog_checksum` with `ER_VARIABLE_NOT_SETTABLE_IN_TRANSACTION` when a BEGIN or XA transaction is active
- Reject with GTID ownership error when the session owns a specific GTID
- Unskip `sys_vars/binlog_checksum_basic`

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./... -count=1` passes  
- [x] `sys_vars/binlog_checksum_basic` now passes (was skipped)
- [x] Full suite: 1862 passed (was 1861), no regressions
- [x] FDL guards maintained: subquery_sj_mat=8435, explain_json_all=1355, explain_json_none=1256
- [x] `sys_vars/gtid_next_basic` still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)