### PR TITLE
fix: unskip sys_vars/autocommit_func4 and autocommit_func5 (now pass)

### DIFF
--- a/cmd/mtrrun/skiplist.json
+++ b/cmd/mtrrun/skiplist.json
@@ -2773,14 +2773,6 @@
       "reason": "LOAD DATA not fully supported"
     },
     {
-      "test": "sys_vars/autocommit_func4",
-      "reason": "still failing"
-    },
-    {
-      "test": "sys_vars/autocommit_func5",
-      "reason": "still failing"
-    },
-    {
       "test": "sys_vars/completion_type_func",
       "reason": "still failing"
     },


### PR DESCRIPTION
## Summary
- Found `sys_vars/autocommit_func4` and `sys_vars/autocommit_func5` already pass when run with `-skipped-only -force`
- Removed both from skiplist (free-pass, no code changes needed)
- Pass count: 1865 → 1867 (+2)

## FDL Guard Check
- `subquery_sj_mat`: line 8435 (guard: 8435) - OK
- `explain_json_all`: line 1355 (guard: 1355) - OK
- `explain_json_none`: line 1256 (guard: 1256) - OK

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./... -count=1` passes
- [x] Full mtrrun suite: Passed 1867 (was 1865)
- [x] No regressions detected
- [x] All FDL guards maintained

🤖 Generated with [Claude Code](https://claude.com/claude-code)