### PR TITLE
fix: event_scheduler state を 'Waiting on empty queue' に修正

### DIFF
--- a/executor/show.go
+++ b/executor/show.go
@@ -1063,7 +1063,7 @@ func (e *Executor) execShow(stmt *sqlparser.Show, query string) (*Result, error)
 				nil,
 				"Daemon",
 				int64(0),
-				"Waiting for next activation",
+				"Waiting on empty queue",
 				nil,
 			}}, rows...)
 		}


### PR DESCRIPTION
## Summary
- `SHOW PROCESSLIST` の event_scheduler 行の State を MySQL 互換の `"Waiting on empty queue"` に修正
- イベントスケジューラ未実装のため、常に空キュー待ち状態を返す

## Test plan
- [x] `go build ./... && go test ./... -count=1`
- [ ] `go run ./cmd/mtrrun -test other/sp-threads` で line 37 の diff が解消されること（line 177 の別エラーはスコープ外）

Closes #523

Made with [Cursor](https://cursor.com)