### PR TITLE
fix: SHOW PROCESSLIST event_scheduler state to 'Waiting on empty queue'

### DIFF
--- a/executor/show.go
+++ b/executor/show.go
@@ -1063,7 +1063,7 @@ func (e *Executor) execShow(stmt *sqlparser.Show, query string) (*Result, error)
 				nil,
 				"Daemon",
 				int64(0),
-				"Waiting for next activation",
+				"Waiting on empty queue",
 				nil,
 			}}, rows...)
 		}


### PR DESCRIPTION
## Summary
- Fixes `SHOW PROCESSLIST` event_scheduler row State from `'Waiting for next activation'` to `'Waiting on empty queue'`
- MySQL reports `'Waiting on empty queue'` when no events are scheduled; since event scheduler is unimplemented, this is always the correct value
- `other/sp-threads` FDL improved from line 37 → line 39

## Changes
- `executor/show.go` L1066: 1-line string constant fix

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./... -count=1` passes
- [x] Full mtrrun: Passed=1887 (no regression from baseline)
- [x] FDL guards: subquery_sj_mat=8435 ✓, explain_json_all=1355 ✓, explain_json_none=1256 ✓
- [x] sp-threads FDL: 37 → 39 (improved)

Closes #523

🤖 Generated with [Claude Code](https://claude.com/claude-code)