### PR TITLE
fix: UNIX_TIMESTAMP(datetime) の session time_zone 対応

### DIFF
--- a/cmd/mtrrun/skiplist.json
+++ b/cmd/mtrrun/skiplist.json
@@ -3969,10 +3969,6 @@
       "reason": "output mismatch or execution error"
     },
     {
-      "test": "sys_vars/time_zone_func",
-      "reason": "output mismatch or execution error"
-    },
-    {
       "test": "sys_vars/max_sort_length_func",
       "reason": "output mismatch or execution error"
     },

--- a/executor/expr_eval.go
+++ b/executor/expr_eval.go
@@ -5638,89 +5638,88 @@ func (e *Executor) evalRowExprTupleAware(expr sqlparser.Expr, row storage.Row) (
 	return e.evalRowExpr(expr, row)
 }
 
+func (e *Executor) lookupColValue(v *sqlparser.ColName, row storage.Row) (interface{}, bool) {
+	colName := v.Name.String()
+	// Handle _rowid: MySQL alias for the single-column integer primary key
+	if strings.EqualFold(colName, "_rowid") {
+		pkCol := e.findRowIDColumn(row)
+		if pkCol != "" {
+			if val, ok := row[pkCol]; ok {
+				return val, true
+			}
+		}
+		return nil, false
+	}
+	// Try qualified lookup first (alias.col) if qualifier is set
+	if !v.Qualifier.IsEmpty() {
+		qualified := v.Qualifier.Name.String() + "." + colName
+		if val, ok := row[qualified]; ok {
+			return val, true
+		}
+		// Try full qualifier (db.table.col) for multi-database references
+		fullQualified := sqlparser.String(v.Qualifier) + "." + colName
+		fullQualified = strings.Trim(fullQualified, "`")
+		if val, ok := row[fullQualified]; ok {
+			return val, true
+		}
+		// Try case-insensitive qualified lookup (handles t1.A when key is t1.a)
+		upperQualified := strings.ToUpper(qualified)
+		for k, kv := range row {
+			if strings.ToUpper(k) == upperQualified {
+				return kv, true
+			}
+		}
+		// Fall back to correlatedRow for correlated subquery references
+		if e.correlatedRow != nil {
+			if val, ok := e.correlatedRow[qualified]; ok {
+				return val, true
+			}
+			if val, ok := e.correlatedRow[fullQualified]; ok {
+				return val, true
+			}
+			upperName := strings.ToUpper(colName)
+			for k, kv := range e.correlatedRow {
+				if strings.ToUpper(k) == upperName {
+					return kv, true
+				}
+			}
+			return nil, false
+		}
+	}
+	// Fall back to un-prefixed lookup
+	if val, ok := row[colName]; ok {
+		return val, true
+	}
+	// Case-insensitive fallback (needed for information_schema columns)
+	upperName := strings.ToUpper(colName)
+	for k, rv := range row {
+		if strings.ToUpper(k) == upperName {
+			return rv, true
+		}
+	}
+	// Fall back to correlatedRow for correlated subquery
+	if e.correlatedRow != nil {
+		if val, ok := e.correlatedRow[colName]; ok {
+			return val, true
+		}
+		if !v.Qualifier.IsEmpty() {
+			qualified := v.Qualifier.Name.String() + "." + colName
+			if val, ok := e.correlatedRow[qualified]; ok {
+				return val, true
+			}
+		}
+	}
+	return nil, false
+}
+
 func (e *Executor) evalRowExpr(expr sqlparser.Expr, row storage.Row) (interface{}, error) {
 	switch v := expr.(type) {
 	case *sqlparser.ColName:
-		colName := v.Name.String()
-		// Handle _rowid: MySQL alias for the single-column integer primary key
-		if strings.EqualFold(colName, "_rowid") {
-			pkCol := e.findRowIDColumn(row)
-			if pkCol != "" {
-				if val, ok := row[pkCol]; ok {
-					return val, nil
-				}
-			}
+		val, ok := e.lookupColValue(v, row)
+		if !ok {
 			return nil, nil
 		}
-		// Try qualified lookup first (alias.col) if qualifier is set
-		if !v.Qualifier.IsEmpty() {
-			qualified := v.Qualifier.Name.String() + "." + colName
-			if val, ok := row[qualified]; ok {
-				return val, nil
-			}
-			// Try full qualifier (db.table.col) for multi-database references
-			fullQualified := sqlparser.String(v.Qualifier) + "." + colName
-			fullQualified = strings.Trim(fullQualified, "`")
-			if val, ok := row[fullQualified]; ok {
-				return val, nil
-			}
-			// Try case-insensitive qualified lookup (handles t1.A when key is t1.a)
-			upperQualified := strings.ToUpper(qualified)
-			for k, kv := range row {
-				if strings.ToUpper(k) == upperQualified {
-					return kv, nil
-				}
-			}
-			// Fall back to correlatedRow for correlated subquery references
-			if e.correlatedRow != nil {
-				if val, ok := e.correlatedRow[qualified]; ok {
-					return val, nil
-				}
-				if val, ok := e.correlatedRow[fullQualified]; ok {
-					return val, nil
-				}
-				// Try unqualified lookup in correlatedRow: handles the case where
-				// the outer row's keys are unqualified (e.g. {a:0, b:10}) but the
-				// subquery WHERE references them as t1.a.  We must look here BEFORE
-				// falling through to row[colName], otherwise we'd incorrectly return
-				// the inner table's value (e.g. t2.a) instead of the outer t1.a.
-				upperName := strings.ToUpper(colName)
-				for k, kv := range e.correlatedRow {
-					if strings.ToUpper(k) == upperName {
-						return kv, nil
-					}
-				}
-				// Qualifier was present but not resolved from correlatedRow either.
-				// Do NOT fall through to bare row[colName]: that would incorrectly
-				// match a same-named column in the inner table (e.g., t2.a when
-				// looking for t1.a in a correlated subquery).
-				return nil, nil
-			}
-		}
-		// Fall back to un-prefixed lookup
-		if val, ok := row[colName]; ok {
-			return val, nil
-		}
-		// Case-insensitive fallback (needed for information_schema columns)
-		upperName := strings.ToUpper(colName)
-		for k, v := range row {
-			if strings.ToUpper(k) == upperName {
-				return v, nil
-			}
-		}
-		// Fall back to correlatedRow for correlated subquery
-		if e.correlatedRow != nil {
-			if val, ok := e.correlatedRow[colName]; ok {
-				return val, nil
-			}
-			if !v.Qualifier.IsEmpty() {
-				qualified := v.Qualifier.Name.String() + "." + colName
-				if val, ok := e.correlatedRow[qualified]; ok {
-					return val, nil
-				}
-			}
-		}
-		return nil, nil
+		return val, nil
 	case *sqlparser.Subquery:
 		// Scalar subquery in row context (correlated)
 		return e.execSubqueryScalar(v, row)

--- a/executor/func_datetime.go
+++ b/executor/func_datetime.go
@@ -188,22 +188,44 @@ func evalDatetimeFunc(e *Executor, name string, v *sqlparser.FuncExpr, row *stor
 			// Return as integer when called with no arguments
 			return int64(e.nowTime().Unix()), true, nil
 		}
-		val, err := e.evalExprMaybeRow(v.Exprs[0], row)
-		if err != nil {
-			return nil, true, err
+		var val interface{}
+		var err error
+		useUTCInstant := false
+		if col, ok := v.Exprs[0].(*sqlparser.ColName); ok && e.hasExplicitSessionTimeZone() && e.columnTypeForColName(col) == "TIMESTAMP" && row != nil {
+			useUTCInstant = true
+			var found bool
+			val, found = e.lookupColValue(col, *row)
+			if !found {
+				val = nil
+			}
+		} else {
+			val, err = e.evalExprMaybeRow(v.Exprs[0], row)
+			if err != nil {
+				return nil, true, err
+			}
 		}
-		t, err := parseDateTimeValue(val)
+		var t time.Time
+		if useUTCInstant {
+			t, err = parseDateTimeAsUTC(val)
+		} else {
+			t, err = parseDateTimeValue(val)
+		}
 		if err != nil {
 			return nil, true, nil
 		}
-		// Re-interpret the parsed wall-clock time in the session timezone so that
-		// UNIX_TIMESTAMP('1998-09-16 09:26:00') with time_zone='+03:00' correctly
-		// treats the datetime as being in +03:00, not UTC.
-		loc := e.timeZone
-		if loc == nil {
-			loc = time.Local
+		var tInZone time.Time
+		if useUTCInstant {
+			tInZone = t
+		} else {
+			// Re-interpret the parsed wall-clock time in the session timezone so that
+			// UNIX_TIMESTAMP('1998-09-16 09:26:00') with time_zone='+03:00' correctly
+			// treats the datetime as being in +03:00, not UTC.
+			loc := e.timeZone
+			if loc == nil {
+				loc = time.Local
+			}
+			tInZone = time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(), t.Nanosecond(), loc)
 		}
-		tInZone := time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(), t.Nanosecond(), loc)
 		unixSec := tInZone.Unix()
 		// MySQL returns 0 for timestamps outside the valid UNIX_TIMESTAMP range:
 		// [1970-01-01 00:00:01 UTC, 2038-01-19 03:14:07 UTC]
@@ -1857,6 +1879,101 @@ func mysqlToDays(t time.Time) int64 {
 	}
 	days := 365*y + y/4 - y/100 + y/400 + (153*(m-3)+2)/5 + d + 1721119 - 1
 	return days - 1721059
+}
+
+func columnBaseTypeFromDef(typeStr string) string {
+	ct := strings.ToUpper(strings.TrimSpace(typeStr))
+	if paren := strings.IndexByte(ct, '('); paren >= 0 {
+		ct = strings.TrimSpace(ct[:paren])
+	}
+	return ct
+}
+
+func (e *Executor) columnTypeForColName(col *sqlparser.ColName) string {
+	colName := col.Name.String()
+	if e.queryTableDef != nil {
+		for _, c := range e.queryTableDef.Columns {
+			if strings.EqualFold(c.Name, colName) {
+				return columnBaseTypeFromDef(c.Type)
+			}
+		}
+	}
+	if e.Catalog != nil && e.CurrentDB != "" {
+		if db, err := e.Catalog.GetDatabase(e.CurrentDB); err == nil {
+			tableName := ""
+			if !col.Qualifier.IsEmpty() {
+				tableName = col.Qualifier.Name.String()
+			}
+			var tables []string
+			if tableName != "" {
+				tables = []string{tableName}
+			} else {
+				tables = db.ListTables()
+			}
+			for _, tbl := range tables {
+				tDef, _ := db.GetTable(tbl)
+				if tDef == nil {
+					continue
+				}
+				for _, c := range tDef.Columns {
+					if strings.EqualFold(c.Name, colName) {
+						return columnBaseTypeFromDef(c.Type)
+					}
+				}
+			}
+		}
+	}
+	return ""
+}
+
+func parseDateTimeAsUTC(val interface{}) (time.Time, error) {
+	t, err := parseDateTimeValue(val)
+	if err != nil {
+		return time.Time{}, err
+	}
+	return time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), t.Second(), t.Nanosecond(), time.UTC), nil
+}
+
+func (e *Executor) formatTimestampUTCForSession(val interface{}) interface{} {
+	if val == nil {
+		return nil
+	}
+	s := toString(val)
+	if strings.HasPrefix(s, "0000-00-00") {
+		return s
+	}
+	t, err := parseDateTimeAsUTC(val)
+	if err != nil {
+		return val
+	}
+	loc := e.timeZone
+	if loc == nil {
+		loc = time.Local
+	}
+	out := t.In(loc)
+	if dotIdx := strings.IndexByte(s, '.'); dotIdx > 10 {
+		frac := s[dotIdx+1:]
+		if len(frac) > 6 {
+			frac = frac[:6]
+		}
+		return out.Format("2006-01-02 15:04:05") + "." + frac
+	}
+	return out.Format("2006-01-02 15:04:05")
+}
+
+func (e *Executor) hasExplicitSessionTimeZone() bool {
+	_, ok := e.sessionScopeVars["time_zone"]
+	return ok
+}
+
+func (e *Executor) formatSelectDisplayValue(expr sqlparser.Expr, val interface{}) interface{} {
+	if !e.hasExplicitSessionTimeZone() {
+		return val
+	}
+	if col, ok := expr.(*sqlparser.ColName); ok && e.columnTypeForColName(col) == "TIMESTAMP" {
+		return e.formatTimestampUTCForSession(val)
+	}
+	return val
 }
 
 func parseDateTimeValue(val interface{}) (time.Time, error) {

--- a/executor/select.go
+++ b/executor/select.go
@@ -3048,6 +3048,7 @@ func (e *Executor) execSelect(stmt *sqlparser.Select) (*Result, error) {
 			if err != nil {
 				return nil, err
 			}
+			val = e.formatSelectDisplayValue(expr, val)
 			if len(selectTableDefs) == 1 && strings.EqualFold(selectTableDefs[0].Charset, "ucs2") {
 				if _, isCol := expr.(*sqlparser.ColName); isCol {
 					if s, ok := val.(string); ok {


### PR DESCRIPTION
## Summary
- TIMESTAMP 列の `UNIX_TIMESTAMP` を UTC 瞬間として計算
- 明示的 `SET time_zone` 後の SELECT で TIMESTAMP 列をセッション TZ 表示に変換
- `sys_vars/time_zone_func` pass、skiplist から除外

## mtrrun
| テスト | 結果 |
|--------|------|
| `sys_vars/time_zone_func` | **pass** |

## Test plan
- [x] `go build ./... && go test ./... -count=1`
- [x] `go run ./cmd/mtrrun -test sys_vars/time_zone_func -skipped-only -force`

Closes #513

Made with [Cursor](https://cursor.com)