### PR TITLE
fix: reject TIMESTAMPDIFF/UNIX_TIMESTAMP(date) in partition expr; fix YEAR='0' comparison

### DIFF
--- a/executor/ddl.go
+++ b/executor/ddl.go
@@ -127,12 +127,61 @@ func validatePartitionExpr(expr sqlparser.Expr) (disallowed bool, wrongExpr bool
 	case *sqlparser.LocateExpr:
 		// locate(substr, str) and position(substr IN str) - always disallowed
 		return true, false
+	case *sqlparser.TimestampDiffExpr:
+		// TIMESTAMPDIFF is not allowed in partition expressions
+		return true, false
 	case *sqlparser.ColName:
 		// Column references are always allowed
 	case *sqlparser.Literal:
 		// Literal values are always allowed
 	}
 	return false, false
+}
+
+// validateUnixTimestampPartitionExpr checks that unix_timestamp(col) in a partition expression
+// uses only TIMESTAMP columns. DATE/DATETIME columns are not allowed (error 1486).
+func validateUnixTimestampPartitionExpr(expr sqlparser.Expr, cols []*sqlparser.ColumnDefinition) error {
+	// Build map of column name -> type (lowercase)
+	colTypes := make(map[string]string, len(cols))
+	for _, col := range cols {
+		colTypes[strings.ToLower(col.Name.String())] = strings.ToLower(col.Type.Type)
+	}
+	return validateUnixTimestampExprWalk(expr, colTypes)
+}
+
+func validateUnixTimestampExprWalk(expr sqlparser.Expr, colTypes map[string]string) error {
+	if expr == nil {
+		return nil
+	}
+	switch e := expr.(type) {
+	case *sqlparser.FuncExpr:
+		name := strings.ToLower(e.Name.String())
+		if name == "unix_timestamp" && len(e.Exprs) == 1 {
+			// unix_timestamp(col): check the argument is a TIMESTAMP column
+			if col, ok := e.Exprs[0].(*sqlparser.ColName); ok {
+				colType := colTypes[strings.ToLower(col.Name.String())]
+				// Allow only TIMESTAMP; DATE and DATETIME are not allowed
+				if colType != "timestamp" {
+					return mysqlError(1486, "HY000", "Constant, random or timezone-dependent expressions in (sub)partitioning function are not allowed")
+				}
+			}
+		}
+		for _, arg := range e.Exprs {
+			if err := validateUnixTimestampExprWalk(arg, colTypes); err != nil {
+				return err
+			}
+		}
+	case *sqlparser.BinaryExpr:
+		if err := validateUnixTimestampExprWalk(e.Left, colTypes); err != nil {
+			return err
+		}
+		if err := validateUnixTimestampExprWalk(e.Right, colTypes); err != nil {
+			return err
+		}
+	case *sqlparser.UnaryExpr:
+		return validateUnixTimestampExprWalk(e.Expr, colTypes)
+	}
+	return nil
 }
 
 // validateUTF8StringForDDL checks if a string contains valid utf8mb3 (3-byte UTF-8) when character_set_client=binary.
@@ -2512,6 +2561,11 @@ func (e *Executor) execCreateTable(stmt *sqlparser.CreateTable) (*Result, error)
 			if po.Type != sqlparser.KeyType {
 				if disallowed, _ := validatePartitionExpr(po.Expr); disallowed {
 					return nil, mysqlError(1491, "HY000", "This partition function is not allowed")
+				}
+				// Validate unix_timestamp(col): col must be TIMESTAMP type.
+				// DATE/DATETIME columns raise error 1486.
+				if err := validateUnixTimestampPartitionExpr(po.Expr, stmt.TableSpec.Columns); err != nil {
+					return nil, err
 				}
 			}
 		}

--- a/executor/typeutil.go
+++ b/executor/typeutil.go
@@ -707,12 +707,45 @@ func normalizeYearComparisonTyped(ls, rs string, origLeft, origRight interface{}
 		return ok
 	}
 
