### PR TITLE
fix: restore SP param column names and ROW_COUNT tracking in routines (Closes #520)

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -2273,6 +2273,23 @@ func (e *Executor) Execute(query string) (res *Result, retErr error) {
 	if trimmedForCount != "" && e.routineDepth == 0 {
 		e.questions++
 	}
+	// Update ROW_COUNT() tracking (MySQL semantics) for all statements, including those
+	// inside stored routines and triggers. MySQL's ROW_COUNT() returns the affected-row count
+	// of the most recent DML statement, even when called inside a stored function/procedure.
+	// - After SELECT: -1
+	// - After failed DML: -1 (remains unchanged)
+	// - After successful DML: AffectedRows
+	defer func() {
+		if retErr == nil && res != nil {
+			if res.Columns != nil {
+				// SELECT result: set to -1
+				e.lastAffectedRows = -1
+			} else {
+				// DML result: set to affected rows
+				e.lastAffectedRows = int64(res.AffectedRows)
+			}
+		}
+	}()
 	// Track execution errors in the diagnostics area (for SHOW ERRORS / SHOW WARNINGS).
 	// Only track for client-level statements (not internal routine calls).
 	if e.routineDepth == 0 {
@@ -2298,20 +2315,6 @@ func (e *Executor) Execute(query string) (res *Result, retErr error) {
 				}
 				e.postErrorWarnings = nil
 			}
-			// Update ROW_COUNT() tracking (MySQL semantics):
-			// - After SELECT: -1
-			// - After failed DML: -1 (remains unchanged since it was already -1 or a previous value)
-			// - After successful DML: AffectedRows
-			if retErr == nil && res != nil {
-				if res.Columns != nil {
-					// SELECT result: set to -1
-					e.lastAffectedRows = -1
-				} else {
-					// DML result: set to affected rows
-					e.lastAffectedRows = int64(res.AffectedRows)
-				}
-			}
-			// On error, leave lastAffectedRows as -1 (MySQL returns -1 after failed statements)
 		}()
 	}
 

