### PR TITLE
fix: unskip sys_vars/autocommit_func3 (tactical round 155)

### DIFF
--- a/cmd/mtrrun/skiplist.json
+++ b/cmd/mtrrun/skiplist.json
@@ -2781,10 +2781,6 @@
       "reason": "LOAD DATA not fully supported"
     },
     {
-      "test": "sys_vars/autocommit_func3",
-      "reason": "still failing"
-    },
-    {
       "test": "sys_vars/autocommit_func4",
       "reason": "still failing"
     },


### PR DESCRIPTION
## Summary
- Removes `sys_vars/autocommit_func3` from the skiplist as the test now passes
- The test validates `autocommit` variable toggle and ROLLBACK behavior with InnoDB tables

## Test Results
- Passes: 1862 → 1863 (+1)
- No regressions
- FDL guards maintained: subquery_sj_mat=8435, explain_json_all=1355, explain_json_none=1256

## Test Plan
- [x] `go build ./...` passes
- [x] `go test ./... -count=1` passes
- [x] Full `mtrrun` suite: 1863 passed (up from 1862)
- [x] No regressions (verified with suite+name unique key)
- [x] FDL guards verified for subquery_sj_mat, explain_json_all, explain_json_none

🤖 Generated with [Claude Code](https://claude.com/claude-code)