### PR TITLE
fix(executor): propagate division-by-zero from FK cascade virtual columns

### DIFF
--- a/executor/fk_checks.go
+++ b/executor/fk_checks.go
@@ -214,7 +214,10 @@ func (e *Executor) handleParentRowRemoval(dbName, tableName string, parentRow st
 						}
 						// Re-evaluate virtual generated columns that may depend on the
 						// nullified FK columns (e.g. fld2 INT AS (fld1) VIRTUAL).
-						_ = e.populateGeneratedColumns(childRow, childDef.Columns)
+						if err := e.populateGeneratedColumns(childRow, childDef.Columns); err != nil {
+							childTbl.Unlock()
+							return err
+						}
 						modifiedRows = append(modifiedRows, oldChild)
 					}
 				}
@@ -318,7 +321,10 @@ func (e *Executor) handleParentRowUpdate(dbName, tableName string, oldRow, newRo
 						}
 						// Re-evaluate virtual generated columns that may depend on the
 						// updated FK columns (e.g. fld2 INT AS (fld1) VIRTUAL).
-						_ = e.populateGeneratedColumns(childRow, childDef.Columns)
+						if err := e.populateGeneratedColumns(childRow, childDef.Columns); err != nil {
+							childTbl.Unlock()
+							return err
+						}
 						newChild := make(storage.Row)
 						for k, v := range childRow {
 							newChild[k] = v
@@ -352,7 +358,10 @@ func (e *Executor) handleParentRowUpdate(dbName, tableName string, oldRow, newRo
 						}
 						// Re-evaluate virtual generated columns that may depend on the
 						// updated FK columns (e.g. fld2 INT AS (fld1) VIRTUAL).
-						_ = e.populateGeneratedColumns(childRow, childDef.Columns)
+						if err := e.populateGeneratedColumns(childRow, childDef.Columns); err != nil {
+							childTbl.Unlock()
+							return err
+						}
 						newChild := make(storage.Row)
 						for k, v := range childRow {
 							newChild[k] = v


### PR DESCRIPTION
## Summary
- FK `ON UPDATE CASCADE` / `SET NULL` paths called `populateGeneratedColumns` but discarded errors with `_ =`
- Under `ERROR_FOR_DIVISION_BY_ZERO` + strict sql_mode, recomputing `100/fld1` when `fld1=0` must abort the parent `UPDATE` with ER_DIVISION_BY_ZERO (22012)
- Fixes `innodb/virtual_fk` (first diff was at line 407)

## Test plan
- [x] `go run ./cmd/mtrrun -test innodb/virtual_fk` — pass (was fail at line 407)
- [x] `go build ./... && go test ./... -count=1`

Refs #504

Made with [Cursor](https://cursor.com)