### PR TITLE
fix: enable_info SELECT affected rows and sql_warnings info control

### DIFF
--- a/cmd/mtrrun/skiplist.json
+++ b/cmd/mtrrun/skiplist.json
@@ -3845,10 +3845,6 @@
       "reason": "fulltext search result ordering + LOCK=NONE not implemented"
     },
     {
-      "test": "sys_vars/sql_warnings_func",
-      "reason": "sql_warnings variable not controlling info line output"
-    },
-    {
       "test": "parts/partition_engine_innodb",
       "reason": "output mismatch"
     },
@@ -3971,10 +3967,6 @@
     {
       "test": "sys_vars/sql_buffer_result_func",
       "reason": "Created_tmp_tables not tracking correctly"
-    },
-    {
-      "test": "sys_vars/sql_select_limit_func",
-      "reason": "affected rows mismatch"
     },
     {
       "test": "sys_vars/slow_launch_time_func",

--- a/executor/ddl.go
+++ b/executor/ddl.go
@@ -1001,10 +1001,14 @@ func (e *Executor) execCreateTable(stmt *sqlparser.CreateTable) (*Result, error)
 			// Strategy: execute the SELECT first, then swap tables.
 			if stmt.Temp {
 				if _, alreadyTemp := e.tempTables[tableName]; !alreadyTemp {
-					// Execute SELECT while permanent table is still visible
+					// Execute SELECT while permanent table is still visible.
+					// Increment routineDepth so that sql_select_limit is not applied (CREATE ... SELECT
+					// is not subject to sql_select_limit, matching MySQL behavior).
 					prevInsideDML := e.insideDML
 					e.insideDML = true
+					e.routineDepth++
 					selResult, selErr := e.Execute(selectSQL)
+					e.routineDepth--
 					e.insideDML = prevInsideDML
 					// Release any row locks acquired by the inner SELECT (insideDML=true causes
 					// shared locks to be acquired; release them since CREATE TEMPORARY TABLE is not transactional).
@@ -1068,7 +1072,10 @@ func (e *Executor) execCreateTable(stmt *sqlparser.CreateTable) (*Result, error)
 					}
 					e.upsertInnoDBStatsRows(dbName, tableName, e.tableRowCount(dbName, tableName))
 					e.tempTables[tableName] = true
-					return &Result{}, nil
+					rowCount := uint64(len(selResult.Rows))
+					infoMsg := fmt.Sprintf("Records: %d  Duplicates: 0  Warnings: 0", rowCount)
+					e.lastInsertInfo = infoMsg
+					return &Result{AffectedRows: rowCount, InfoMessage: infoMsg}, nil
 				}
 			}
 			result, err := e.execCreateTableSelect(dbName, tableName, selectSQL)
@@ -2903,7 +2910,11 @@ func (e *Executor) execCreateTable(stmt *sqlparser.CreateTable) (*Result, error)
 				}
 			}
 		}
+		// Increment routineDepth so that sql_select_limit is not applied to the SELECT
+		// (MySQL's CREATE TABLE ... SELECT is not subject to sql_select_limit).
+		e.routineDepth++
 		selResult, selErr := e.Execute(selectSQL)
+		e.routineDepth--
 		if selErr != nil {
 			return nil, selErr
 		}
@@ -3005,6 +3016,14 @@ func (e *Executor) execCreateTable(stmt *sqlparser.CreateTable) (*Result, error)
 	// Use FromCreate variant so that SHOW INDEX cardinality returns NULL
 	// for freshly created tables (no ANALYZE run yet). MySQL behavior.
 	e.upsertInnoDBStatsRowsFromCreate(dbName, tableName, e.tableRowCount(dbName, tableName))
+
+	// For CREATE TABLE ... SELECT, return the row count as AffectedRows and set lastInsertInfo.
+	if stmt.Select != nil {
+		rowCount := uint64(e.tableRowCount(dbName, tableName))
+		infoMsg := fmt.Sprintf("Records: %d  Duplicates: 0  Warnings: 0", rowCount)
+		e.lastInsertInfo = infoMsg
+		return &Result{AffectedRows: rowCount, InfoMessage: infoMsg}, nil
+	}
 
 	return &Result{}, nil
 }
@@ -10310,9 +10329,13 @@ func (e *Executor) execCreateTableSelect(targetDB, newTableName, selectSQL strin
 		}
 	}
 	// Mark as DML context so that overflow in strict mode raises errors (not warnings).
