### PR TITLE
fix: tactical bug fixes - SOUNDS LIKE paren, optimizer_switch default, ST_Y NULL

### DIFF
--- a/executor/executor.go
+++ b/executor/executor.go
@@ -3,6 +3,7 @@ package executor
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -1100,12 +1101,17 @@ func (e *Executor) normalizeOptimizerSwitchInput(newValue string, expr sqlparser
 		return "default", nil
 	}
 
-	// String value: validate — must contain '=' in each comma-separated part
+	// String value: validate — must contain '=' in each comma-separated part,
 	// or be "default". Bare words like "index_merge" or "foobar" are invalid.
+	// MySQL allows "default,flag=on" to reset first then apply flags.
 	stripped := strings.Trim(trimmed, "'\"")
 	for _, part := range strings.Split(stripped, ",") {
 		part = strings.TrimSpace(part)
 		if part == "" {
+			continue
+		}
+		// "default" is valid: resets to compiled default before applying remaining flags
+		if strings.EqualFold(part, "default") {
 			continue
 		}
 		if !strings.Contains(part, "=") {
@@ -7394,6 +7400,12 @@ func (e *Executor) execOtherAdmin(query string) (*Result, error) {
 			}
 		}()
 		if evalErr != nil {
+			// Suppress intOverflowError (large hex literals) — MySQL would produce a warning
+			// and return NULL rather than raising a fatal error.
+			var intOvErr *intOverflowError
+			if errors.As(evalErr, &intOvErr) {
+				return &Result{AffectedRows: 0}, nil
+			}
 			return nil, evalErr
 		}
 		return &Result{AffectedRows: 0}, nil

--- a/executor/preprocess.go
+++ b/executor/preprocess.go
@@ -662,6 +662,12 @@ func (e *Executor) preprocessQuery(query string) (string, *Result, error) {
 
 	// Rewrite "SOUNDS LIKE" to SOUNDEX comparison so vitess can parse it
 	if strings.Contains(upper, "SOUNDS LIKE") {
+		// Handle parenthesized variants first: (expr)SOUNDS LIKE(expr)
+		slReParen := regexp.MustCompile(`(?i)\(('(?:[^'\\]|\\.)*'|0x[0-9a-fA-F]+|\w+)\)\s*SOUNDS\s+LIKE\s*\(('(?:[^'\\]|\\.)*'|0x[0-9a-fA-F]+|\w+)\)`)
+		query = slReParen.ReplaceAllString(query, "SOUNDEX($1) = SOUNDEX($2)")
+		trimmed = strings.TrimSpace(query)
+		upper = strings.ToUpper(trimmed)
+		// Handle unparenthesized variants: expr SOUNDS LIKE expr
 		slRe := regexp.MustCompile(`(?i)('(?:[^'\\]|\\.)*'|\w+)\s+SOUNDS\s+LIKE\s+('(?:[^'\\]|\\.)*'|\w+)`)
 		query = slRe.ReplaceAllString(query, "SOUNDEX($1) = SOUNDEX($2)")
 		trimmed = strings.TrimSpace(query)

--- a/executor/spatial_funcs.go
+++ b/executor/spatial_funcs.go
@@ -115,6 +115,10 @@ func extractSpatialPointCoord(wkt string, prop sqlparser.PointPropertyType) (int
 // setSpatialPointCoord sets a coordinate on a WKT POINT and returns the modified WKT.
 // Preserves EWKT SRID prefix if present.
 func setSpatialPointCoord(wkt string, prop sqlparser.PointPropertyType, newVal interface{}) (interface{}, error) {
+	// MySQL: ST_X/ST_Y/ST_Latitude/ST_Longitude with NULL new value returns NULL
+	if newVal == nil {
+		return nil, nil
+	}
 	srid := geomGetSRID(wkt)
 	coords := parseSpatialPointCoords(wkt) // parseSpatialPointCoords strips SRID internally
 	if coords == nil {


### PR DESCRIPTION
## Summary

Tactical bugfixes addressing MySQL spec correctness; no new test passes but 2 tests improve from ERROR to FAIL (FDL improvement):

- **SOUNDS LIKE parenthesized form** (`preprocess.go`): When the left operand of SOUNDS LIKE is parenthesized, e.g. `('str')SOUNDS LIKE(0x...)`, the existing regex failed to match because it required whitespace before `SOUNDS`. Added a new regex pass for the `(expr)SOUNDS LIKE(expr)` form. Fixes parse errors in `other/lead_lag` (ERROR→FAIL).

- **intOverflowError in DO statements** (`executor.go`): When a DO statement contains a large hex literal (> uint64 max) in an arithmetic context, MySQL produces a warning and returns NULL. We were returning a fatal intOverflowError. Now we suppress it and return affected rows=0.

- **optimizer_switch `default` in comma-separated values** (`executor.go`): `SET optimizer_switch = 'default,semijoin=off'` (reset to defaults then apply overrides) was rejected with Error 1231. Added `default` as a valid keyword in the comma-separated part validator. Fixes `other/optimizer_switch` from ERROR→FAIL at line 240.

- **ST_X/ST_Y NULL new-value returns NULL** (`spatial_funcs.go`): Per MySQL spec, `ST_Y(point, NULL)` should return NULL. Previously we propagated the original geometry value.

## FDL Guards (maintained)
- `subquery_sj_mat` FDL: 8435 ≥ 8435 ✓
- `explain_json_all` FDL: 1355 ≥ 1355 ✓
- `explain_json_none` FDL: 1256 ≥ 1256 ✓

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./... -count=1` passes
- [x] `other/lead_lag`: ERROR → FAIL (FDL improvement)
- [x] `other/optimizer_switch`: ERROR → FAIL at line 240 (FDL improvement)
- [x] No regressions in `other`, `sys_vars`, `json`, `funcs_1`, `gis`, `innodb`, `perfschema` subsets

🤖 Generated with [Claude Code](https://claude.com/claude-code)