### PR TITLE
fix: collation order for InnoDB covering index scans on string keys

### DIFF
--- a/executor/virtual_basic_order_test.go
+++ b/executor/virtual_basic_order_test.go
@@ -1,0 +1,47 @@
+package executor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/myuon/mylite/catalog"
+	"github.com/myuon/mylite/storage"
+)
+
+// Regression for innodb/virtual_basic: SELECT on a covering secondary index over a
+// VIRTUAL generated VARCHAR column must return rows in collation order, not byte order.
+func TestVirtualBasicSelectPOrder(t *testing.T) {
+	t.Helper()
+	cat := catalog.New()
+	store := storage.NewEngine()
+	e := New(cat, store)
+	if _, err := e.Execute("CREATE DATABASE IF NOT EXISTS test"); err != nil {
+		t.Fatalf("CREATE DATABASE: %v", err)
+	}
+	e.CurrentDB = "test"
+	ddl := `CREATE TABLE t (a INT, b INT, c INT GENERATED ALWAYS AS(a+b), h VARCHAR(10), j INT, m INT GENERATED ALWAYS AS(b + j), n VARCHAR(10), p VARCHAR(20) GENERATED ALWAYS AS(CONCAT(n, h)), INDEX idx1(c), INDEX idx2 (m), INDEX idx3(p))`
+	if _, err := e.Execute(ddl); err != nil {
+		t.Fatalf("CREATE TABLE: %v", err)
+	}
+	for _, ins := range []string{
+		`INSERT INTO t VALUES(11, 22, DEFAULT, "AAA", 8, DEFAULT, "XXX", DEFAULT)`,
+		`INSERT INTO t VALUES(1, 2, DEFAULT, "uuu", 9, DEFAULT, "uu", DEFAULT)`,
+		`INSERT INTO t VALUES(3, 4, DEFAULT, "uooo", 1, DEFAULT, "umm", DEFAULT)`,
+	} {
+		if _, err := e.Execute(ins); err != nil {
+			t.Fatalf("INSERT: %v", err)
+		}
+	}
+	r, err := e.Execute("SELECT p FROM t")
+	if err != nil {
+		t.Fatalf("SELECT: %v", err)
+	}
+	var got []string
+	for _, row := range r.Rows {
+		got = append(got, row[0].(string))
+	}
+	want := []string{"ummuooo", "uuuuu", "XXXAAA"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("order mismatch: got %v want %v", got, want)
+	}
+}

--- a/storage/index_access.go
+++ b/storage/index_access.go
@@ -354,7 +354,7 @@ func (t *Table) scanByIndexOrder(idxCols []string) []Row {
 	sort.SliceStable(out, func(i, j int) bool {
 		ri, rj := out[i], out[j]
 		for _, c := range bare {
-			cmp := compareRowValue(rowGetCI(ri, c), rowGetCI(rj, c))
+			cmp := t.compareIndexKeyColumn(rowGetCI(ri, c), rowGetCI(rj, c), c)
 			if cmp < 0 {
 				return true
 			}
@@ -363,7 +363,7 @@ func (t *Table) scanByIndexOrder(idxCols []string) []Row {
 			}
 		}
 		for _, c := range pkCols {
-			cmp := compareRowValue(rowGetCI(ri, c), rowGetCI(rj, c))
+			cmp := t.compareIndexKeyColumn(rowGetCI(ri, c), rowGetCI(rj, c), c)
 			if cmp < 0 {
 				return true
 			}
@@ -374,6 +374,37 @@ func (t *Table) scanByIndexOrder(idxCols []string) []Row {
 		return false
 	})
 	return out
+}
+
+// compareIndexKeyColumn compares two index-key values the way InnoDB orders
+// B-tree entries: numeric types by value, string types by table/column collation.
+func (t *Table) compareIndexKeyColumn(a, b interface{}, colName string) int {
+	if t.Def != nil && !hasNonSortableCharset(t.Def.Charset) &&
+		isStringIndexColumnType(columnTypeForName(t.Def, colName)) {
+		return compareRowValueWithCollation(a, b, effectivePKCollation(t.Def, colName))
+	}
+	return compareRowValue(a, b)
+}
+
+func columnTypeForName(def *catalog.TableDef, colName string) string {
+	if def == nil {
+		return ""
+	}
+	for _, col := range def.Columns {
+		if strings.EqualFold(col.Name, colName) {
+			return col.Type
+		}
+	}
+	return ""
+}
+
+func isStringIndexColumnType(colType string) bool {
+	upper := strings.ToUpper(colType)
+	if idx := strings.Index(upper, " GENERATED"); idx >= 0 {
+		upper = upper[:idx]
+	}
+	return strings.HasPrefix(upper, "CHAR") || strings.HasPrefix(upper, "VARCHAR") ||
+		strings.HasPrefix(upper, "TEXT")
 }
 
 // inRange reports whether v lies within the lower/upper bounds for the

--- a/storage/index_access_collation_test.go
+++ b/storage/index_access_collation_test.go
@@ -1,0 +1,40 @@
+package storage
+
+import (
+	"testing"
+
+	"github.com/myuon/mylite/catalog"
+)
+
+func TestScanByIndexOrder_StringCollation(t *testing.T) {
+	def := &catalog.TableDef{
+		Name:       "t",
+		Charset:    "utf8mb4",
+		Collation:  "utf8mb4_0900_ai_ci",
+		Columns: []catalog.ColumnDef{
+			{Name: "a", Type: "INT"},
+			{Name: "p", Type: "VARCHAR(20) GENERATED ALWAYS AS (CONCAT(n, h))"},
+			{Name: "n", Type: "VARCHAR(10)"},
+			{Name: "h", Type: "VARCHAR(10)"},
+		},
+		Indexes: []catalog.IndexDef{{Name: "idx3", Columns: []string{"p"}}},
+	}
+	tbl := &Table{
+		Def: def,
+		Rows: []Row{
+			{"a": int64(11), "p": "XXXAAA"},
+			{"a": int64(1), "p": "uuuuu"},
+			{"a": int64(3), "p": "ummuooo"},
+		},
+	}
+	rows, err := tbl.ScanByIndex(IndexAccessSpec{Type: "index", IndexName: "idx3"})
+	if err != nil {
+		t.Fatalf("ScanByIndex: %v", err)
+	}
+	want := []string{"ummuooo", "uuuuu", "XXXAAA"}
+	for i, row := range rows {
+		if got := row["p"].(string); got != want[i] {
+			t.Fatalf("row %d: got %q want %q (full order: %v)", i, got, want[i], rows)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Fix `scanByIndexOrder` to sort string index keys with the table/column collation (matching InnoDB B-tree order) instead of raw byte order.
- Resolves wrong row order for `SELECT p FROM t` in `innodb/virtual_basic` when `p` is a VIRTUAL generated `VARCHAR` with a covering secondary index (`idx3`).
- Adds regression tests in `storage` and `executor`.

## Test plan

- [x] `go build ./... && go test ./... -count=1`
- [x] `go run ./cmd/mtrrun -test innodb/virtual_basic` — first-diff-line improved from **74** to **150**

Refs #504

Made with [Cursor](https://cursor.com)