+	// Also increment routineDepth so that sql_select_limit is not applied to the SELECT
+	// (MySQL's CREATE TABLE ... SELECT is not subject to sql_select_limit).
 	prevInsideDML := e.insideDML
 	e.insideDML = true
+	e.routineDepth++
 	result, err := e.Execute(selectSQL)
+	e.routineDepth--
 	e.insideDML = prevInsideDML
 	// Release any row locks acquired by the inner SELECT (insideDML=true causes shared
 	// locks to be acquired on source rows; those locks must not outlive this call since
@@ -10369,7 +10392,10 @@ func (e *Executor) execCreateTableSelect(targetDB, newTableName, selectSQL strin
 		tbl.Insert(sRow) //nolint:errcheck
 	}
 	e.upsertInnoDBStatsRows(targetDB, newTableName, e.tableRowCount(targetDB, newTableName))
-	return &Result{}, nil
+	rowCount := uint64(len(result.Rows))
+	infoMsg := fmt.Sprintf("Records: %d  Duplicates: 0  Warnings: 0", rowCount)
+	e.lastInsertInfo = infoMsg
+	return &Result{AffectedRows: rowCount, InfoMessage: infoMsg}, nil
 }
 
 // hasPrimaryKey returns true if the table has an explicit primary key defined.

--- a/executor/dml_insert.go
+++ b/executor/dml_insert.go
@@ -624,7 +624,9 @@ func (e *Executor) execInsert(stmt *sqlparser.Insert) (*Result, error) {
 			}
 		}
 
-		return &Result{AffectedRows: affected, InsertID: uint64(lastInsertID)}, nil
+		infoMsgFast := fmt.Sprintf("Records: %d  Duplicates: 0  Warnings: 0", affected)
+		e.lastInsertInfo = infoMsgFast
+		return &Result{AffectedRows: affected, InsertID: uint64(lastInsertID), InfoMessage: infoMsgFast}, nil
 	}
 
 	// odkvExtSourceRows holds per-row source context (all columns from the FROM clause)