-	if isYearLike(li) && isSmallYear(ri) && !isYearLike(ri) && (isOrigString(origLeft) || isOrigString(origRight)) {
-		ri = convertSmallYear(ri)
+	// isYearColumnString checks if a string looks like a YEAR column value: exactly
+	// 4 digits representing 0000 or 1901-2155.
+	isYearColumnStr := func(s string) bool {
+		if len(s) != 4 {
+			return false
+		}
+		n, err := strconv.Atoi(s)
+		if err != nil {
+			return false
+		}
+		return n == 0 || (n >= 1901 && n <= 2155)
+	}
+
+	// For string '0', '00', '000' vs YEAR column: these short-zero strings represent
+	// year 2000 in MySQL (2-digit year mapping), but '0000' represents the zero year.
+	// Integer literal 0 represents the zero year sentinel (stays 0000).
+	// This conversion only triggers when one side is a 4-digit YEAR column string (like "2000").
+	convertSmallYearStr := func(n int, orig interface{}, s string) int {
+		if n == 0 && isOrigString(orig) && len(strings.TrimLeft(s, "0")) == 0 && len(s) < 4 {
+			return 2000
+		}
+		return convertSmallYear(n)
+	}
+	// canConvertSmall: like !isYearLike but also allows n==0 from a short string literal.
+	canConvertSmall := func(n int, orig interface{}, s string, otherSide string) bool {
+		if n == 0 {
+			// Convert string '0'/'00'/'000' to 2000 only when other side is a 4-digit YEAR string.
+			return isOrigString(orig) && len(strings.TrimLeft(s, "0")) == 0 && len(s) < 4 &&
+				isYearColumnStr(otherSide)
+		}
+		return !isYearLike(n)
+	}
+
+	if isYearLike(li) && isSmallYear(ri) && canConvertSmall(ri, origRight, rs, ls) && (isOrigString(origLeft) || isOrigString(origRight)) {
+		ri = convertSmallYearStr(ri, origRight, rs)
 		return ls, fmt.Sprintf("%d", ri)
 	}
-	if isYearLike(ri) && isSmallYear(li) && !isYearLike(li) && (isOrigString(origLeft) || isOrigString(origRight)) {
-		li = convertSmallYear(li)
+	if isYearLike(ri) && isSmallYear(li) && canConvertSmall(li, origLeft, ls, rs) && (isOrigString(origLeft) || isOrigString(origRight)) {
+		li = convertSmallYearStr(li, origLeft, ls)
 		return fmt.Sprintf("%d", li), rs
 	}
 


### PR DESCRIPTION
## Summary

- **`executor/ddl.go`**: Add `*sqlparser.TimestampDiffExpr` to `validatePartitionExpr` so `PARTITION BY RANGE(TIMESTAMPDIFF(...))` now correctly raises error 1491 "This partition function is not allowed". Vitess parses `TIMESTAMPDIFF` as its own AST node (not `FuncExpr`), so it was silently passing the existing disallowed-function check.
- **`executor/ddl.go`**: Add `validateUnixTimestampPartitionExpr` to detect `unix_timestamp(col)` where `col` is `DATE`/`DATETIME` (not `TIMESTAMP`) and raise error 1486 "Constant, random or timezone-dependent expressions in (sub)partitioning function are not allowed".
- **`executor/typeutil.go`**: Fix `normalizeYearComparisonTyped` so string literal `'0'`/`'00'`/`'000'` is converted to year 2000 (matching MySQL 2-digit year rules) only when the opposing side is a 4-digit YEAR-column string (e.g. `"2000"`). This prevents false year-conversion in non-YEAR comparisons like `0E0 <=> "0"`.

## Test plan

- `other/partition_bug18198`: **pass** (was fail, FDL 125 → now passes)
- `other/type_year`: FDL 153 → 230 (significant improvement)
- Full suite: **1890 pass** (was 1889, +1 net), **zero regressions**
- FDL guards: subquery_sj_mat=8435, explain_json_all=1355, explain_json_none=1256 (all maintained)

🤖 Generated with [Claude Code](https://claude.com/claude-code)