### PR TITLE
fix: correct FLOOR for negatives, datetime sci-notation, and optimizer_switch default prefix

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -1090,11 +1090,17 @@ func (e *Executor) normalizeOptimizerSwitchInput(newValue string, expr sqlparser
 	}
 
 	// String value: validate — must contain '=' in each comma-separated part
-	// or be "default". Bare words like "index_merge" or "foobar" are invalid.
+	// or be "default"/"def". Bare words like "index_merge" or "foobar" are invalid.
+	// MySQL supports "default,flag=on" syntax which resets to default then applies overrides.
 	stripped := strings.Trim(trimmed, "'\"")
 	for _, part := range strings.Split(stripped, ",") {
 		part = strings.TrimSpace(part)
 		if part == "" {
+			continue
+		}
+		// "default" or abbreviations "def","defa",... are valid reset tokens
+		partUpper := strings.ToUpper(part)
+		if strings.HasPrefix("DEFAULT", partUpper) && len(partUpper) >= 3 {
 			continue
 		}
 		if !strings.Contains(part, "=") {
@@ -1177,9 +1183,38 @@ func (e *Executor) mergeOptimizerSwitch(newValue string, isGlobal bool) string {
 	}
 
 	// Apply new flags (merge/update)
+	// MySQL supports "default" as a part within the list (e.g. "default,semijoin=off")
+	// which resets all flags to the compiled default, then applies subsequent overrides.
 	for _, part := range strings.Split(newValue, ",") {
 		part = strings.TrimSpace(part)
 		if part == "" {
+			continue
+		}
+		// Handle "default" token: reset flags to compiled defaults
+		partUpper := strings.ToUpper(part)
+		if strings.HasPrefix("DEFAULT", partUpper) && len(partUpper) >= 3 {
+			compiled, ok := e.getCompiledDefault("optimizer_switch")
+			if !ok {
+				continue
+			}
+			// Reset flags and flagIndex to compiled defaults
+			flags = flags[:0]
+			flagIndex = map[string]int{}
+			for _, cp := range strings.Split(compiled, ",") {
+				cp = strings.TrimSpace(cp)
+				if cp == "" {
+					continue
+				}
+				ckv := strings.SplitN(cp, "=", 2)
+				if len(ckv) == 2 {
+					k := strings.TrimSpace(ckv[0])
+					v := strings.TrimSpace(ckv[1])
+					if _, exists := flagIndex[k]; !exists {
+						flagIndex[k] = len(flags)
+						flags = append(flags, flagEntry{k, v})
+					}
+				}
+			}
 			continue
 		}
 		kv := strings.SplitN(part, "=", 2)

--- a/executor/func_datetime.go
+++ b/executor/func_datetime.go
@@ -1896,6 +1896,15 @@ func parseDateTimeValue(val interface{}) (time.Time, error) {
 			break
 		}
 	}
+	// Handle scientific notation (e.g. "2.02605071000002e13" from NOW()+0.2).
+	// Convert to integer string and re-try parsing.
+	if strings.ContainsAny(s, "eE") {
+		if fv, err := strconv.ParseFloat(s, 64); err == nil {
+			intStr := strconv.FormatInt(int64(fv), 10)
+			// Recurse with the integer string (avoid infinite loop – intStr has no 'e')
+			return parseDateTimeValue(intStr)
+		}
+	}
 	// Handle YYYYMMDDHHMMSS.ffffff (compact numeric with fractional seconds)
 	// Also handle YYYYMMDD.ff (8 digits + dot: treat as date, ignore fractional part)
 	if !isAllDigits {

--- a/executor/func_math.go
+++ b/executor/func_math.go
@@ -110,7 +110,7 @@ func evalMathFunc(e *Executor, name string, v *sqlparser.FuncExpr, row *storage.
 		if err != nil {
 			return nil, true, err
 		}
-		return int64(f), true, nil
+		return int64(math.Floor(f)), true, nil
 	case "ceil", "ceiling":
 		val, isNull, err := e.evalArg1(v.Exprs, "CEIL", row)
 		if err != nil {


### PR DESCRIPTION
## Summary

- **FLOOR bug fix**: `FLOOR(-5.5)` now correctly returns `-6` instead of `-5`. Root cause: Go's `int64(-5.5)` truncates toward zero; replaced with `int64(math.Floor(f))`.
- **Datetime scientific notation**: `parseDateTimeValue` now handles strings like `"2.02605071000002e13"` produced by `NOW()+0.2` arithmetic. Detects the `e`/`E` character, converts via `ParseFloat`+`FormatInt`, then re-parses. Fixes `WEEK(NOW()+0.2)` returning NULL.
- **optimizer_switch `default,flag=val` syntax**: `SET optimizer_switch='default,semijoin=off'` previously rejected with error 1231. Now correctly resets to compiled default first, then applies the flag overrides. Fixes the `optimizer_switch` test progressing past the first `SET` statement.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./... -count=1` passes (executor, harness, storage)
- [x] FDL guards maintained: subquery_sj_mat≥8435, explain_json_all≥1355, explain_json_none≥1256
- [x] No pass→fail regressions confirmed from mtrrun baseline (result-20260507-051122.json vs result-20260507-053114.json)
- [x] optimizer_switch test converts from error to fail (improvement in error count)

🤖 Generated with [Claude Code](https://claude.com/claude-code)