--- a/executor/executor.go
+++ b/executor/executor.go
@@ -3322,7 +3322,8 @@ func (e *Executor) Execute(query string) (res *Result, retErr error) {
 		res, err := e.execSelect(s)
 		// Apply SQL_SELECT_LIMIT when no explicit LIMIT clause is present.
 		// MySQL applies sql_select_limit as the maximum rows returned to the client.
-		if err == nil && res != nil && s.Limit == nil {
+		// Inside stored procedures (routineDepth > 0), sql_select_limit is bypassed.
+		if err == nil && res != nil && s.Limit == nil && e.routineDepth == 0 {
 			if limitStr, ok := e.sessionScopeVars["sql_select_limit"]; ok {
 				if limit, convErr := strconv.ParseInt(limitStr, 10, 64); convErr == nil && limit >= 0 {
 					if int64(len(res.Rows)) > limit {

--- a/mtrrunner/runner.go
+++ b/mtrrunner/runner.go
@@ -2999,10 +2999,12 @@ func (ctx *execContext) executeQuery(stmt string) error {
 
 	// Collect result rows
 	var resultLines []string
+	var rowCount int // actual number of rows (for affected rows output)
 	// Track per-column cell strings for Max_length computation when metadata is enabled.
 	colMaxLen := make([]int, len(columns))
 	var resultCells [][]string // only populated when metadataEnabled
 	for rows.Next() {
+		rowCount++
 		values := make([]interface{}, len(columns))
 		valuePtrs := make([]interface{}, len(columns))
 		for i := range values {
@@ -3134,6 +3136,11 @@ func (ctx *execContext) executeQuery(stmt string) error {
 	if strings.HasPrefix(strings.ToUpper(strings.TrimSpace(stmt)), "EXPLAIN") &&
 		strings.Contains(strings.ToUpper(stmt), "FORMAT=TREE") {
 		ctx.output.WriteString("\n")
+	}
+
+	// --enable_info: output "affected rows: N" for SELECT (N = number of rows returned)
+	if ctx.infoEnabled {
+		ctx.output.WriteString(fmt.Sprintf("affected rows: %d\n", rowCount))
 	}
 
 	return nil
@@ -3484,6 +3491,10 @@ func (ctx *execContext) executeQueryOrExec(stmt string) error {
 			for _, line := range resultLines {
 				ctx.output.WriteString(line + "\n")
 			}
+			// --enable_info: output "affected rows: N" for each result set returned by CALL
+			if ctx.infoEnabled {
+				ctx.output.WriteString(fmt.Sprintf("affected rows: %d\n", len(resultLines)))
+			}
 		}
 
 		// Advance to next result set
@@ -3496,6 +3507,13 @@ func (ctx *execContext) executeQueryOrExec(stmt string) error {
 	ctx.replaceColumns = nil
 	ctx.replaceResult = nil
 	ctx.replaceRegex = nil
+
+	// --enable_info: CALL statements emit "affected rows: 0" for the CALL itself
+	// after all result sets from the procedure body have been output.
+	upper2 := strings.ToUpper(strings.TrimSpace(stmt))
+	if ctx.infoEnabled && strings.HasPrefix(upper2, "CALL ") {
+		ctx.output.WriteString("affected rows: 0\n")
+	}
 
 	return nil
 }
@@ -3560,23 +3578,46 @@ func (ctx *execContext) executeExec(stmt string) error {
 		if strings.HasPrefix(upper, "ALTER TABLE") || strings.HasPrefix(upper, "LOAD DATA") ||
 			strings.HasPrefix(upper, "CREATE INDEX") || strings.HasPrefix(upper, "DROP INDEX") {
 			ctx.output.WriteString(fmt.Sprintf("info: Records: %d  Duplicates: 0  Warnings: 0\n", affected))
-		} else if strings.HasPrefix(upper, "INSERT") || strings.HasPrefix(upper, "REPLACE") {
-			// Query the server for INSERT/REPLACE info (Records/Duplicates/Warnings)
+		} else if (strings.HasPrefix(upper, "CREATE TABLE") || strings.HasPrefix(upper, "CREATE TEMPORARY TABLE")) &&
+			strings.Contains(upper, " SELECT ") {
+			// CREATE TABLE ... SELECT: treat like INSERT, use LAST_INSERT_INFO for Records count.
 			var info string
 			if activeConn != nil {
 				row := activeConn.QueryRowContext(context.Background(), "MYLITE LAST_INSERT_INFO")
-				if err := row.Scan(&info); err == nil && info != "" {
-					ctx.output.WriteString(fmt.Sprintf("info: %s\n", info))
-				} else {
-					ctx.output.WriteString(fmt.Sprintf("info: Records: %d  Duplicates: 0  Warnings: 0\n", affected))
+				if err := row.Scan(&info); err != nil || info == "" {
+					info = fmt.Sprintf("Records: %d  Duplicates: 0  Warnings: 0", affected)
 				}
 			} else {
 				row := ctx.db.QueryRow("MYLITE LAST_INSERT_INFO")
-				if err := row.Scan(&info); err == nil && info != "" {
-					ctx.output.WriteString(fmt.Sprintf("info: %s\n", info))
-				} else {
-					ctx.output.WriteString(fmt.Sprintf("info: Records: %d  Duplicates: 0  Warnings: 0\n", affected))
+				if err := row.Scan(&info); err != nil || info == "" {
+					info = fmt.Sprintf("Records: %d  Duplicates: 0  Warnings: 0", affected)
 				}
+			}
+			ctx.output.WriteString(fmt.Sprintf("info: %s\n", info))
+		} else if strings.HasPrefix(upper, "INSERT") || strings.HasPrefix(upper, "REPLACE") {
+			// Get actual warning count BEFORE calling MYLITE LAST_INSERT_INFO, because
+			// each server call shifts lastWarningCount and clears the previous one.
+			actualWarnings := ctx.getWarningCount(activeConn)
+			// Query the server for INSERT/REPLACE info (Records/Duplicates/Warnings).
+			var info string
+			if activeConn != nil {
+				row := activeConn.QueryRowContext(context.Background(), "MYLITE LAST_INSERT_INFO")
+				if err := row.Scan(&info); err != nil || info == "" {
+					info = fmt.Sprintf("Records: %d  Duplicates: 0  Warnings: 0", affected)
+				}
+			} else {
+				row := ctx.db.QueryRow("MYLITE LAST_INSERT_INFO")
+				if err := row.Scan(&info); err != nil || info == "" {
+					info = fmt.Sprintf("Records: %d  Duplicates: 0  Warnings: 0", affected)
+				}
+			}
+			// Patch Warnings value in info string to reflect actual warning count.
+			if actualWarnings > 0 {
+				info = patchWarningsCount(info, actualWarnings)
+			}
+			// Only output info line when there are no warnings, or when sql_warnings=1.
+			if actualWarnings == 0 || ctx.getSQLWarnings(activeConn) {
+				ctx.output.WriteString(fmt.Sprintf("info: %s\n", info))
 			}
 		} else if strings.HasPrefix(upper, "UPDATE") {
 			// Query the server for the update info message (Rows matched/Changed)
@@ -3778,6 +3819,76 @@ func (ctx *execContext) getActiveConn() *sql.Conn {
 		return ctx.defaultConn
 	}
 	return ctx.connByName[strings.ToLower(ctx.currentConn)]
+}
+
+// extractWarningsCount parses the Warnings value from an info string like
+// "Records: 1  Duplicates: 0  Warnings: 1" and returns it as an integer.
+func extractWarningsCount(info string) int {
+	const prefix = "Warnings: "
+	idx := strings.Index(info, prefix)
+	if idx < 0 {
+		return 0
+	}
+	rest := strings.TrimSpace(info[idx+len(prefix):])
+	// rest may have trailing content; take first token
+	end := strings.IndexByte(rest, ' ')
+	if end >= 0 {
+		rest = rest[:end]
+	}
+	n, err := strconv.Atoi(rest)
+	if err != nil {
+		return 0
+	}
+	return n
+}
+
+// patchWarningsCount replaces the Warnings value in an info string with the given count.
+func patchWarningsCount(info string, count int) string {
+	const prefix = "Warnings: "
+	idx := strings.Index(info, prefix)
+	if idx < 0 {
+		return info
+	}
+	start := idx + len(prefix)
+	end := start
+	for end < len(info) && info[end] >= '0' && info[end] <= '9' {
+		end++
+	}
+	return info[:start] + strconv.Itoa(count) + info[end:]
+}
+
+// getWarningCount returns the server's current @@warning_count value.
+func (ctx *execContext) getWarningCount(activeConn *sql.Conn) int {
+	var val int
+	if activeConn != nil {
+		row := activeConn.QueryRowContext(context.Background(), "SELECT @@warning_count")
+		if err := row.Scan(&val); err == nil {
+			return val
+		}
+	} else {
+		row := ctx.db.QueryRow("SELECT @@warning_count")
+		if err := row.Scan(&val); err == nil {
+			return val
+		}
+	}
+	return 0
+}
+
+// getSQLWarnings returns true if @@sql_warnings is non-zero on the active connection.
+func (ctx *execContext) getSQLWarnings(activeConn *sql.Conn) bool {
+	var val int
+	if activeConn != nil {
+		row := activeConn.QueryRowContext(context.Background(), "SELECT @@sql_warnings")
+		if err := row.Scan(&val); err == nil {
+			return val != 0
+		}
+	} else {
+		row := ctx.db.QueryRow("SELECT @@sql_warnings")
+		if err := row.Scan(&val); err == nil {
+			return val != 0
+		}
+	}
+	return false
 }
 
 // queryRows executes a SQL query and returns the results as a slice of string slices.


### PR DESCRIPTION
## Summary
- Output `affected rows: N` for SELECT queries when `--enable_info` is active (N = number of rows returned)
- For CALL statements, output `affected rows: N` per result set then `affected rows: 0` for the CALL itself
- Suppress INSERT/REPLACE `info:` line when `@@sql_warnings=0` and actual warnings > 0; patch Warnings count using `@@warning_count` queried before `MYLITE LAST_INSERT_INFO`
- Bypass `sql_select_limit` inside stored procedures (`routineDepth > 0`) to match MySQL behavior
- `CREATE TABLE ... SELECT` now returns proper `AffectedRows` and sets `lastInsertInfo`; also bypasses `sql_select_limit` for the SELECT sub-query
- INSERT...SELECT fast path sets `lastInsertInfo` to prevent stale info from previous CREATE TABLE...SELECT

## Test plan
- [x] `sys_vars/sql_select_limit_func` passes
- [x] `sys_vars/sql_warnings_func` passes
- [x] Full mtrrun suite: pass=1884 (baseline=1883, +1)
- [x] FDL guard: subquery_sj_mat=8435≥8435, explain_json_all=1355≥1355, explain_json_none=1256≥1256
- [x] `go test ./... -count=1` all pass

Closes #510

🤖 Generated with [Claude Code](https://claude.com/claude-code)