--- a/executor/procedures.go
+++ b/executor/procedures.go
@@ -4207,7 +4207,7 @@ func (e *Executor) execRoutineBodyWithContext(body []string, ctx *routineContext
 		// Handle CALL inside routine body (nested SP call with local var substitution)
 		if strings.HasPrefix(stmtUpper, "CALL ") {
 			resolvedSQL := e.substituteLocalVars(stmtStr, localVars)
-			_, err := e.Execute(resolvedSQL)
+			callResult, err := e.Execute(resolvedSQL)
 			if err != nil {
 				// Check if a handler can catch this error
 				handled, exitFlag := e.tryHandler(err, ctx)
@@ -4224,6 +4224,14 @@ func (e *Executor) execRoutineBodyWithContext(body []string, ctx *routineContext
 					continue
 				}
 				return nil, err
+			}
+			// Propagate result sets from nested CALL into the parent's result set collection.
+			// A nested procedure may produce multiple result sets (first + ExtraResultSets).
+			if callResult != nil && callResult.IsResultSet && ctx.resultSets != nil {
+				*ctx.resultSets = append(*ctx.resultSets, callResult)
+				if len(callResult.ExtraResultSets) > 0 {
+					*ctx.resultSets = append(*ctx.resultSets, callResult.ExtraResultSets...)
+				}
 			}
 			continue
 		}
@@ -4251,6 +4259,9 @@ func (e *Executor) execRoutineBodyWithContext(body []string, ctx *routineContext
 		if ctx.triggerNewRow != nil || ctx.triggerOldRow != nil {
 			resolvedSQL = e.resolveNewOldRefs(resolvedSQL, ctx.triggerNewRow, ctx.triggerOldRow)
 		}
+		// Before substitution, record which SELECT columns are bare variable references
+		// so we can restore their names after execution (MySQL returns param name as column name).
+		varColAliases := selectColumnVarAliases(resolvedSQL, localVars)
 		resolvedSQL = e.substituteLocalVars(resolvedSQL, localVars)
 		stmtResult, err := e.Execute(resolvedSQL)
 		if err != nil {
@@ -4270,6 +4281,16 @@ func (e *Executor) execRoutineBodyWithContext(body []string, ctx *routineContext
 				continue
 			}
 			return nil, err
+		}
+		// Restore column names for bare variable references in SELECT statements.
+		// e.g. "SELECT a" where a=2 executes as "SELECT 2" giving column name "2";
+		// MySQL returns "a" as the column name (the parameter name).
+		if stmtResult != nil && stmtResult.IsResultSet && varColAliases != nil {
+			for idx, varName := range varColAliases {
+				if idx < len(stmtResult.Columns) {
+					stmtResult.Columns[idx] = varName
+				}
+			}
 		}
 		// Store result sets produced by SELECT statements inside the routine body.
 		// They will be returned if an EXIT HANDLER fires, or from the routine call itself.
@@ -4747,6 +4768,165 @@ func (e *Executor) substituteLocalVars(sql string, vars map[string]interface{}) 
 		if strings.Contains(result, backtickForm) {
 			result = strings.ReplaceAll(result, backtickForm, valStr)
 		}
+	}
+	return result
+}
+
+// selectColumnVarAliases examines a SELECT statement (before variable substitution) and
+// returns a map from column index to the original variable name for each select-list expression
+// that is a bare local variable reference (e.g. "SELECT a, b+1" where a is a local var returns {0: "a"}).
+// This is used to restore column names after substituteLocalVars turns "SELECT a" into "SELECT 2".
+func selectColumnVarAliases(stmtStr string, localVars map[string]interface{}) map[int]string {
+	// Only handle SELECT statements (not SELECT INTO, which is handled separately)
+	upper := strings.ToUpper(strings.TrimSpace(stmtStr))
+	if !strings.HasPrefix(upper, "SELECT") {
+		return nil
+	}
+	// Skip past "SELECT" keyword
+	body := strings.TrimSpace(stmtStr[6:])
+	if len(body) == 0 {
+		return nil
+	}
+	// Strip optional DISTINCT/ALL/SQL_NO_CACHE etc.
+	for _, kw := range []string{"DISTINCT ", "ALL ", "SQL_NO_CACHE ", "SQL_CACHE ", "HIGH_PRIORITY "} {
+		if strings.HasPrefix(strings.ToUpper(body), kw) {
+			body = strings.TrimSpace(body[len(kw):])
+		}
+	}
+
+	// Find the end of the select-list: the top-level FROM keyword (outside parens/quotes)
+	selectListEnd := len(body)
+	depth := 0
+	inSingle := false
+	inDouble := false
+	inBacktick := false
+	for i := 0; i < len(body); i++ {
+		ch := body[i]
+		if inSingle {
+			if ch == '\'' {
+				inSingle = false
+			}
+			continue
+		}
+		if inDouble {
+			if ch == '"' {
+				inDouble = false
+			}
+			continue
+		}
+		if inBacktick {
+			if ch == '`' {
+				inBacktick = false
+			}
+			continue
+		}
+		switch ch {
+		case '\'':
+			inSingle = true
+		case '"':
+			inDouble = true
+		case '`':
+			inBacktick = true
+		case '(':
+			depth++
+		case ')':
+			depth--
+		default:
+			if depth == 0 && i+4 < len(body) {
+				rem := strings.ToUpper(body[i:])
+				if (strings.HasPrefix(rem, "FROM ") || strings.HasPrefix(rem, "FROM\t") || strings.HasPrefix(rem, "FROM\n")) {
+					// Make sure it's a word boundary (not e.g. "TRANSFORM")
+					if i == 0 || !isAlphaNum(body[i-1]) {
+						selectListEnd = i
+					}
+				}
+			}
+		}
+	}
+
+	selectList := strings.TrimSpace(body[:selectListEnd])
+	if selectList == "" {
+		return nil
+	}
+
+	// Split select list by top-level commas
+	var exprs []string
+	depth = 0
+	inSingle = false
+	inDouble = false
+	inBacktick = false
+	start := 0
+	for i := 0; i < len(selectList); i++ {
+		ch := selectList[i]
+		if inSingle {
+			if ch == '\'' {
+				inSingle = false
+			}
+			continue
+		}
+		if inDouble {
+			if ch == '"' {
+				inDouble = false
+			}
+			continue
+		}
+		if inBacktick {
+			if ch == '`' {
+				inBacktick = false
+			}
+			continue
+		}
+		switch ch {
+		case '\'':
+			inSingle = true
+		case '"':
+			inDouble = true
+		case '`':
+			inBacktick = true
+		case '(':
+			depth++
+		case ')':
+			depth--
+		case ',':
+			if depth == 0 {
+				exprs = append(exprs, strings.TrimSpace(selectList[start:i]))
+				start = i + 1
+			}
+		}
+	}
+	exprs = append(exprs, strings.TrimSpace(selectList[start:]))
+
+	result := make(map[int]string)
+	for idx, expr := range exprs {
+		expr = strings.TrimSpace(expr)
+		// Check for explicit alias: "expr AS alias" or "expr alias" — skip those
+		exprUpper := strings.ToUpper(expr)
+		if strings.Contains(exprUpper, " AS ") {
+			continue
+		}
+		// A bare variable reference is a single identifier (no dots, spaces, operators, parens)
+		// that matches a local variable name (case-insensitive)
+		isIdentifier := len(expr) > 0
+		for _, c := range expr {
+			if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_') {
+				isIdentifier = false
+				break
+			}
+		}
+		if !isIdentifier {
+			continue
+		}
+		// Must start with a letter or underscore (not a digit)
+		if expr[0] >= '0' && expr[0] <= '9' {
+			continue
+		}
+		// Check if this identifier is a local variable
+		if _, ok := localVars[strings.ToLower(expr)]; ok {
+			result[idx] = expr
+		}
+	}
+	if len(result) == 0 {
+		return nil
 	}
 	return result
 }


### PR DESCRIPTION
## Summary

- **Column name restoration**: `substituteLocalVars` turns `SELECT a` (where `a` is a SP parameter) into `SELECT 2`, losing the column name. Added `selectColumnVarAliases()` to detect bare parameter references in SELECT column lists and restore their original names in the result set after execution.
- **Nested CALL result propagation**: Result sets from `CALL` statements inside routine bodies were silently discarded. Now propagated to the parent result set collection so multi-level nested procedures return all their result sets.
- **ROW_COUNT() in routines**: `lastAffectedRows` (used by `ROW_COUNT()`) was only updated at `routineDepth==0` (client level). DML inside stored functions/procedures never updated it, causing `ROW_COUNT()` to return stale/wrong values. Moved tracking outside the depth guard.

Fixes `other/sp-prelocking` (pass: 1888 → 1889, no regressions).

FDL guards maintained: subquery_sj_mat=8435, explain_json_all=1355, explain_json_none=1256.

Closes #520

## Test plan

- [x] `go build ./... && go test ./... -count=1` passes
- [x] `other/sp-prelocking` now PASS
- [x] Full mtrrun: 1889 pass (was 1888), no regressions
- [x] FDL guards: subquery_sj_mat ≥ 8435, explain_json_all ≥ 1355, explain_json_none ≥ 1256

🤖 Generated with [Claude Code](https://claude.com/claude-code)