### PR TITLE
feat: support integer bitmask for SET optimizer_switch

### DIFF
--- a/cmd/mtrrun/skiplist.json
+++ b/cmd/mtrrun/skiplist.json
@@ -3925,10 +3925,6 @@
       "reason": "@@session.character_set_results casing issue"
     },
     {
-      "test": "sys_vars/optimizer_switch_basic",
-      "reason": "complex SET optimizer_switch parsing not supported"
-    },
-    {
       "test": "other/derived",
       "reason": "access denied for user mysqltest_1"
     },

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -1044,11 +1044,83 @@ func (e *Executor) setSysVar(name string, value string, isGlobal bool) {
 	}
 }
 
+// optimizerSwitchFlags is the canonical ordered list of optimizer_switch flag names.
+// Bit N corresponds to the Nth flag (0-based). This matches MySQL 8.0's bitmask order.
+var optimizerSwitchFlags = []string{
+	"index_merge", "index_merge_union", "index_merge_sort_union", "index_merge_intersection",
+	"engine_condition_pushdown", "index_condition_pushdown", "mrr", "mrr_cost_based",
+	"block_nested_loop", "batched_key_access", "materialization", "semijoin",
+	"loosescan", "firstmatch", "duplicateweedout", "subquery_materialization_cost_based",
+	"use_index_extensions", "condition_fanout_filter", "derived_merge", "use_invisible_indexes",
+	"skip_scan",
+}
+
+// normalizeOptimizerSwitchInput validates and pre-processes a raw SET optimizer_switch value.
+// It rejects float/scientific notation, converts integer bitmasks to flag=on/off strings,
+// validates string values, and expands "default"/"def".
+func (e *Executor) normalizeOptimizerSwitchInput(newValue string, expr sqlparser.Expr) (string, error) {
+	// Reject float/scientific notation (unquoted literals like 1.1 or 1e1)
+	if lit, isLit := expr.(*sqlparser.Literal); isLit {
+		litStr := sqlparser.String(lit)
+		isQuoted := strings.HasPrefix(litStr, "'") || strings.HasPrefix(litStr, "\"")
+		if !isQuoted && strings.ContainsAny(litStr, ".eE") {
+			return "", mysqlError(1232, "42000", "Incorrect argument type to variable 'optimizer_switch'")
+		}
+	}
+
+	trimmed := strings.TrimSpace(newValue)
+
+	// Integer value: treat as bitmask
+	if n, err := strconv.ParseInt(trimmed, 10, 64); err == nil {
+		parts := make([]string, len(optimizerSwitchFlags))
+		for i, flag := range optimizerSwitchFlags {
+			if (n>>uint(i))&1 == 1 {
+				parts[i] = flag + "=on"
+			} else {
+				parts[i] = flag + "=off"
+			}
+		}
+		return strings.Join(parts, ","), nil
+	}
+
+	// "default" or "def" prefix: reset to compiled default (handled in mergeOptimizerSwitch)
+	upper := strings.ToUpper(trimmed)
+	if strings.HasPrefix("DEFAULT", upper) && len(upper) >= 3 {
+		return "default", nil
+	}
+
+	// String value: validate — must contain '=' in each comma-separated part
+	// or be "default". Bare words like "index_merge" or "foobar" are invalid.
+	stripped := strings.Trim(trimmed, "'\"")
+	for _, part := range strings.Split(stripped, ",") {
+		part = strings.TrimSpace(part)
+		if part == "" {
+			continue
+		}
+		if !strings.Contains(part, "=") {
+			return "", mysqlError(1231, "42000", fmt.Sprintf("Variable 'optimizer_switch' can't be set to the value of '%s'", stripped))
+		}
+	}
+	return newValue, nil
+}
+
 // mergeOptimizerSwitch merges a partial optimizer_switch setting into the current value.
 // MySQL allows SET optimizer_switch='flag=on' to only change one flag at a time.
 func (e *Executor) mergeOptimizerSwitch(newValue string, isGlobal bool) string {
-	// Special case: 'default' resets optimizer_switch to the compiled default value.
-	if strings.EqualFold(strings.TrimSpace(newValue), "default") {
+	// Special case: 'default'/'def' resets optimizer_switch.
+	// For session: reset to current global value. For global: reset to compiled default.
+	trimmed := strings.TrimSpace(newValue)
+	upper := strings.ToUpper(trimmed)
+	if upper == "DEFAULT" || (strings.HasPrefix("DEFAULT", upper) && len(upper) >= 3) {
+		if !isGlobal {
+			// Session "default" → use global value
+			if gv, ok := e.getGlobalVar("optimizer_switch"); ok {
+				return gv
+			}
+			if v, ok := e.startupVars["optimizer_switch"]; ok {
+				return v
+			}
+		}
 		if compiled, ok := e.getCompiledDefault("optimizer_switch"); ok {
 			return compiled
 		}

--- a/executor/variables.go
+++ b/executor/variables.go
@@ -1460,6 +1460,17 @@ func (e *Executor) execSet(stmt *sqlparser.Set) (*Result, error) {
 							return nil, featErr
 						}
 						e.sessionScopeVars[cleanName] = featVal
+					} else if cleanName == "optimizer_switch" {
+						// optimizer_switch accepts integer bitmask, key=value strings, or "default".
+						sv := val
+						if evalVal != nil {
+							sv = fmt.Sprintf("%v", evalVal)
+						}
+						normalized, swErr := e.normalizeOptimizerSwitchInput(sv, expr.Expr)
+						if swErr != nil {
+							return nil, swErr
+						}
+						e.sessionScopeVars[cleanName] = e.mergeOptimizerSwitch(normalized, isGlobal)
 					} else if isBooleanVariable(cleanName) {
 						boolVal, bErr := normalizeBooleanSetValue(cleanName, expr.Expr, evalVal)
 						if bErr != nil {
@@ -1476,9 +1487,6 @@ func (e *Executor) execSet(stmt *sqlparser.Set) (*Result, error) {
 								sv = "OFF"
 							}
 						}
-						if cleanName == "optimizer_switch" {
-							sv = e.mergeOptimizerSwitch(sv, isGlobal)
-						}
 						e.sessionScopeVars[cleanName] = sv
 					} else if err == nil && evalVal == nil {
 						// nil means NULL.
@@ -1490,11 +1498,7 @@ func (e *Executor) execSet(stmt *sqlparser.Set) (*Result, error) {
 							delete(e.sessionScopeVars, cleanName)
 						}
 					} else {
-						sv := val
-						if cleanName == "optimizer_switch" {
-							sv = e.mergeOptimizerSwitch(sv, isGlobal)
-						}
-						e.sessionScopeVars[cleanName] = sv
+						e.sessionScopeVars[cleanName] = val
 					}
 				}
 				// If SET GLOBAL was used, move the newly-stored value to global scope


### PR DESCRIPTION
## Summary

- Adds `normalizeOptimizerSwitchInput` function in `executor/executor.go` that pre-processes `SET optimizer_switch=N` integer values by expanding them as bitmasks (bit 0 = index_merge, bit 1 = index_merge_union, etc.)
- Rejects float/scientific notation (e.g. `1.1`, `1e1`) with `ER_WRONG_TYPE_FOR_VAR` (1232)
- Rejects bare-word strings without `=` (e.g. `'index_merge'`, `'foobar'`) with `ER_WRONG_VALUE_FOR_VAR` (1231)
- Fixes `SET SESSION optimizer_switch='default'` to reset to current global value (not compiled default)
- Removes `sys_vars/optimizer_switch_basic` from skiplist

## Test plan

- [x] `sys_vars/optimizer_switch_basic` passes
- [x] `go test ./... -count=1` passes
- [x] Full mtrrun: Passed=1883 (+1 vs baseline 1882)
- [x] FDL guard: subquery_sj_mat=8435 ✓, explain_json_all=1355 ✓, explain_json_none=1256 ✓
- [x] No regression (no previously passing tests are now failing)

Closes #511

🤖 Generated with [Claude Code](https://claude.com/claude-code)