### PR TITLE
feat(perfschema): add unary operator stripping to statement digest (Refs #254)

### DIFF
--- a/cmd/mtrrun/skiplist.json
+++ b/cmd/mtrrun/skiplist.json
@@ -3633,10 +3633,6 @@
       "reason": "output mismatch, timeout, or error"
     },
     {
-      "test": "perfschema/unary_digest",
-      "reason": "output mismatch, timeout, or error"
-    },
-    {
       "test": "perfschema/view_table_io",
       "reason": "output mismatch, timeout, or error"
     },

--- a/executor/perfschema_digest.go
+++ b/executor/perfschema_digest.go
@@ -27,6 +27,7 @@ import (
 func normalizeStatementDigest(query string) (digest string, digestText string) {
 	tokens := tokenizeForDigest(query)
 	tokens = reclassifyNullTokens(tokens)
+	tokens = collapseUnaryOperators(tokens)
 	tokens = collapseInsideParenLiterals(tokens)
 	tokens = collapseValueLists(tokens)
 	tokens = collapseTopLevelLiteralList(tokens)
@@ -34,6 +35,76 @@ func normalizeStatementDigest(query string) (digest string, digestText string) {
 	h := sha256.Sum256([]byte(digestText))
 	digest = hex.EncodeToString(h[:])
 	return digest, digestText
+}
+
+// collapseUnaryOperators strips unary '+' and '-' operators that immediately
+// precede a literal (number/string/null) in a unary-operator context.
+//
+// A '+'/'-' operator is considered unary when the preceding non-operator token
+// (looking back past any chain of +/- operators) is one of:
+//   - start of the token stream (implicit: after SELECT, etc.)
+//   - a '(' punctuation
+//   - a ',' punctuation
+//   - another operator (!=, <=, >= etc. — but not +/- themselves in binary context)
+//   - a keyword such as SELECT, WHERE, AND, OR, NOT, BY, HAVING, SET, RETURN, THEN, ELSE
+//
+// Crucially, unary stripping only applies when the operator directly precedes a
+// LITERAL token (number/string/null). When it precedes an identifier (e.g. -a),
+// the operator is kept.
+func collapseUnaryOperators(tokens []digestToken) []digestToken {
+	// We make multiple passes until no changes occur (handles chains like +++1).
+	for {
+		changed := false
+		out := make([]digestToken, 0, len(tokens))
+		i := 0
+		for i < len(tokens) {
+			t := tokens[i]
+			// Check if this is a '+' or '-' operator followed by a literal
+			if t.kind == tokOperator && (t.text == "+" || t.text == "-") && i+1 < len(tokens) && isLiteralTok(tokens[i+1]) {
+				// Look back at the last non-unary-op token in `out` to determine context
+				if isUnaryContext(out) {
+					// Strip this unary operator
+					changed = true
+					i++ // skip the operator, keep the literal
+					continue
+				}
+			}
+			out = append(out, t)
+			i++
+		}
+		tokens = out
+		if !changed {
+			break
+		}
+	}
+	return tokens
+}
+
+// isUnaryContext returns true if the given token sequence (already emitted)
+// indicates that a following '+'/'-' operator is in unary position.
+func isUnaryContext(out []digestToken) bool {
+	if len(out) == 0 {
+		return true
+	}
+	prev := out[len(out)-1]
+	switch prev.kind {
+	case tokPunct:
+		return prev.text == "(" || prev.text == ","
+	case tokOperator:
+		// Any binary comparison operator or logical operator puts next +/- in unary context
+		// But NOT a preceding literal (binary context): that's handled by caller checking isLiteralTok
+		return true
+	case tokKeyword:
+		// These keywords put the next token in an "expression start" context
+		switch prev.text {
+		case "SELECT", "WHERE", "AND", "OR", "NOT", "BY", "HAVING",
+			"SET", "RETURN", "THEN", "ELSE", "ON", "WHEN",
+			"BETWEEN", "IN", "EXISTS", "CASE", "UNION", "ALL",
+			"VALUES", "VALUE":
+			return true
+		}
+	}
+	return false
 }
 
 // reclassifyNullTokens changes tokNull tokens to tokKeyword when they appear

--- a/executor/perfschema_digest_test.go
+++ b/executor/perfschema_digest_test.go
@@ -45,6 +45,58 @@ func TestNormalizeStatementDigest_StableHash(t *testing.T) {
 	}
 }
 
+func TestNormalizeStatementDigest_UnaryOperators(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		// Unary +/- before literal at top-level SELECT (stripped)
+		{"select_pos1", "select 1 from expect_unary", "SELECT ? FROM `expect_unary`"},
+		{"select_pos2", "select +1 from expect_unary", "SELECT ? FROM `expect_unary`"},
+		{"select_neg", "select -1 from expect_unary", "SELECT ? FROM `expect_unary`"},
+		{"select_many_plus", "select ++++++1 from expect_unary", "SELECT ? FROM `expect_unary`"},
+		{"select_many_minus", "select ------1 from expect_unary", "SELECT ? FROM `expect_unary`"},
+		// Binary context (preceded by literal): operators kept
+		{"select_binary_plus", "select 0+1 from expect_binary", "SELECT ? + ? FROM `expect_binary`"},
+		{"select_binary_minus", "select 0-1 from expect_binary", "SELECT ? - ? FROM `expect_binary`"},
+		// Identifier context: unary operator kept (not stripped)
+		{"select_unary_ident", "select -a, +b from t", "SELECT - `a` , + `b` FROM `t`"},
+		// Inside tuple: unary stripped (context is '(' or ',')
+		{"insert_unary_tuple", "insert into t values (-1, +2, -3)", "INSERT INTO `t` VALUES (...)"},
+		// Full unary_digest test case for expect_unchanged: -a, +b kept
+		{"select_unchanged", "select a-b, a+b, -a, -b, +a, +b from expect_unchanged",
+			"SELECT `a` - `b` , `a` + `b` , - `a` , - `b` , + `a` , + `b` FROM `expect_unchanged`"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, got := normalizeStatementDigest(tc.in)
+			if got != tc.want {
+				t.Errorf("normalize(%q)\n got  %q\nwant %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestNormalizeStatementDigest_UnaryDigestAllVariants verifies that all 5 variants
+// of the unary_digest test normalize to the same DIGEST_TEXT.
+func TestNormalizeStatementDigest_UnaryDigestAllVariants(t *testing.T) {
+	queries := []string{
+		"select 1 from expect_unary",
+		"select +1 from expect_unary",
+		"select -1 from expect_unary",
+		"select ++++++++++++++++++++++++++++++++++++++++++++++++1 from expect_unary",
+		"select ------------------------------------------------1 from expect_unary",
+	}
+	want := "SELECT ? FROM `expect_unary`"
+	for _, q := range queries {
+		_, got := normalizeStatementDigest(q)
+		if got != want {
+			t.Errorf("normalize(%q)\n got  %q\nwant %q", q, got, want)
+		}
+	}
+}
+
 func TestNormalizeStatementDigest_CommentsStripped(t *testing.T) {
 	_, got := normalizeStatementDigest("SELECT 1 /* hello */ + 1")
 	if strings.Contains(got, "hello") {


### PR DESCRIPTION
## Summary

- Add `collapseUnaryOperators` normalization pass to `normalizeStatementDigest` in `executor/perfschema_digest.go`
- Unary `+`/`-` operators preceding a **literal** (number/string/null) are stripped when in unary context (after `(`, `,`, `SELECT`, `WHERE`, etc.)
- Binary operator uses (e.g. `0+1`) and identifier operands (e.g. `-a`, `+b`) are kept unchanged — only literal operands get stripped
- Multiple chained unary ops (e.g. `++++++1`) are collapsed iteratively until stable
- Unskips `perfschema/unary_digest`, which now passes

## Key normalization rules implemented

| Query | DIGEST_TEXT |
|---|---|
| `select +1 from t` | `SELECT ? FROM \`t\`` |
| `select -1 from t` | `SELECT ? FROM \`t\`` |
| `select +++1 from t` | `SELECT ? FROM \`t\`` (chains collapsed) |
| `select 0+1 from t` | `SELECT ? + ? FROM \`t\`` (binary kept) |
| `select -a from t` | `SELECT - \`a\` FROM \`t\`` (ident not stripped) |
| `insert into t values (-1, +2)` | `INSERT INTO \`t\` VALUES (...)` (inside tuple) |

## Test results

- `perfschema/unary_digest`: **skip → pass** ✓
- FDL guards all maintained: subquery_sj_mat=8435, explain_json_all=1355, explain_json_none=1256 ✓
- No regressions (one flaky MyISAM timeout unrelated to these changes)
- All unit tests pass: `go test ./... -count=1`

Refs #254

🤖 Generated with [Claude Code](https://claude.com/claude-code)