### PR TITLE
fix: ALTER TABLE ADD INDEX + RENAME INDEX 複合操作修正

### DIFF
--- a/executor/ddl.go
+++ b/executor/ddl.go
@@ -4851,6 +4851,15 @@ func (e *Executor) execAlterTable(stmt *sqlparser.AlterTable) (*Result, error) {
 			for _, idx := range tableDef.Indexes {
 				origIdxNames[strings.ToLower(idx.Name)] = true
 			}
+			// Indexes added in this ALTER are valid RENAME/ALTER INDEX sources.
+			for _, opt := range stmt.AlterOptions {
+				if addIdx, ok := opt.(*sqlparser.AddIndexDefinition); ok {
+					name := strings.ToLower(addIdx.IndexDefinition.Info.Name.String())
+					if name != "" {
+						origIdxNames[name] = true
+					}
+				}
+			}
 			// Collect rename sources and alter-index targets separately
 			renameSources := make(map[string]bool)
 			alterTargets := make(map[string]bool)


### PR DESCRIPTION
## Summary
- 同一 ALTER TABLE 内で ADD INDEX される名前を RENAME INDEX pre-validation に含める
- `ADD INDEX i1(f), RENAME INDEX i1 TO bb` の Error 1176 を解消

## mtrrun
- `innodb/innodb_rename_index`: error@1176 → line 154 まで到達（line 209 で別問題: failed ALTER の部分適用）

## Test plan
- [x] `go build ./... && go test ./... -count=1`
- [x] `go run ./cmd/mtrrun -test innodb/innodb_rename_index -skipped-only -force`

Closes #503

Made with [Cursor](https://cursor.com)