### PR TITLE
fix: closed-interval MBR containment for MBRWITHIN boundary points (Closes #521)

### DIFF
--- a/executor/spatial_funcs.go
+++ b/executor/spatial_funcs.go
@@ -1761,24 +1761,13 @@ func mbrDimContains(oMin, oMax, iMin, iMax float64) bool {
 }
 
 // mbrContainsBoxes returns true if outer MBR box [ox1,oy1,ox2,oy2] contains inner
-// MBR box [ix1,iy1,ix2,iy2] according to MySQL 5.7 MBRCONTAINS semantics:
-//   - Exact equality → true (handles degenerate equal MBRs like POINT=POINT)
-//   - Inner weakly contained in outer (all coordinates), AND for each dimension,
-//     inner must strictly intersect the open interior of outer in that dimension
-//     (or exactly equal a degenerate outer dimension).
+// MBR box [ix1,iy1,ix2,iy2] using closed-interval (inclusive boundary) containment.
+// A point on the boundary of the outer MBR is considered "within" it.
+// This matches MySQL 8.0 MBRCONTAINS / MBRWITHIN semantics.
 func mbrContainsBoxes(outer, inner []float64) bool {
 	ox1, oy1, ox2, oy2 := outer[0], outer[1], outer[2], outer[3]
 	ix1, iy1, ix2, iy2 := inner[0], inner[1], inner[2], inner[3]
-	// Weak containment
-	if !(ox1 <= ix1 && oy1 <= iy1 && ox2 >= ix2 && oy2 >= iy2) {
-		return false
-	}
-	// Exact equality
-	if ox1 == ix1 && oy1 == iy1 && ox2 == ix2 && oy2 == iy2 {
-		return true
-	}
-	// Per-dimension containment check
-	return mbrDimContains(ox1, ox2, ix1, ix2) && mbrDimContains(oy1, oy2, iy1, iy2)
+	return ox1 <= ix1 && oy1 <= iy1 && ox2 >= ix2 && oy2 >= iy2
 }
 
 // mbrContains returns true if outer geometry's MBR contains inner geometry's MBR


### PR DESCRIPTION
## Summary

- **Root cause**: `mbrContainsBoxes` used strict open-interval semantics (`mbrDimContains`) that excluded points exactly on the boundary of an outer MBR. For example, `POINT(1 0)` with y=0 was excluded by `MBRWithin(pos, polygon)` when the polygon's y-min is 0.
- **Bug**: In `innodb/skip_locked_nowait_isolation`, the `SELECT ... WHERE MBRWithin(pos, @g) LIMIT 2 FOR UPDATE NOWAIT` query excluded boundary-row seats (seat_id=1, POINT(1 0) and seat_id=3, POINT(2 0)) from its WHERE result. This left only con1's own X-locked rows (seats 2, 4) in `lockRows[:2]`, so `TryAcquireRowLock` succeeded (re-entrant) and no NOWAIT error was raised.
- **Fix**: Replace the strict open-interval containment check with standard closed-interval (`ox1 <= ix1 && oy1 <= iy1 && ox2 >= ix2 && oy2 >= iy2`), matching MySQL 8.0 MBRWITHIN/MBRCONTAINS semantics where boundary points are included.

## Test plan

- [x] `innodb/skip_locked_nowait_isolation` now PASSes (all 4 isolation levels: READ UNCOMMITTED, READ COMMITTED, REPEATABLE READ, SERIALIZABLE)
- [x] `go build ./... && go test ./... -count=1` all green
- [x] Full mtrrun: 1889 passed (no regression from baseline)
- [x] FDL guards maintained: subquery_sj_mat=8435, explain_json_all=1355, explain_json_none=1256
- [x] Pre-existing failing spatial tests (`spatial_testing_functions_contains`, `archive_gis`, `gis-precise`, `gis-rt-precise`) have identical FDL before and after the fix — no regression

Closes #521

🤖 Generated with [Claude Code](https://claude.com/claude-code)